### PR TITLE
minor UI bugfixes

### DIFF
--- a/NetBird/Source/App/ViewModels/MainViewModel.swift
+++ b/NetBird/Source/App/ViewModels/MainViewModel.swift
@@ -321,6 +321,9 @@ class ViewModel: ObservableObject {
     func handleServerChanged() {
         AppLogger.shared.log("Server changed - stopping engine and resetting state")
 
+        // Stop polling to prevent transitional states from updating UI
+        stopPollingDetails()
+        
         // Reset connection flags first to update UI immediately
         connectPressed = false
         disconnectPressed = false

--- a/NetBird/Source/App/Views/MainView.swift
+++ b/NetBird/Source/App/Views/MainView.swift
@@ -122,6 +122,11 @@ struct MainView: View {
                         SideDrawer(viewModel: viewModel, isShowing: $viewModel.presentSideDrawer)
                         NavigationLink("", destination: ServerView(), isActive: $viewModel.navigateToServerView)
                             .hidden()
+                            .onChange(of: viewModel.navigateToServerView) { newValue in
+                                  if !newValue {
+                                      viewModel.startPollingDetails()
+                                  }
+                            }
                         if viewModel.networkExtensionAdapter.showBrowser,
                            let loginURLString = viewModel.networkExtensionAdapter.loginURL,
                            let loginURL = URL(string: loginURLString)


### PR DESCRIPTION
Removal of setting statusDetailsIsValid to false in handleServerChanged - this variable is used to decide whether to display the splash screen or the main app UI. 

Add usage of Task.detached to execute stop in background without swift's actor isolation issues.

When user navigates to ServerView, a dialog pops up that when confirmed it disconnects the user's device and stops the engine via handleServerChanged. This method's setting of states manually was conflicting with the state polling that runs when the user first opens the app (on MainViewModel, startPollingDetails). This MR will change this behavior by stopping polling by the time handleServerChanged is called, and resume it when user navigates back from ServerView. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server change handling with optimized polling management for more consistent UI state updates and responsiveness.
  * Enhanced navigation flow by properly resuming polling when returning from server views for better overall app performance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->