### PR TITLE
Update the year on the 'about' screen from 2023 -> 2026

### DIFF
--- a/NetBird/Source/App/Views/AboutView.swift
+++ b/NetBird/Source/App/Views/AboutView.swift
@@ -54,7 +54,7 @@ struct AboutView: View {
                 .padding(.horizontal, UIScreen.main.bounds.width * 0.20)
                 .padding(.bottom, 50)
                 
-                Text("© 2026 NetBird all rights reserved")
+                Text("© \(String(Calendar.current.component(.year, from: Date()))) NetBird all rights reserved")
                     .foregroundColor(.white)
                     .padding(.bottom, UIScreen.main.bounds.height * 0.01)
             }


### PR DESCRIPTION
Update the year on the 'about' screen from 2023 -> 2026

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the About section to display the current year dynamically instead of a fixed year, ensuring the copyright notice stays up-to-date across releases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->