### PR TITLE
 Fix DNS resolution failure when toggling exit nodes 

### DIFF
--- a/.github/workflows/build-upload.yml
+++ b/.github/workflows/build-upload.yml
@@ -21,6 +21,11 @@ on:
         type: string
         default: ''
         description: 'Marketing version override (e.g. from git tag)'
+      upload:
+        required: false
+        type: boolean
+        default: true
+        description: 'Upload to App Store Connect (false = build only)'
 
 concurrency:
   group: build-upload-${{ inputs.ref }}
@@ -300,6 +305,7 @@ jobs:
             ${{ steps.settings.outputs.version-args }}
 
       - name: Export and Upload to App Store Connect
+        if: inputs.upload
         working-directory: ios-client
         env:
           API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -109,18 +109,6 @@ jobs:
               core.info('No version specified, using latest');
             }
 
-      - name: React to comment
-        if: github.event_name == 'issue_comment' && steps.resolve.outputs.should-build == 'true'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            await github.rest.reactions.createForIssueComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: context.payload.comment.id,
-              content: 'rocket',
-            });
-
   build:
     name: Build and Upload
     needs: gate

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -3,10 +3,9 @@ name: TestFlight
 on:
   push:
     branches: [main]
+    tags: ['v*']
   pull_request:
     branches: [main]
-  issue_comment:
-    types: [created]
 
 permissions:
   contents: read
@@ -22,14 +21,12 @@ jobs:
     if: >
       github.event_name == 'push' ||
       (github.event_name == 'pull_request' &&
-       github.event.pull_request.head.repo.full_name == github.repository) ||
-      (github.event_name == 'issue_comment' &&
-       github.event.issue.pull_request &&
-       contains(github.event.comment.body, '/testflight'))
+       github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     outputs:
       ref: ${{ steps.resolve.outputs.ref }}
       should-build: ${{ steps.resolve.outputs.should-build }}
+      upload: ${{ steps.resolve.outputs.upload }}
       netbird-ref: ${{ steps.resolve.outputs.netbird-ref }}
       version: ${{ steps.resolve.outputs.version }}
     steps:
@@ -38,10 +35,19 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            // Push to main/ci-cd — always build
+            // Push to main or tag — always build and upload
             if (context.eventName === 'push') {
               core.setOutput('ref', context.sha);
               core.setOutput('should-build', 'true');
+              core.setOutput('upload', 'true');
+
+              // Extract version from tag (v1.2.3 → 1.2.3)
+              const ref = context.ref;
+              if (ref.startsWith('refs/tags/v')) {
+                const version = ref.replace('refs/tags/v', '');
+                core.setOutput('version', version);
+                core.info(`Tag push, using version: ${version}`);
+              }
               return;
             }
 
@@ -58,55 +64,31 @@ jobs:
 
               core.setOutput('ref', context.payload.pull_request.head.sha);
               core.setOutput('should-build', 'true');
-              return;
-            }
 
-            // /testflight comment on PR — validate permissions and fork status
-            const { data: pr } = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.issue.number,
-            });
+              // Parse /testflight line from PR description for upload flag and parameters
+              const body = context.payload.pull_request.body || '';
+              const hasTestflight = body.includes('/testflight');
+              core.setOutput('upload', hasTestflight ? 'true' : 'false');
+              core.info(`PR description ${hasTestflight ? 'contains' : 'does not contain'} /testflight, upload=${hasTestflight}`);
 
-            // Skip fork PRs
-            if (pr.head.repo.full_name !== `${context.repo.owner}/${context.repo.repo}`) {
-              core.info(`Skipping fork PR from ${pr.head.repo.full_name}`);
-              core.setOutput('should-build', 'false');
-              return;
-            }
+              const lines = body.split('\n');
+              for (const line of lines) {
+                const trimmed = line.trim();
+                if (!trimmed.startsWith('/testflight')) continue;
 
-            // Check commenter has write access
-            const { data: perm } = await github.rest.repos.getCollaboratorPermissionLevel({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              username: context.actor,
-            });
-
-            if (!['admin', 'write'].includes(perm.permission)) {
-              core.info(`User ${context.actor} does not have write access`);
-              core.setOutput('should-build', 'false');
-              return;
-            }
-
-            core.setOutput('ref', pr.head.sha);
-            core.setOutput('should-build', 'true');
-
-            // Parse optional parameters from comment: netbird-ref=xxx version=x.y.z
-            const comment = context.payload.comment.body;
-            core.info(`Comment: ${comment}`);
-            const netbirdRefMatch = comment.match(/netbird-ref=(\S+)/);
-            if (netbirdRefMatch) {
-              core.setOutput('netbird-ref', netbirdRefMatch[1]);
-              core.info(`Using netbird-ref: ${netbirdRefMatch[1]}`);
-            } else {
-              core.info('No netbird-ref specified, using latest');
-            }
-            const versionMatch = comment.match(/version=(\S+)/);
-            if (versionMatch) {
-              core.setOutput('version', versionMatch[1]);
-              core.info(`Using version: ${versionMatch[1]}`);
-            } else {
-              core.info('No version specified, using latest');
+                core.info(`Found /testflight line: ${trimmed}`);
+                const netbirdRefMatch = trimmed.match(/netbird-ref=(\S+)/);
+                if (netbirdRefMatch) {
+                  core.setOutput('netbird-ref', netbirdRefMatch[1]);
+                  core.info(`Using netbird-ref: ${netbirdRefMatch[1]}`);
+                }
+                const versionMatch = trimmed.match(/version=(\S+)/);
+                if (versionMatch) {
+                  core.setOutput('version', versionMatch[1]);
+                  core.info(`Using version: ${versionMatch[1]}`);
+                }
+                break;
+              }
             }
 
   build:
@@ -118,12 +100,13 @@ jobs:
       ref: ${{ needs.gate.outputs.ref }}
       netbird-ref: ${{ needs.gate.outputs.netbird-ref }}
       version: ${{ needs.gate.outputs.version }}
+      upload: ${{ needs.gate.outputs.upload == 'true' }}
     secrets: inherit
 
   notify:
     name: Notify PR
     needs: [gate, build]
-    if: always() && (github.event_name == 'issue_comment' || github.event_name == 'pull_request')
+    if: always() && github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -137,12 +120,7 @@ jobs:
             const shortSha = ref.substring(0, 7);
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
 
-            let prNumber;
-            if (context.eventName === 'pull_request') {
-              prNumber = context.payload.pull_request.number;
-            } else {
-              prNumber = context.issue.number;
-            }
+            const prNumber = context.payload.pull_request.number;
 
             let body;
             if (buildResult === 'success') {

--- a/NetBird/Source/App/Views/Components/RouteCard.swift
+++ b/NetBird/Source/App/Views/Components/RouteCard.swift
@@ -98,7 +98,7 @@ struct RouteCard: View {
     }
 
     private var statusIndicatorColor: Color {
-        if peerViewModel.peerInfo.contains(where: { info in
+        if route.selected && peerViewModel.peerInfo.contains(where: { info in
             info.connStatus == "Connected" && (info.routes.contains(route.network ?? "") || route.domains?.contains(where: { $0.domain.contains(route.network ?? "") }) == true)
         }) {
             return Color.green

--- a/NetbirdKit/NetworkChangeListener.swift
+++ b/NetbirdKit/NetworkChangeListener.swift
@@ -19,11 +19,16 @@ enum IPAddressType {
 
 class NetworkChangeListener: NSObject, NetBirdSDKNetworkChangeListenerProtocol {
     func onNetworkChanged(_ p0: String?) {
-        guard let validString = p0, !validString.isEmpty else {
-            return
+        let routesString = p0 ?? ""
+
+        if routesString.isEmpty {
+            AppLogger.shared.log("onNetworkChanged: empty routes from Go")
+        } else {
+            AppLogger.shared.log("onNetworkChanged: routes=\(routesString)")
         }
-        
-        let (v4Routes, v6Routes, containsDefault) = parseRoutesToNESettings(routesString: validString)
+
+        let (v4Routes, v6Routes, containsDefault) = parseRoutesToNESettings(routesString: routesString)
+        AppLogger.shared.log("onNetworkChanged: v4=\(v4Routes.count) v6=\(v6Routes.count) containsDefault=\(containsDefault)")
         self.tunnelManager.setRoutes(v4Routes: v4Routes, v6Routes: v6Routes, containsDefault: containsDefault)
     }
     

--- a/NetbirdKit/NetworkChangeListener.swift
+++ b/NetbirdKit/NetworkChangeListener.swift
@@ -20,15 +20,7 @@ enum IPAddressType {
 class NetworkChangeListener: NSObject, NetBirdSDKNetworkChangeListenerProtocol {
     func onNetworkChanged(_ p0: String?) {
         let routesString = p0 ?? ""
-
-        if routesString.isEmpty {
-            AppLogger.shared.log("onNetworkChanged: empty routes from Go")
-        } else {
-            AppLogger.shared.log("onNetworkChanged: routes=\(routesString)")
-        }
-
         let (v4Routes, v6Routes, containsDefault) = parseRoutesToNESettings(routesString: routesString)
-        AppLogger.shared.log("onNetworkChanged: v4=\(v4Routes.count) v6=\(v6Routes.count) containsDefault=\(containsDefault)")
         self.tunnelManager.setRoutes(v4Routes: v4Routes, v6Routes: v6Routes, containsDefault: containsDefault)
     }
     

--- a/NetbirdKit/NetworkChangeListener.swift
+++ b/NetbirdKit/NetworkChangeListener.swift
@@ -21,6 +21,9 @@ class NetworkChangeListener: NSObject, NetBirdSDKNetworkChangeListenerProtocol {
     func onNetworkChanged(_ p0: String?) {
         let routesString = p0 ?? ""
         let (v4Routes, v6Routes, containsDefault) = parseRoutesToNESettings(routesString: routesString)
+        if v4Routes.isEmpty && v6Routes.isEmpty && self.interfaceIP == nil {
+            return
+        }
         self.tunnelManager.setRoutes(v4Routes: v4Routes, v6Routes: v6Routes, containsDefault: containsDefault)
     }
     

--- a/NetbirdNetworkExtension/PacketTunnelProviderSettingsManager.swift
+++ b/NetbirdNetworkExtension/PacketTunnelProviderSettingsManager.swift
@@ -23,11 +23,9 @@ class PacketTunnelProviderSettingsManager {
     }
     
     func setRoutes(v4Routes: [NEIPv4Route], v6Routes: [NEIPv6Route], containsDefault: Bool) {
-            let prev = self.needFallbackNS
             self.needFallbackNS = containsDefault
             self.ipv4Routes = v4Routes
             self.ipv6Routes = v6Routes
-            AppLogger.shared.log("setRoutes: v4=\(v4Routes.count) v6=\(v6Routes.count) containsDefault=\(containsDefault) needFallbackNS: \(prev)->\(containsDefault)")
             self.updateTunnel()
     }
 
@@ -52,7 +50,6 @@ class PacketTunnelProviderSettingsManager {
             dnsSettings.searchDomains = searchDomains
         }
 
-        AppLogger.shared.log("setDNS: server=\(config.serverIP) matchDomains=[\"\"] searchDomains=\(searchDomains) (mgmt routeAll=\(config.routeAll) domains=\(config.domains.count))")
         self.dnsSettings = dnsSettings
         self.updateTunnel()
     }
@@ -67,14 +64,13 @@ class PacketTunnelProviderSettingsManager {
     
     private func updateTunnel() {
         if let tunnelSettings = createTunnelSettings() {
-            AppLogger.shared.log("updateTunnel: dns=\(tunnelSettings.dnsSettings?.servers ?? []) matchDomains=\(tunnelSettings.dnsSettings?.matchDomains ?? []) v4Routes=\(tunnelSettings.ipv4Settings?.includedRoutes?.count ?? 0)")
             if let tunnelProvider = self.packetTunnelProvider {
                 tunnelProvider.setTunnelSettings(tunnelNetworkSettings: tunnelSettings)
             } else {
-                AppLogger.shared.log("updateTunnel: tunnel provider is nil")
+                print("Failed to get tunnel provider")
             }
         } else {
-            AppLogger.shared.log("updateTunnel: failed to create settings")
+            print("Failed to update tunnel")
         }
     }
     

--- a/NetbirdNetworkExtension/PacketTunnelProviderSettingsManager.swift
+++ b/NetbirdNetworkExtension/PacketTunnelProviderSettingsManager.swift
@@ -23,35 +23,36 @@ class PacketTunnelProviderSettingsManager {
     }
     
     func setRoutes(v4Routes: [NEIPv4Route], v6Routes: [NEIPv6Route], containsDefault: Bool) {
+            let prev = self.needFallbackNS
             self.needFallbackNS = containsDefault
             self.ipv4Routes = v4Routes
             self.ipv6Routes = v6Routes
+            AppLogger.shared.log("setRoutes: v4=\(v4Routes.count) v6=\(v6Routes.count) containsDefault=\(containsDefault) needFallbackNS: \(prev)->\(containsDefault)")
             self.updateTunnel()
     }
-    
+
     func setDNS(config: HostDNSConfig) {
-        var servers = [config.serverIP]
-        if !config.routeAll && needFallbackNS{
-            servers.append("1.1.1.1")
-        }
-        let dnsSettings = NEDNSSettings(servers: servers)
-        if config.routeAll {
-            dnsSettings.matchDomains = [""]
-        } else {
-            var searchDomains: [String] = []
-            var matchDomains: [String] = []
-            for domain in config.domains {
-                if domain.disabled {
-                    continue
-                }
-                matchDomains.append(domain.domain)
-                if !domain.matchOnly {
-                    searchDomains.append(domain.domain)
-                }
+        let dnsSettings = NEDNSSettings(servers: [config.serverIP])
+
+        // Always route all DNS through the tunnel on iOS.
+        // The Go DNS server has a root zone fallback handler that forwards
+        // unmatched queries to host DNS servers (e.g. 1.1.1.1).
+        // This avoids DNS failures when exit node routes (0.0.0.0/0) are
+        // added or removed, as iOS system DNS on cellular is unreliable
+        // with an active VPN tunnel.
+        dnsSettings.matchDomains = [""]
+
+        var searchDomains: [String] = []
+        for domain in config.domains {
+            if !domain.disabled && !domain.matchOnly {
+                searchDomains.append(domain.domain)
             }
-            dnsSettings.matchDomains = matchDomains
+        }
+        if !searchDomains.isEmpty {
             dnsSettings.searchDomains = searchDomains
         }
+
+        AppLogger.shared.log("setDNS: server=\(config.serverIP) matchDomains=[\"\"] searchDomains=\(searchDomains) (mgmt routeAll=\(config.routeAll) domains=\(config.domains.count))")
         self.dnsSettings = dnsSettings
         self.updateTunnel()
     }
@@ -66,13 +67,14 @@ class PacketTunnelProviderSettingsManager {
     
     private func updateTunnel() {
         if let tunnelSettings = createTunnelSettings() {
+            AppLogger.shared.log("updateTunnel: dns=\(tunnelSettings.dnsSettings?.servers ?? []) matchDomains=\(tunnelSettings.dnsSettings?.matchDomains ?? []) v4Routes=\(tunnelSettings.ipv4Settings?.includedRoutes?.count ?? 0)")
             if let tunnelProvider = self.packetTunnelProvider {
                 tunnelProvider.setTunnelSettings(tunnelNetworkSettings: tunnelSettings)
             } else {
-                print("Failed to get tunnel provider")
+                AppLogger.shared.log("updateTunnel: tunnel provider is nil")
             }
         } else {
-            print("Failed to update tunnel")
+            AppLogger.shared.log("updateTunnel: failed to create settings")
         }
     }
     


### PR DESCRIPTION
## Summary
  - Route all DNS through the tunnel on iOS by always setting matchDomains=[""], eliminating the drift between Go's DNS server (which has a root zone fallback handler) and iOS 
  tunnel settings that only matched specific domains
  - Handle empty route notifications from Go — when the exit node was the only route and was deselected, the notifier sent an empty string that Swift silently dropped, leaving 
  stale 0.0.0.0/0 in the tunnel and black-holing all traffic                                                                                                                    
  - Fix route card status indicator showing green after deselecting a route by checking route.selected before evaluating peer connection status

##  Test plan                                                 
                                                                                                                                                                                
  - Connect on WiFi with exit node enabled, disable it — DNS should continue working                                                                                            
  - Connect on cellular with exit node enabled, disable it — DNS should continue working
  - Re-enable exit node — DNS should work through the exit node                                                                                                                 
  - Disable exit node — UI status color should change to gray immediately
  - Connect without any exit node — DNS should work for NB domains and external domains 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Release/TestFlight flow updated: uploads can be triggered by tags or PR description and optionally skipped.
* **Bug Fixes**
  * Route cards only show “Connected” when a route is actively selected.
* **Improvements**
  * Network handling now applies parsed route updates even when no routes are present.
  * DNS and tunnel domain/search handling simplified for more consistent behavior; upload can be disabled for build-only runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->