### PR TITLE
Derive marketing version from git tags instead of Xcode project

### DIFF
--- a/.github/workflows/build-upload.yml
+++ b/.github/workflows/build-upload.yml
@@ -71,12 +71,7 @@ jobs:
 
       - name: Build NetBirdSDK xcframework
         working-directory: ios-client
-        run: |
-          if [ -n "${{ inputs.version }}" ]; then
-            ./build-go-lib.sh "${{ inputs.version }}"
-          else
-            ./build-go-lib.sh
-          fi
+        run: ./build-go-lib.sh
 
       - name: Setup App Store Connect API key
         working-directory: ios-client

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -31,7 +31,6 @@ jobs:
       build-number: ${{ steps.resolve.outputs.build-number }}
     steps:
       - name: Checkout (for git tags)
-        if: github.event_name == 'push'
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -39,18 +38,21 @@ jobs:
           sparse-checkout: .
 
       - name: Resolve version from latest tag
-        if: github.event_name == 'push'
         id: derive-version
         run: |
           LATEST_TAG=$(git describe --tags --match 'v*' --abbrev=0 2>/dev/null || echo "")
           if [ -z "$LATEST_TAG" ]; then
             echo "version=0.0.1" >> "$GITHUB_OUTPUT"
-            echo "No version tags found, defaulting to 0.0.1"
+            echo "No semver tags found, defaulting to 0.0.1"
+          elif ! echo "$LATEST_TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "version=0.0.1" >> "$GITHUB_OUTPUT"
+            echo "Latest tag '$LATEST_TAG' is not valid semver, defaulting to 0.0.1"
           else
             VERSION="${LATEST_TAG#v}"
-            MAJOR=$(echo "$VERSION" | cut -d. -f1)
-            MINOR=$(echo "$VERSION" | cut -d. -f2)
-            PATCH=$(echo "$VERSION" | cut -d. -f3)
+            MAJOR="${VERSION%%.*}"
+            REST="${VERSION#*.}"
+            MINOR="${REST%%.*}"
+            PATCH="${REST#*.}"
             NEXT_PATCH=$((PATCH + 1))
             NEXT_VERSION="${MAJOR}.${MINOR}.${NEXT_PATCH}"
             echo "version=$NEXT_VERSION" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -64,6 +64,9 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            // Default build number from workflow run number (can be overridden by /testflight)
+            core.setOutput('build-number', '${{ github.run_number }}');
+
             // Push to main — always build and upload
             if (context.eventName === 'push') {
               core.setOutput('ref', context.sha);
@@ -170,7 +173,7 @@ jobs:
 
             const uploaded = '${{ needs.gate.outputs.upload }}' === 'true';
             const version = '${{ needs.gate.outputs.version }}' || 'default';
-            const buildNumber = '${{ needs.gate.outputs.build-number }}' || '${{ github.run_number }}';
+            const buildNumber = '${{ needs.gate.outputs.build-number }}';
 
             let body;
             if (buildResult === 'success' && uploaded) {

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -42,11 +42,11 @@ jobs:
         run: |
           LATEST_TAG=$(git describe --tags --match 'v*' --abbrev=0 2>/dev/null || echo "")
           if [ -z "$LATEST_TAG" ]; then
-            echo "version=0.0.1" >> "$GITHUB_OUTPUT"
-            echo "No semver tags found, defaulting to 0.0.1"
+            echo "::error::No v* tags found — cannot derive version"
+            exit 1
           elif ! echo "$LATEST_TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
-            echo "version=0.0.1" >> "$GITHUB_OUTPUT"
-            echo "Latest tag '$LATEST_TAG' is not valid semver, defaulting to 0.0.1"
+            echo "::error::Latest tag '$LATEST_TAG' is not valid semver (expected vX.Y.Z)"
+            exit 1
           else
             VERSION="${LATEST_TAG#v}"
             MAJOR="${VERSION%%.*}"

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -94,11 +94,13 @@ jobs:
               core.setOutput('should-build', 'true');
 
               // Parse /testflight line from PR description for upload flag and parameters
-              const body = context.payload.pull_request.body || '';
+              // Strip HTML comments so template examples don't trigger upload
+              const body = (context.payload.pull_request.body || '').replace(/<!--[\s\S]*?-->/g, '');
               const hasTestflight = body.includes('/testflight');
               core.setOutput('upload', hasTestflight ? 'true' : 'false');
               core.info(`PR description ${hasTestflight ? 'contains' : 'does not contain'} /testflight, upload=${hasTestflight}`);
 
+              let explicitVersion = false;
               const lines = body.split('\n');
               for (const line of lines) {
                 const trimmed = line.trim();
@@ -114,6 +116,7 @@ jobs:
                 if (versionMatch) {
                   core.setOutput('version', versionMatch[1]);
                   core.info(`Using version: ${versionMatch[1]}`);
+                  explicitVersion = true;
                 }
                 const buildNumberMatch = trimmed.match(/build-number=(\S+)/);
                 if (buildNumberMatch) {
@@ -121,6 +124,15 @@ jobs:
                   core.info(`Using build-number: ${buildNumberMatch[1]}`);
                 }
                 break;
+              }
+
+              // Fall back to tag-derived version if not explicitly set
+              if (!explicitVersion) {
+                const derived = '${{ steps.derive-version.outputs.version }}';
+                if (derived) {
+                  core.setOutput('version', derived);
+                  core.info(`Using tag-derived version: ${derived}`);
+                }
               }
             }
 

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -3,7 +3,6 @@ name: TestFlight
 on:
   push:
     branches: [main]
-    tags: ['v*']
   pull_request:
     branches: [main]
 
@@ -31,23 +30,49 @@ jobs:
       version: ${{ steps.resolve.outputs.version }}
       build-number: ${{ steps.resolve.outputs.build-number }}
     steps:
+      - name: Checkout (for git tags)
+        if: github.event_name == 'push'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          sparse-checkout: .
+
+      - name: Resolve version from latest tag
+        if: github.event_name == 'push'
+        id: derive-version
+        run: |
+          LATEST_TAG=$(git describe --tags --match 'v*' --abbrev=0 2>/dev/null || echo "")
+          if [ -z "$LATEST_TAG" ]; then
+            echo "version=0.0.1" >> "$GITHUB_OUTPUT"
+            echo "No version tags found, defaulting to 0.0.1"
+          else
+            VERSION="${LATEST_TAG#v}"
+            MAJOR=$(echo "$VERSION" | cut -d. -f1)
+            MINOR=$(echo "$VERSION" | cut -d. -f2)
+            PATCH=$(echo "$VERSION" | cut -d. -f3)
+            NEXT_PATCH=$((PATCH + 1))
+            NEXT_VERSION="${MAJOR}.${MINOR}.${NEXT_PATCH}"
+            echo "version=$NEXT_VERSION" >> "$GITHUB_OUTPUT"
+            echo "Latest tag: $LATEST_TAG → next version: $NEXT_VERSION"
+          fi
+
       - name: Resolve build ref and validate
         id: resolve
         uses: actions/github-script@v7
         with:
           script: |
-            // Push to main or tag — always build and upload
+            // Push to main — always build and upload
             if (context.eventName === 'push') {
               core.setOutput('ref', context.sha);
               core.setOutput('should-build', 'true');
               core.setOutput('upload', 'true');
 
-              // Extract version from tag (v1.2.3 → 1.2.3)
-              const ref = context.ref;
-              if (ref.startsWith('refs/tags/v')) {
-                const version = ref.replace('refs/tags/v', '');
-                core.setOutput('version', version);
-                core.info(`Tag push, using version: ${version}`);
+              // Use version derived from latest tag (patch bumped)
+              const derived = '${{ steps.derive-version.outputs.version }}';
+              if (derived) {
+                core.setOutput('version', derived);
+                core.info(`Main push, derived version: ${derived}`);
               }
               return;
             }


### PR DESCRIPTION
On main pushes, compute the version by finding the latest v* tag and bumping the patch component (e.g. v0.1.4 → 0.1.5). This eliminates manual "bump version" commits and aligns with how android-client manages versions.

Also remove tag trigger from testflight.yml since release.yml already handles v* tag pushes, avoiding duplicate builds.

Fix netbird version in system meta.

/testflight version=0.1.5
## Description



<!-- To upload to TestFlight add a /testflight line outside this comment:

/testflight version=0.1.5 build-number=3
/testflight version=0.1.5 build-number=3 netbird-ref=main

- version: app version, must be X.Y.Z (Apple requirement)
- build-number: the (N) in TestFlight, must be unique per version. Defaults to CI run number if omitted
- netbird-ref: netbird branch/tag/SHA for Go SDK build. Defaults to submodule pin
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated TestFlight build workflow: tag-push triggers removed; workflow now auto-derives build versions from git tags (falls back to 0.0.1 when none or invalid) and ensures full repository history is available for accurate versioning. Main-branch push behavior for builds and uploads remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->