### PR TITLE
Fix tvOS build using correct target names

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -196,7 +196,7 @@ jobs:
         run: |
           xcodebuild -resolvePackageDependencies \
             -project NetBird.xcodeproj \
-            -scheme NetBird
+            -target "NetBird TV"
 
       - name: Build tvOS App
         working-directory: ios-client
@@ -204,7 +204,7 @@ jobs:
           set -o pipefail
           xcodebuild build \
             -project NetBird.xcodeproj \
-            -scheme NetBird \
+            -target "NetBird TV" \
             -destination 'generic/platform=tvOS' \
             -configuration Debug \
             CODE_SIGNING_ALLOWED=NO \
@@ -218,7 +218,7 @@ jobs:
           set -o pipefail
           xcodebuild build \
             -project NetBird.xcodeproj \
-            -scheme NetbirdNetworkExtension \
+            -target "NetBirdTVNetworkExtension" \
             -destination 'generic/platform=tvOS' \
             -configuration Debug \
             CODE_SIGNING_ALLOWED=NO \


### PR DESCRIPTION
The tvOS build job was using -scheme NetBird which only supports iOS. Use -target "NetBird TV" and -target "NetBirdTVNetworkExtension" to match the actual tvOS targets in the Xcode project.

Broken since #69 (2026-03-17).

## Description



<!-- To upload to TestFlight add a /testflight line outside this comment:

/testflight version=0.1.5 build-number=3
/testflight version=0.1.5 build-number=3 netbird-ref=main

- version: app version, must be X.Y.Z (Apple requirement)
- build-number: the (N) in TestFlight, must be unique per version. Defaults to CI run number if omitted
- netbird-ref: netbird branch/tag/SHA for Go SDK build. Defaults to submodule pin
-->
