### PR TITLE
Fix tvOS CI build by switching from -target to -schemes

### DIFF
--- a/.github/workflows/build-upload.yml
+++ b/.github/workflows/build-upload.yml
@@ -196,10 +196,39 @@ jobs:
           echo "  Run number: ${GITHUB_RUN_NUMBER}"
           echo "========================================="
 
+      - name: Install provisioning profiles
+        env:
+          PROFILE_APP_BASE64: ${{ secrets.PROVISIONING_PROFILE_APP_BASE64 }}
+          PROFILE_EXT_BASE64: ${{ secrets.PROVISIONING_PROFILE_EXTENSION_BASE64 }}
+        run: |
+          mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
+
+          # Install app profile
+          echo "$PROFILE_APP_BASE64" | base64 --decode > $RUNNER_TEMP/app.mobileprovision
+          APP_UUID=$(/usr/libexec/PlistBuddy -c "Print :UUID" /dev/stdin <<< \
+            $(security cms -D -i $RUNNER_TEMP/app.mobileprovision))
+          APP_NAME=$(/usr/libexec/PlistBuddy -c "Print :Name" /dev/stdin <<< \
+            $(security cms -D -i $RUNNER_TEMP/app.mobileprovision))
+          cp $RUNNER_TEMP/app.mobileprovision \
+            ~/Library/MobileDevice/Provisioning\ Profiles/${APP_UUID}.mobileprovision
+          echo "APP_PROFILE_NAME=$APP_NAME" >> "$GITHUB_ENV"
+
+          # Install extension profile
+          echo "$PROFILE_EXT_BASE64" | base64 --decode > $RUNNER_TEMP/ext.mobileprovision
+          EXT_UUID=$(/usr/libexec/PlistBuddy -c "Print :UUID" /dev/stdin <<< \
+            $(security cms -D -i $RUNNER_TEMP/ext.mobileprovision))
+          EXT_NAME=$(/usr/libexec/PlistBuddy -c "Print :Name" /dev/stdin <<< \
+            $(security cms -D -i $RUNNER_TEMP/ext.mobileprovision))
+          cp $RUNNER_TEMP/ext.mobileprovision \
+            ~/Library/MobileDevice/Provisioning\ Profiles/${EXT_UUID}.mobileprovision
+          echo "EXT_PROFILE_NAME=$EXT_NAME" >> "$GITHUB_ENV"
+
+          echo "Installed profiles: app='$APP_NAME' ($APP_UUID), ext='$EXT_NAME' ($EXT_UUID)"
+
       - name: Generate ExportOptions.plist
         working-directory: ios-client
         run: |
-          cat > ExportOptions.plist << 'EOF'
+          cat > ExportOptions.plist << EOF
           <?xml version="1.0" encoding="UTF-8"?>
           <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
           <plist version="1.0">
@@ -209,11 +238,18 @@ jobs:
             <key>destination</key>
             <string>upload</string>
             <key>signingStyle</key>
-            <string>automatic</string>
+            <string>manual</string>
             <key>teamID</key>
             <string>TA739QLA7A</string>
             <key>uploadSymbols</key>
             <true/>
+            <key>provisioningProfiles</key>
+            <dict>
+              <key>io.netbird.app</key>
+              <string>${APP_PROFILE_NAME}</string>
+              <key>io.netbird.app.NetbirdNetworkExtension</key>
+              <string>${EXT_PROFILE_NAME}</string>
+            </dict>
           </dict>
           </plist>
           EOF
@@ -254,7 +290,6 @@ jobs:
             -archivePath $RUNNER_TEMP/NetBird.xcarchive \
             -exportOptionsPlist ExportOptions.plist \
             -exportPath $RUNNER_TEMP/export \
-            -allowProvisioningUpdates \
             -authenticationKeyPath ~/".appstoreconnect/private_keys/AuthKey_${API_KEY_ID}.p8" \
             -authenticationKeyID "$API_KEY_ID" \
             -authenticationKeyIssuerID "$API_ISSUER_ID"
@@ -265,3 +300,5 @@ jobs:
           security delete-keychain "$KEYCHAIN_PATH" 2>/dev/null || true
           rm -rf ~/.appstoreconnect/private_keys 2>/dev/null || true
           rm -f $RUNNER_TEMP/dist.p12 $RUNNER_TEMP/dev.p12 2>/dev/null || true
+          rm -f $RUNNER_TEMP/app.mobileprovision $RUNNER_TEMP/ext.mobileprovision 2>/dev/null || true
+          rm -rf ~/Library/MobileDevice/Provisioning\ Profiles 2>/dev/null || true

--- a/.github/workflows/build-upload.yml
+++ b/.github/workflows/build-upload.yml
@@ -200,6 +200,7 @@ jobs:
         env:
           PROFILE_APP_BASE64: ${{ secrets.PROVISIONING_PROFILE_APP_BASE64 }}
           PROFILE_EXT_BASE64: ${{ secrets.PROVISIONING_PROFILE_EXTENSION_BASE64 }}
+          PROFILE_WIDGET_BASE64: ${{ secrets.PROVISIONING_PROFILE_WIDGET_BASE64 }}
         run: |
           mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
 
@@ -213,7 +214,7 @@ jobs:
             ~/Library/MobileDevice/Provisioning\ Profiles/${APP_UUID}.mobileprovision
           echo "APP_PROFILE_NAME=$APP_NAME" >> "$GITHUB_ENV"
 
-          # Install extension profile
+          # Install network extension profile
           echo "$PROFILE_EXT_BASE64" | base64 --decode > $RUNNER_TEMP/ext.mobileprovision
           EXT_UUID=$(/usr/libexec/PlistBuddy -c "Print :UUID" /dev/stdin <<< \
             $(security cms -D -i $RUNNER_TEMP/ext.mobileprovision))
@@ -223,7 +224,17 @@ jobs:
             ~/Library/MobileDevice/Provisioning\ Profiles/${EXT_UUID}.mobileprovision
           echo "EXT_PROFILE_NAME=$EXT_NAME" >> "$GITHUB_ENV"
 
-          echo "Installed profiles: app='$APP_NAME' ($APP_UUID), ext='$EXT_NAME' ($EXT_UUID)"
+          # Install widget extension profile
+          echo "$PROFILE_WIDGET_BASE64" | base64 --decode > $RUNNER_TEMP/widget.mobileprovision
+          WIDGET_UUID=$(/usr/libexec/PlistBuddy -c "Print :UUID" /dev/stdin <<< \
+            $(security cms -D -i $RUNNER_TEMP/widget.mobileprovision))
+          WIDGET_NAME=$(/usr/libexec/PlistBuddy -c "Print :Name" /dev/stdin <<< \
+            $(security cms -D -i $RUNNER_TEMP/widget.mobileprovision))
+          cp $RUNNER_TEMP/widget.mobileprovision \
+            ~/Library/MobileDevice/Provisioning\ Profiles/${WIDGET_UUID}.mobileprovision
+          echo "WIDGET_PROFILE_NAME=$WIDGET_NAME" >> "$GITHUB_ENV"
+
+          echo "Installed profiles: app='$APP_NAME' ($APP_UUID), ext='$EXT_NAME' ($EXT_UUID), widget='$WIDGET_NAME' ($WIDGET_UUID)"
 
       - name: Generate ExportOptions.plist
         working-directory: ios-client
@@ -249,6 +260,8 @@ jobs:
               <string>${APP_PROFILE_NAME}</string>
               <key>io.netbird.app.NetbirdNetworkExtension</key>
               <string>${EXT_PROFILE_NAME}</string>
+              <key>io.netbird.app.NetBirdWidgetExtension</key>
+              <string>${WIDGET_PROFILE_NAME}</string>
             </dict>
           </dict>
           </plist>
@@ -300,5 +313,5 @@ jobs:
           security delete-keychain "$KEYCHAIN_PATH" 2>/dev/null || true
           rm -rf ~/.appstoreconnect/private_keys 2>/dev/null || true
           rm -f $RUNNER_TEMP/dist.p12 $RUNNER_TEMP/dev.p12 2>/dev/null || true
-          rm -f $RUNNER_TEMP/app.mobileprovision $RUNNER_TEMP/ext.mobileprovision 2>/dev/null || true
+          rm -f $RUNNER_TEMP/app.mobileprovision $RUNNER_TEMP/ext.mobileprovision $RUNNER_TEMP/widget.mobileprovision 2>/dev/null || true
           rm -rf ~/Library/MobileDevice/Provisioning\ Profiles 2>/dev/null || true

--- a/.github/workflows/build-upload.yml
+++ b/.github/workflows/build-upload.yml
@@ -196,39 +196,10 @@ jobs:
           echo "  Run number: ${GITHUB_RUN_NUMBER}"
           echo "========================================="
 
-      - name: Install provisioning profiles
-        env:
-          PROFILE_APP_BASE64: ${{ secrets.PROVISIONING_PROFILE_APP_BASE64 }}
-          PROFILE_EXT_BASE64: ${{ secrets.PROVISIONING_PROFILE_EXTENSION_BASE64 }}
-        run: |
-          mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
-
-          # Install app profile
-          echo "$PROFILE_APP_BASE64" | base64 --decode > $RUNNER_TEMP/app.mobileprovision
-          APP_UUID=$(/usr/libexec/PlistBuddy -c "Print :UUID" /dev/stdin <<< \
-            $(security cms -D -i $RUNNER_TEMP/app.mobileprovision))
-          APP_NAME=$(/usr/libexec/PlistBuddy -c "Print :Name" /dev/stdin <<< \
-            $(security cms -D -i $RUNNER_TEMP/app.mobileprovision))
-          cp $RUNNER_TEMP/app.mobileprovision \
-            ~/Library/MobileDevice/Provisioning\ Profiles/${APP_UUID}.mobileprovision
-          echo "APP_PROFILE_NAME=$APP_NAME" >> "$GITHUB_ENV"
-
-          # Install extension profile
-          echo "$PROFILE_EXT_BASE64" | base64 --decode > $RUNNER_TEMP/ext.mobileprovision
-          EXT_UUID=$(/usr/libexec/PlistBuddy -c "Print :UUID" /dev/stdin <<< \
-            $(security cms -D -i $RUNNER_TEMP/ext.mobileprovision))
-          EXT_NAME=$(/usr/libexec/PlistBuddy -c "Print :Name" /dev/stdin <<< \
-            $(security cms -D -i $RUNNER_TEMP/ext.mobileprovision))
-          cp $RUNNER_TEMP/ext.mobileprovision \
-            ~/Library/MobileDevice/Provisioning\ Profiles/${EXT_UUID}.mobileprovision
-          echo "EXT_PROFILE_NAME=$EXT_NAME" >> "$GITHUB_ENV"
-
-          echo "Installed profiles: app='$APP_NAME' ($APP_UUID), ext='$EXT_NAME' ($EXT_UUID)"
-
       - name: Generate ExportOptions.plist
         working-directory: ios-client
         run: |
-          cat > ExportOptions.plist << EOF
+          cat > ExportOptions.plist << 'EOF'
           <?xml version="1.0" encoding="UTF-8"?>
           <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
           <plist version="1.0">
@@ -238,18 +209,11 @@ jobs:
             <key>destination</key>
             <string>upload</string>
             <key>signingStyle</key>
-            <string>manual</string>
+            <string>automatic</string>
             <key>teamID</key>
             <string>TA739QLA7A</string>
             <key>uploadSymbols</key>
             <true/>
-            <key>provisioningProfiles</key>
-            <dict>
-              <key>io.netbird.app</key>
-              <string>${APP_PROFILE_NAME}</string>
-              <key>io.netbird.app.NetbirdNetworkExtension</key>
-              <string>${EXT_PROFILE_NAME}</string>
-            </dict>
           </dict>
           </plist>
           EOF
@@ -290,6 +254,7 @@ jobs:
             -archivePath $RUNNER_TEMP/NetBird.xcarchive \
             -exportOptionsPlist ExportOptions.plist \
             -exportPath $RUNNER_TEMP/export \
+            -allowProvisioningUpdates \
             -authenticationKeyPath ~/".appstoreconnect/private_keys/AuthKey_${API_KEY_ID}.p8" \
             -authenticationKeyID "$API_KEY_ID" \
             -authenticationKeyIssuerID "$API_ISSUER_ID"
@@ -300,5 +265,3 @@ jobs:
           security delete-keychain "$KEYCHAIN_PATH" 2>/dev/null || true
           rm -rf ~/.appstoreconnect/private_keys 2>/dev/null || true
           rm -f $RUNNER_TEMP/dist.p12 $RUNNER_TEMP/dev.p12 2>/dev/null || true
-          rm -f $RUNNER_TEMP/app.mobileprovision $RUNNER_TEMP/ext.mobileprovision 2>/dev/null || true
-          rm -rf ~/Library/MobileDevice/Provisioning\ Profiles 2>/dev/null || true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -196,7 +196,7 @@ jobs:
         run: |
           xcodebuild -resolvePackageDependencies \
             -project NetBird.xcodeproj \
-            -target "NetBird TV"
+            -scheme "NetBird TV"
 
       - name: Build tvOS App
         working-directory: ios-client
@@ -204,7 +204,7 @@ jobs:
           set -o pipefail
           xcodebuild build \
             -project NetBird.xcodeproj \
-            -target "NetBird TV" \
+            -scheme "NetBird TV" \
             -destination 'generic/platform=tvOS' \
             -configuration Debug \
             CODE_SIGNING_ALLOWED=NO \
@@ -218,7 +218,7 @@ jobs:
           set -o pipefail
           xcodebuild build \
             -project NetBird.xcodeproj \
-            -target "NetBirdTVNetworkExtension" \
+            -scheme "NetBirdTVNetworkExtension" \
             -destination 'generic/platform=tvOS' \
             -configuration Debug \
             CODE_SIGNING_ALLOWED=NO \

--- a/NetBird.xcodeproj/xcshareddata/xcschemes/NetBird TV.xcscheme
+++ b/NetBird.xcodeproj/xcshareddata/xcschemes/NetBird TV.xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2610"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "441C5AED2EDF0DAE0055EEFC"
+               BuildableName = "NetBird TV.app"
+               BlueprintName = "NetBird TV"
+               ReferencedContainer = "container:NetBird.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "441C5AED2EDF0DAE0055EEFC"
+            BuildableName = "NetBird TV.app"
+            BlueprintName = "NetBird TV"
+            ReferencedContainer = "container:NetBird.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "441C5AED2EDF0DAE0055EEFC"
+            BuildableName = "NetBird TV.app"
+            BlueprintName = "NetBird TV"
+            ReferencedContainer = "container:NetBird.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/NetBird.xcodeproj/xcshareddata/xcschemes/NetBirdTVNetworkExtension.xcscheme
+++ b/NetBird.xcodeproj/xcshareddata/xcschemes/NetBirdTVNetworkExtension.xcscheme
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2610"
+   wasCreatedForAppExtension = "YES"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "441C5AFC2EDF0DD20055EEFC"
+               BuildableName = "NetBirdTVNetworkExtension.appex"
+               BlueprintName = "NetBirdTVNetworkExtension"
+               ReferencedContainer = "container:NetBird.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "441C5AED2EDF0DAE0055EEFC"
+               BuildableName = "NetBird TV.app"
+               BlueprintName = "NetBird TV"
+               ReferencedContainer = "container:NetBird.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "441C5AFC2EDF0DD20055EEFC"
+            BuildableName = "NetBirdTVNetworkExtension.appex"
+            BlueprintName = "NetBirdTVNetworkExtension"
+            ReferencedContainer = "container:NetBird.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "441C5AED2EDF0DAE0055EEFC"
+            BuildableName = "NetBird TV.app"
+            BlueprintName = "NetBird TV"
+            ReferencedContainer = "container:NetBird.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES"
+      askForAppToLaunch = "Yes"
+      launchAutomaticallySubstyle = "2">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "441C5AED2EDF0DAE0055EEFC"
+            BuildableName = "NetBird TV.app"
+            BlueprintName = "NetBird TV"
+            ReferencedContainer = "container:NetBird.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
Fix tvOS CI build by adding shared schemes and switching from -target to -scheme

PR #90 fixed the tvOS build by switching from the wrong iOS scheme to the correct tvOS targets. However, using -target instead of -scheme causes Xcode to create build directories inside SPM package checkouts. This conflicts with nanopb's 'build' file (a Python script at the repo root), causing:

  error: File exists but is not a directory: .../checkouts/nanopb/build

The iOS build doesn't hit this because it uses -scheme, which takes a different code path in Xcode's build system.

Fix: add shared tvOS schemes (NetBird TV, NetBirdTVNetworkExtension) and use -scheme in the CI workflow, matching how the iOS build works.

## Description



<!-- To upload to TestFlight add a /testflight line outside this comment:

/testflight version=0.1.5 build-number=3
/testflight version=0.1.5 build-number=3 netbird-ref=main

- version: app version, must be X.Y.Z (Apple requirement)
- build-number: the (N) in TestFlight, must be unique per version. Defaults to CI run number if omitted
- netbird-ref: netbird branch/tag/SHA for Go SDK build. Defaults to submodule pin
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated tvOS build workflow to use Xcode schemes for app and extension builds.
  * Added shared Xcode schemes to standardize testing, launch, profiling and archive actions.
  * Switched signing to automatic, removed manual provisioning profile installation, and added automatic provisioning updates during archive/export.
  * Adjusted cleanup to no longer remove temporary provisioning files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->