### PR TITLE
Update build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,6 +118,20 @@ jobs:
             CODE_SIGN_IDENTITY="" \
             | xcpretty --color
 
+      - name: Build Widget Extension
+        working-directory: ios-client
+        run: |
+          set -o pipefail
+          xcodebuild build \
+            -project NetBird.xcodeproj \
+            -scheme NetBirdWidgetExtensionExtension \
+            -destination 'generic/platform=iOS' \
+            -configuration Debug \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGN_IDENTITY="" \
+            | xcpretty --color
+
   build_tvos:
     name: Build tvOS App
     runs-on: macos-15


### PR DESCRIPTION
## Description



<!-- To upload to TestFlight add a /testflight line outside this comment:

/testflight version=0.1.6 build-number=1
/testflight version=0.1.6 build-number=1 netbird-ref=main

- version: app version, must be X.Y.Z (Apple requirement)
- build-number: the (N) in TestFlight, must be unique per version. Defaults to CI run number if omitted
- netbird-ref: netbird branch/tag/SHA for Go SDK build. Defaults to submodule pin
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build infrastructure to ensure widget extension compilation is included in the CI/CD pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->