### PR TITLE
Revert ForceRelay default to false now that P2P issues are fixed

### DIFF
--- a/NetBird/Source/App/ViewModels/MainViewModel.swift
+++ b/NetBird/Source/App/ViewModels/MainViewModel.swift
@@ -108,7 +108,7 @@ class ViewModel: ObservableObject {
             UserDefaults.standard.synchronize()
         }
     }
-    @Published var forceRelayConnection = true
+    @Published var forceRelayConnection = false
     @Published var showForceRelayAlert = false
     @Published var connectOnDemand = false
     @Published var showOnDemandAlert = false
@@ -616,14 +616,8 @@ class ViewModel: ObservableObject {
     
     func getForcedRelayConnectionEnabled() -> Bool {
         let userDefaults = UserDefaults(suiteName: GlobalConstants.userPreferencesSuiteName)
-        #if os(iOS)
-        userDefaults?.register(defaults: [GlobalConstants.keyForceRelayConnection: true])
-        return userDefaults?.bool(forKey: GlobalConstants.keyForceRelayConnection) ?? true
-        #else
-        // forced relay battery optimization not need on Apple Tv
         userDefaults?.register(defaults: [GlobalConstants.keyForceRelayConnection: false])
         return userDefaults?.bool(forKey: GlobalConstants.keyForceRelayConnection) ?? false
-        #endif
     }
     
     func setConnectOnDemand(isEnabled: Bool) {

--- a/NetBirdTests/SharedUserDefaultsTests.swift
+++ b/NetBirdTests/SharedUserDefaultsTests.swift
@@ -51,11 +51,11 @@ final class SharedUserDefaultsTests: XCTestCase {
         XCTAssertFalse(value, "Login required flag should be false after clearing")
     }
 
-    func testForceRelayConnectionDefaultsToTrue() throws {
+    func testForceRelayConnectionDefaultsToFalse() throws {
         let defaults = try XCTUnwrap(userDefaults)
         defaults.removeObject(forKey: GlobalConstants.keyForceRelayConnection)
-        defaults.register(defaults: [GlobalConstants.keyForceRelayConnection: true])
+        defaults.register(defaults: [GlobalConstants.keyForceRelayConnection: false])
         let value = defaults.bool(forKey: GlobalConstants.keyForceRelayConnection)
-        XCTAssertTrue(value, "Force relay connection should default to true")
+        XCTAssertFalse(value, "Force relay connection should default to false")
     }
 }

--- a/NetbirdKit/EnvVarPackager.swift
+++ b/NetbirdKit/EnvVarPackager.swift
@@ -14,12 +14,10 @@ class EnvVarPackager {
             return nil
         }
 
-        #if os(iOS)
-        let defaultForceRelay = true
-        #else
-        // Forced relay battery optimization not needed on Apple TV
+        // P2P connections are more efficient than relay for both performance
+        // and battery life. The previous default of true was a workaround for
+        // ICE stability issues that have since been fixed upstream.
         let defaultForceRelay = false
-        #endif
 
         defaults.register(defaults: [GlobalConstants.keyForceRelayConnection: defaultForceRelay])
         let forceRelayConnection = defaults.bool(forKey: GlobalConstants.keyForceRelayConnection)


### PR DESCRIPTION
## Summary

The ForceRelay default was set to `true` on iOS as a workaround for P2P stability issues. Now that the underlying ICE issues have been fixed upstream (netbirdio/netbird: guard loop fix #5805, candidate buffering, network address discovery #5807), P2P connections work reliably and should be enabled by default.

P2P connections are more efficient than relay for both performance and battery life, making the previous "battery optimization" rationale for forcing relay incorrect.

## Changes

- `NetbirdKit/EnvVarPackager.swift`: Remove iOS-specific `#if os(iOS)` block, set `defaultForceRelay = false` for all platforms
- `NetBird/Source/App/ViewModels/MainViewModel.swift`: Change default from `true` to `false`, simplify `getForcedRelayConnectionEnabled()` to remove iOS-specific branch
- `NetBirdTests/SharedUserDefaultsTests.swift`: Update test to assert `false` is the default

Users who have explicitly toggled this setting will not be affected as their preference is persisted in UserDefaults.

## Related Issues

Related netbirdio/netbird#5589 — Default Force Relay to Off
Related netbirdio/netbird#3968 — Posture checks peer network range failed on iPhone
Related netbirdio/netbird#4657 — iOS Client loses all routes when Posture Checks are enabled