### PR TITLE
ci: remove /testflight example from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,13 +1,3 @@
 ## Description
 
 
-
-<!-- To upload to TestFlight add a /testflight line outside this comment:
-
-/testflight version=0.1.5 build-number=3
-/testflight version=0.1.5 build-number=3 netbird-ref=main
-
-- version: app version, must be X.Y.Z (Apple requirement)
-- build-number: the (N) in TestFlight, must be unique per version. Defaults to CI run number if omitted
-- netbird-ref: netbird branch/tag/SHA for Go SDK build. Defaults to submodule pin
--->


### PR DESCRIPTION
The example testflight lines were inside an HTML comment intended to be hidden, but the gate's command parser (testflight.yml) scans by line prefix without stripping HTML comments, so the template's `testflight version=0.1.5 build-number=3` leaked through as a real override on every PR, forcing builds to 0.1.5 (3) regardless of tags.



