### PR TITLE
ci: fix TypeError in issue_comment gate, pr was already unwrapped

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -107,12 +107,12 @@ jobs:
 
               // Block fork PRs — untrusted code must not run with privileged credentials
               const baseRepo = `${context.repo.owner}/${context.repo.repo}`;
-              if (pr.data.head.repo.full_name !== baseRepo) {
-                core.info(`PR is from fork ${pr.data.head.repo.full_name} — skipping`);
+              if (pr.head.repo.full_name !== baseRepo) {
+                core.info(`PR is from fork ${pr.head.repo.full_name} — skipping`);
                 return;
               }
 
-              core.setOutput('ref', pr.data.head.sha);
+              core.setOutput('ref', pr.head.sha);
               core.setOutput('should-build', 'true');
               core.setOutput('upload', 'true');
 


### PR DESCRIPTION
The response from github.rest.pulls.get is destructured as `const { data: pr } = ...` on line 102, so `pr` is already the PR object. Lines 110, 111, and 115 then did `pr.data.head.*` — double dereference — which crashed with 'Cannot read properties of undefined (reading head)' the first time anyone commented /testflight after PR #97 landed the issue_comment handler.

## Description




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TestFlight workflow configuration for improved internal process handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->