### PR TITLE
feat: add MDM managed app configuration support for iOS

### DIFF
--- a/NetBird.xcodeproj/project.pbxproj
+++ b/NetBird.xcodeproj/project.pbxproj
@@ -162,6 +162,10 @@
 		A1C3D5EE2F000008001A2B3C /* CellularOnDemandPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1C3D5E82F000002001A2B3C /* CellularOnDemandPolicy.swift */; };
 		A1C3D5EF2F000009001A2B3C /* CellularOnDemandPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1C3D5E82F000002001A2B3C /* CellularOnDemandPolicy.swift */; };
 		A1C3D5F02F00000A001A2B3C /* CellularOnDemandPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1C3D5E82F000002001A2B3C /* CellularOnDemandPolicy.swift */; };
+		BB1100012F30000100000001 /* ManagedConfigReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB1100002F30000100000001 /* ManagedConfigReader.swift */; };
+		BB1100022F30000100000001 /* ManagedConfigReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB1100002F30000100000001 /* ManagedConfigReader.swift */; };
+		BB1100032F30000100000001 /* ManagedConfigReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB1100002F30000100000001 /* ManagedConfigReader.swift */; };
+		BB1100042F30000100000001 /* ManagedConfigReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB1100002F30000100000001 /* ManagedConfigReader.swift */; };
 		AA0001012F22000100000001 /* ProfileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0001002F22000100000001 /* ProfileManager.swift */; };
 		AA0001022F22000100000001 /* ProfileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0001002F22000100000001 /* ProfileManager.swift */; };
 		AA0001032F22000100000001 /* ProfileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0001002F22000100000001 /* ProfileManager.swift */; };
@@ -359,6 +363,7 @@
 		AA0009002F22000900000001 /* ProfileConnectionCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileConnectionCache.swift; sourceTree = "<group>"; };
 		AA1B2C012F4E5A0100D1E2F3 /* TVGradientBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TVGradientBackground.swift; sourceTree = "<group>"; };
 		B1A2C3D32F3A000100000001 /* PeerDetailSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeerDetailSheet.swift; sourceTree = "<group>"; };
+		BB1100002F30000100000001 /* ManagedConfigReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagedConfigReader.swift; sourceTree = "<group>"; };
 		BB3D4E012F4E5A0200D1E2F3 /* TVPreSharedKeyButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TVPreSharedKeyButton.swift; sourceTree = "<group>"; };
 		C7A1CFF65CC44187912007EC /* iOSNetworksView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOSNetworksView.swift; sourceTree = "<group>"; };
 		CC5F6A012F4E5A0300D1E2F3 /* TVQRCodeSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TVQRCodeSheet.swift; sourceTree = "<group>"; };
@@ -601,6 +606,7 @@
 				AA0001002F22000100000001 /* ProfileManager.swift */,
 				AA0009002F22000900000001 /* ProfileConnectionCache.swift */,
 				A1B2C3D42EEDF500001A2B3C /* ConfigurationProvider.swift */,
+				BB1100002F30000100000001 /* ManagedConfigReader.swift */,
 				50245A2D2A7BDC470034792B /* NetworkChangeListener.swift */,
 				50CD81612AD0595E00CF830B /* DNSManager.swift */,
 				50E608022A7950CB00BAF09B /* Device.swift */,
@@ -1058,6 +1064,7 @@
 				BB3D4E022F4E5A0200D1E2F3 /* TVPreSharedKeyButton.swift in Sources */,
 				CC5F6A022F4E5A0300D1E2F3 /* TVQRCodeSheet.swift in Sources */,
 				978FC4732EEDF167002D0EB8 /* AppLogger.swift in Sources */,
+				BB1100012F30000100000001 /* ManagedConfigReader.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1084,6 +1091,7 @@
 				44F3E3942EE2151100C87FEC /* ConnectionListener.swift in Sources */,
 				44F3E38C2EE214E300C87FEC /* NetBirdAdapter.swift in Sources */,
 				978FC4722EEDF167002D0EB8 /* AppLogger.swift in Sources */,
+				BB1100022F30000100000001 /* ManagedConfigReader.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1111,6 +1119,7 @@
 				505118CF2AD96ECA003027D3 /* x25519.c in Sources */,
 				F1B292082EE0AC2A001D91B8 /* EnvVarPackager.swift in Sources */,
 				978FC4712EEDF167002D0EB8 /* AppLogger.swift in Sources */,
+				BB1100032F30000100000001 /* ManagedConfigReader.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1152,6 +1161,7 @@
 				AA0001042F22000100000001 /* ProfileManager.swift in Sources */,
 				AA0009042F22000900000001 /* ProfileConnectionCache.swift in Sources */,
 				A1B2C3D62EEDF502001A2B3C /* ConfigurationProvider.swift in Sources */,
+				BB1100042F30000100000001 /* ManagedConfigReader.swift in Sources */,
 				50CD81B02AD5B94D00CF830B /* PeerCard.swift in Sources */,
 				B1A2C3D42F3A000100000001 /* PeerDetailSheet.swift in Sources */,
 				50003BCE2AFD405600E5EB6B /* ConnectionListener.swift in Sources */,

--- a/NetBird/Source/App/NetBirdApp.swift
+++ b/NetBird/Source/App/NetBirdApp.swift
@@ -109,6 +109,10 @@ struct NetBirdApp: App {
         activationTask = Task { @MainActor in
             guard isAppActive, !Task.isCancelled else { return }
 
+            #if os(iOS)
+            viewModel.networkExtensionAdapter.applyManagedConfig()
+            #endif
+
             if let initialStatus = await viewModel.networkExtensionAdapter.loadCurrentConnectionState() {
                 viewModel.extensionState = initialStatus
                 viewModel.updateVPNDisplayState()

--- a/NetbirdKit/ManagedConfigReader.swift
+++ b/NetbirdKit/ManagedConfigReader.swift
@@ -1,0 +1,149 @@
+//
+//  ManagedConfigReader.swift
+//  NetBird
+//
+//  Reads MDM-managed app configuration pushed via Apple Managed App Configuration (AppConfig).
+//  Configuration is delivered through the com.apple.configuration.managed UserDefaults domain
+//  by MDM solutions such as Microsoft Intune, Jamf Pro, VMware Workspace ONE, or Mosyle.
+//
+//  Key names match those defined in the Go SDK's ManagedConfig constants.
+//
+
+import Foundation
+import NetBirdSDK
+import os
+
+/// Reads and applies MDM-managed app configuration from the Apple managed configuration domain.
+///
+/// ## How it works
+/// - MDM pushes key-value pairs to the `com.apple.configuration.managed` UserDefaults domain
+/// - This reader checks that domain for NetBird-specific keys
+/// - Values are applied to the Go SDK's config file, overriding user preferences
+/// - Setup keys trigger silent device registration without user interaction
+///
+/// ## Supported keys
+/// - `managementUrl` — Management server URL
+/// - `setupKey` — Setup key for silent device registration
+/// - `adminUrl` — Admin dashboard URL  
+/// - `preSharedKey` — WireGuard pre-shared key
+/// - `rosenpassEnabled` — Enable Rosenpass post-quantum encryption
+/// - `rosenpassPermissive` — Allow non-Rosenpass peers
+/// - `disableAutoConnect` — Prevent auto-connect on launch
+class ManagedConfigReader {
+
+    private static let logger = Logger(subsystem: "io.netbird.app", category: "ManagedConfigReader")
+
+    /// The Apple-native MDM managed configuration domain
+    private static let managedDomain = "com.apple.configuration.managed"
+
+    /// Reads managed configuration from the MDM domain.
+    /// Returns a populated ManagedConfig, or nil if no MDM config is available.
+    static func read() -> NetBirdSDKManagedConfig? {
+        guard let managedDefaults = UserDefaults(suiteName: managedDomain) else {
+            logger.debug("ManagedConfigReader: managed defaults domain not available")
+            return nil
+        }
+
+        let dict = managedDefaults.dictionaryRepresentation()
+
+        // Check if any NetBird keys are present
+        let managementUrlKey = NetBirdSDKGetManagedConfigKeyManagementURL()
+        let setupKeyKey = NetBirdSDKGetManagedConfigKeySetupKey()
+        let adminUrlKey = NetBirdSDKGetManagedConfigKeyAdminURL()
+        let preSharedKeyKey = NetBirdSDKGetManagedConfigKeyPreSharedKey()
+        let rosenpassEnabledKey = NetBirdSDKGetManagedConfigKeyRosenpassEnabled()
+        let rosenpassPermissiveKey = NetBirdSDKGetManagedConfigKeyRosenpassPermissive()
+        let disableAutoConnectKey = NetBirdSDKGetManagedConfigKeyDisableAutoConnect()
+
+        guard let config = NetBirdSDKNewManagedConfig() else {
+            logger.error("ManagedConfigReader: failed to create ManagedConfig")
+            return nil
+        }
+
+        if let managementUrl = dict[managementUrlKey] as? String, !managementUrl.isEmpty {
+            config.setManagementURL(managementUrl)
+            logger.info("ManagedConfigReader: management URL configured")
+        }
+
+        if let setupKey = dict[setupKeyKey] as? String, !setupKey.isEmpty {
+            config.setSetupKey(setupKey)
+            // Do not log the setup key value for security
+            logger.info("ManagedConfigReader: setup key configured")
+        }
+
+        if let adminUrl = dict[adminUrlKey] as? String, !adminUrl.isEmpty {
+            config.setAdminURL(adminUrl)
+            logger.info("ManagedConfigReader: admin URL configured")
+        }
+
+        if let preSharedKey = dict[preSharedKeyKey] as? String, !preSharedKey.isEmpty {
+            config.setPreSharedKey(preSharedKey)
+            logger.info("ManagedConfigReader: pre-shared key configured")
+        }
+
+        if let rosenpassEnabled = dict[rosenpassEnabledKey] as? Bool {
+            config.setRosenpassEnabled(rosenpassEnabled)
+            logger.info("ManagedConfigReader: Rosenpass enabled=\(rosenpassEnabled)")
+        }
+
+        if let rosenpassPermissive = dict[rosenpassPermissiveKey] as? Bool {
+            config.setRosenpassPermissive(rosenpassPermissive)
+            logger.info("ManagedConfigReader: Rosenpass permissive=\(rosenpassPermissive)")
+        }
+
+        if let disableAutoConnect = dict[disableAutoConnectKey] as? Bool {
+            config.setDisableAutoConnect(disableAutoConnect)
+            logger.info("ManagedConfigReader: disable auto-connect=\(disableAutoConnect)")
+        }
+
+        guard config.hasConfig() else {
+            logger.debug("ManagedConfigReader: no NetBird keys found in managed config")
+            return nil
+        }
+
+        logger.info("ManagedConfigReader: MDM managed configuration loaded successfully")
+        return config
+    }
+
+    /// Returns true if any MDM-managed configuration is available.
+    static func hasManagedConfig() -> Bool {
+        guard let config = read() else { return false }
+        return config.hasConfig()
+    }
+
+    /// Applies MDM config to the config file and optionally performs setup key registration.
+    /// - Parameters:
+    ///   - configPath: Path to the NetBird config file
+    ///   - deviceName: Device name for registration
+    /// - Returns: true if MDM config was applied
+    @discardableResult
+    static func applyIfAvailable(configPath: String, deviceName: String) -> Bool {
+        guard let config = read() else { return false }
+
+        do {
+            try config.apply(configPath)
+            logger.info("ManagedConfigReader: MDM config applied to \(configPath)")
+        } catch {
+            logger.error("ManagedConfigReader: failed to apply MDM config: \(error.localizedDescription)")
+            return false
+        }
+
+        // If MDM provides a setup key, attempt silent registration
+        if config.hasSetupKey() {
+            do {
+                guard let auth = NetBirdSDKNewAuth(configPath, "", nil) else {
+                    logger.warning("ManagedConfigReader: failed to create Auth for setup key login")
+                    return true
+                }
+                try auth.loginWithSetupKeySync(config.getSetupKey(), deviceName: deviceName)
+                logger.info("ManagedConfigReader: silent setup key registration completed")
+            } catch {
+                // Setup key login may fail if already registered or key expired.
+                // This is not fatal — continue with normal flow.
+                logger.warning("ManagedConfigReader: setup key login skipped or failed: \(error.localizedDescription)")
+            }
+        }
+
+        return true
+    }
+}

--- a/NetbirdKit/ManagedConfigReader.swift
+++ b/NetbirdKit/ManagedConfigReader.swift
@@ -128,10 +128,12 @@ class ManagedConfigReader {
             return false
         }
 
-        // If MDM provides a setup key, attempt silent registration
+        // If MDM provides a setup key, attempt silent registration.
+        // Pass the MDM management URL so NewAuth connects to the correct server.
         if config.hasSetupKey() {
+            let mgmtUrl = config.getManagementURL() ?? ""
             do {
-                guard let auth = NetBirdSDKNewAuth(configPath, "", nil) else {
+                guard let auth = NetBirdSDKNewAuth(configPath, mgmtUrl, nil) else {
                     logger.warning("ManagedConfigReader: failed to create Auth for setup key login")
                     return true
                 }

--- a/NetbirdKit/ManagedConfigReader.swift
+++ b/NetbirdKit/ManagedConfigReader.swift
@@ -3,7 +3,7 @@
 //  NetBird
 //
 //  Reads MDM-managed app configuration pushed via Apple Managed App Configuration (AppConfig).
-//  Configuration is delivered through the com.apple.configuration.managed UserDefaults domain
+//  Configuration is delivered through the com.apple.configuration.managed UserDefaults key
 //  by MDM solutions such as Microsoft Intune, Jamf Pro, VMware Workspace ONE, or Mosyle.
 //
 //  Key names match those defined in the Go SDK's ManagedConfig constants.
@@ -16,8 +16,8 @@ import os
 /// Reads and applies MDM-managed app configuration from the Apple managed configuration domain.
 ///
 /// ## How it works
-/// - MDM pushes key-value pairs to the `com.apple.configuration.managed` UserDefaults domain
-/// - This reader checks that domain for NetBird-specific keys
+/// - MDM pushes key-value pairs to the `com.apple.configuration.managed` UserDefaults key
+/// - This reader checks that dictionary for NetBird-specific keys
 /// - Values are applied to the Go SDK's config file, overriding user preferences
 /// - Setup keys trigger silent device registration without user interaction
 ///
@@ -33,18 +33,40 @@ class ManagedConfigReader {
 
     private static let logger = Logger(subsystem: "io.netbird.app", category: "ManagedConfigReader")
 
-    /// The Apple-native MDM managed configuration domain
-    private static let managedDomain = "com.apple.configuration.managed"
+    /// The Apple-native MDM managed configuration key in UserDefaults.standard.
+    private static let managedConfigurationKey = "com.apple.configuration.managed"
+
+    private static func managedConfigurationDictionary() -> [String: Any]? {
+        if let dict = UserDefaults.standard.dictionary(forKey: managedConfigurationKey) {
+            return dict
+        }
+
+        if let value = UserDefaults.standard.object(forKey: managedConfigurationKey) {
+            logger.warning("ManagedConfigReader: managed configuration value has unsupported root type: \(String(describing: type(of: value)), privacy: .public)")
+        } else {
+            logger.debug("ManagedConfigReader: managed configuration dictionary not available")
+        }
+
+        return nil
+    }
+
+    private static func managedStringValue(from dict: [String: Any], key: String) -> String? {
+        guard let rawValue = dict[key] as? String else { return nil }
+        let trimmedValue = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if rawValue != trimmedValue {
+            logger.info("ManagedConfigReader: trimmed whitespace from MDM string value for key \(key, privacy: .public)")
+        }
+
+        return trimmedValue.isEmpty ? nil : trimmedValue
+    }
 
     /// Reads managed configuration from the MDM domain.
     /// Returns a populated ManagedConfig, or nil if no MDM config is available.
     static func read() -> NetBirdSDKManagedConfig? {
-        guard let managedDefaults = UserDefaults(suiteName: managedDomain) else {
-            logger.debug("ManagedConfigReader: managed defaults domain not available")
+        guard let dict = managedConfigurationDictionary() else {
             return nil
         }
-
-        let dict = managedDefaults.dictionaryRepresentation()
 
         // Check if any NetBird keys are present
         let managementUrlKey = NetBirdSDKGetManagedConfigKeyManagementURL()
@@ -60,23 +82,23 @@ class ManagedConfigReader {
             return nil
         }
 
-        if let managementUrl = dict[managementUrlKey] as? String, !managementUrl.isEmpty {
+        if let managementUrl = managedStringValue(from: dict, key: managementUrlKey) {
             config.setManagementURL(managementUrl)
             logger.info("ManagedConfigReader: management URL configured")
         }
 
-        if let setupKey = dict[setupKeyKey] as? String, !setupKey.isEmpty {
+        if let setupKey = managedStringValue(from: dict, key: setupKeyKey) {
             config.setSetupKey(setupKey)
             // Do not log the setup key value for security
             logger.info("ManagedConfigReader: setup key configured")
         }
 
-        if let adminUrl = dict[adminUrlKey] as? String, !adminUrl.isEmpty {
+        if let adminUrl = managedStringValue(from: dict, key: adminUrlKey) {
             config.setAdminURL(adminUrl)
             logger.info("ManagedConfigReader: admin URL configured")
         }
 
-        if let preSharedKey = dict[preSharedKeyKey] as? String, !preSharedKey.isEmpty {
+        if let preSharedKey = managedStringValue(from: dict, key: preSharedKeyKey) {
             config.setPreSharedKey(preSharedKey)
             logger.info("ManagedConfigReader: pre-shared key configured")
         }
@@ -131,13 +153,13 @@ class ManagedConfigReader {
         // If MDM provides a setup key, attempt silent registration.
         // Pass the MDM management URL so NewAuth connects to the correct server.
         if config.hasSetupKey() {
-            let mgmtUrl = config.getManagementURL() ?? ""
+            let mgmtUrl = config.getManagementURL()
             do {
                 guard let auth = NetBirdSDKNewAuth(configPath, mgmtUrl, nil) else {
                     logger.warning("ManagedConfigReader: failed to create Auth for setup key login")
                     return true
                 }
-                try auth.loginWithSetupKeySync(config.getSetupKey(), deviceName: deviceName)
+                try auth.login(withSetupKeySync: config.getSetupKey(), deviceName: deviceName)
                 logger.info("ManagedConfigReader: silent setup key registration completed")
             } catch {
                 // Setup key login may fail if already registered or key expired.

--- a/NetbirdKit/NetworkExtensionAdapter.swift
+++ b/NetbirdKit/NetworkExtensionAdapter.swift
@@ -84,6 +84,10 @@ public class NetworkExtensionAdapter: ObservableObject {
             // This must happen in the main app — not via IPC — because the extension
             // process may not be running yet when start() is called.
             restoreConfigIfMissing()
+
+            // Apply MDM managed configuration before login.
+            // MDM values override user-set preferences on every launch.
+            applyManagedConfig()
             #endif
             await loginIfRequired()
             logger.info("start: loginIfRequired() completed")
@@ -92,6 +96,21 @@ public class NetworkExtensionAdapter: ObservableObject {
         }
         logger.info("start: EXIT")
     }
+
+    #if os(iOS)
+    /// Reads and applies MDM-managed app configuration if available.
+    /// MDM config is delivered via the com.apple.configuration.managed UserDefaults domain.
+    private func applyManagedConfig() {
+        guard let configPath = Preferences.configFile() else {
+            logger.warning("applyManagedConfig: config path unavailable")
+            return
+        }
+        let deviceName = Device.getName()
+        if ManagedConfigReader.applyIfAvailable(configPath: configPath, deviceName: deviceName) {
+            logger.info("applyManagedConfig: MDM config applied successfully")
+        }
+    }
+    #endif
 
     #if os(iOS)
     /// If the active profile's config file is missing (deleted after logout) but we have

--- a/NetbirdKit/NetworkExtensionAdapter.swift
+++ b/NetbirdKit/NetworkExtensionAdapter.swift
@@ -99,8 +99,8 @@ public class NetworkExtensionAdapter: ObservableObject {
 
     #if os(iOS)
     /// Reads and applies MDM-managed app configuration if available.
-    /// MDM config is delivered via the com.apple.configuration.managed UserDefaults domain.
-    private func applyManagedConfig() {
+    /// MDM config is delivered via the com.apple.configuration.managed UserDefaults key.
+    public func applyManagedConfig() {
         guard let configPath = Preferences.configFile() else {
             logger.warning("applyManagedConfig: config path unavailable")
             return

--- a/NetbirdNetworkExtension/PacketTunnelProvider.swift
+++ b/NetbirdNetworkExtension/PacketTunnelProvider.swift
@@ -69,6 +69,18 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             return
         }
 
+        // Apply MDM managed configuration at the extension level.
+        // This ensures MDM values are applied even when the extension starts
+        // independently (e.g., via On Demand or Always-on VPN).
+        #if os(iOS)
+        if let extensionConfigPath = Preferences.configFile() {
+            let deviceName = Device.getName()
+            if ManagedConfigReader.applyIfAvailable(configPath: extensionConfigPath, deviceName: deviceName) {
+                AppLogger.shared.log("PacketTunnelProvider: MDM managed config applied")
+            }
+        }
+        #endif
+
         if adapter.needsLogin() {
             signalLoginRequired()
             // Return the error immediately so iOS tears down the tunnel interface at once.


### PR DESCRIPTION
## Summary

Extend NetBird's current iOS MDM support so managed configuration reaches both the app and Network Extension reliably, including zero-touch setup-key enrollment.

Related to netbirdio/netbird#1918. Builds on the merged mobile MDM policy bridge from netbirdio/netbird#6435 and the iOS policy integration from netbirdio/ios-client#206.

## Changes

- Mirrors the non-secret managed policy into the shared App Group for the Network Extension.
- Uses a Darwin notification to apply policy changes across processes while the tunnel is running.
- Keeps `setupKey` app-only and performs enrollment asynchronously through the current Go SDK authentication API.
- Applies `adminURL` after successful authentication and avoids repeated setup-key enrollment with a SHA-256 completion fingerprint.
- Accepts the current `managementURL` / `adminURL` key names and the earlier `managementUrl` / `adminUrl` spellings for compatibility.
- Adds coverage for policy mirroring, secret exclusion, legacy key normalization, and enrollment configuration parsing.

## Managed Configuration

| Key | Type | Description |
|-----|------|-------------|
| `managementURL` | String | Management server URL (`managementUrl` remains accepted) |
| `setupKey` | String | App-only setup key for zero-touch enrollment; never copied to shared storage |
| `adminURL` | String | Admin panel URL (`adminUrl` remains accepted) |
| Other supported policy keys | Varies | Enforced through the current Go MDM policy bridge |

## How It Works

1. iOS delivers Managed App Configuration through `UserDefaults.standard` under `com.apple.configuration.managed`.
2. The app normalizes the policy, removes enrollment-only values, and mirrors the remaining policy into the App Group.
3. The Network Extension reads that mirrored policy and responds to cross-process Darwin notifications.
4. When `managementURL` and `setupKey` are present, the app completes setup-key enrollment without sharing the credential with the extension.

## Validation

- Swift diagnostics and repository diff checks pass on the current branch.
- Managed-device behavior previously validated with Intune remains the target workflow.
- A final Xcode build and XCTest run require macOS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic MDM policy synchronization across the app and network extension.
  - Added zero-touch enrollment using managed setup configuration.
  - Improved handling of notification permissions, foreground notifications, and login-required notification actions.
  - Added widget timeline refreshes when no profile is configured.

- **Bug Fixes**
  - Improved startup and connection-state handling, including cancellation checks and stale button-state resets.
  - Improved managed configuration compatibility with legacy settings and safer policy sharing.
  - Added more reliable crash reporting initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->