### PR TITLE
Align VPN button to arch background via overlay

### DIFF
--- a/NetBird/Source/App/Views/iOS/iOSConnectionView.swift
+++ b/NetBird/Source/App/Views/iOS/iOSConnectionView.swift
@@ -39,13 +39,57 @@ struct iOSConnectionView: View {
                         Image(imageName)
                             .resizable(resizingMode: .stretch)
                             .aspectRatio(contentMode: DeviceType.isPad ? .fill : .fit)
+                            // Button overlaid directly on the image so both share the same
+                            // coordinate space — mirrors Android where btn_connect is a sibling
+                            // of bg_mask inside bg_mask_container.
+                            // vertical_bias=0.07: button top = 7% of (imageHeight - buttonHeight)
+                            // Portrait image ratio h/w = 488/360 = 1.357
+                            // offset = (Screen.width*1.357 - Screen.width*0.79) * 0.07 ≈ Screen.width * 0.04
+                            .overlay(alignment: .top) {
+                                let btnSize = Screen.width * (isLandscape ? 0.40 : 0.79)
+                                let imgH    = isLandscape
+                                    ? Screen.height * 0.81               // landscape: height-constrained
+                                    : Screen.width  * 1.357              // portrait: width-constrained
+                                let biasOffset = max(0, (imgH - btnSize) * 0.07)
+
+                                VStack(spacing: 0) {
+                                    Color.clear.frame(height: biasOffset)
+
+                                    Button(action: {
+                                        if !viewModel.buttonLock {
+                                            switch viewModel.vpnDisplayState {
+                                            case .disconnected:
+                                                viewModel.connect()
+                                            case .connecting, .connected:
+                                                viewModel.close()
+                                            case .disconnecting:
+                                                break
+                                            }
+                                        }
+                                    }) {
+                                        CustomLottieView(vpnState: $viewModel.vpnDisplayState)
+                                            .id(animationKey)
+                                            .frame(width: btnSize, height: btnSize)
+                                            .onReceive(NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)) { _ in
+                                                self.animationKey = UUID()
+                                            }
+                                    }
+
+                                    Text(viewModel.extensionStateText)
+                                        .foregroundColor(Color("TextSecondary"))
+                                        .font(.system(size: 24, weight: .regular))
+                                        .padding(.top, 24)
+
+                                    Spacer()
+                                }
+                            }
                             .padding(.top, Screen.height * (DeviceType.isPad ? (isLandscape ? -0.15 : 0.36) : 0.19))
                             .padding(.leading, UIScreen.main.bounds.height * (isLandscape ? 0.04 : 0))
                             .frame(width: UIScreen.main.bounds.width, height: UIScreen.main.bounds.height)
                             .edgesIgnoringSafeArea(.bottom)
                     }
 
-                    // FQDN + IP + internet status
+                    // FQDN + IP
                     VStack {
                         Text(fqdnCopied ? "Copied" : viewModel.fqdn)
                             .foregroundColor(Color("TextPrimary"))
@@ -94,39 +138,6 @@ struct iOSConnectionView: View {
 
                         Spacer()
                     }
-
-                    // VPN button + status text
-                    VStack {
-                        Spacer()
-                        Button(action: {
-                            if !viewModel.buttonLock {
-                                switch viewModel.vpnDisplayState {
-                                case .disconnected:
-                                    viewModel.connect()
-                                case .connecting, .connected:
-                                    viewModel.close()
-                                case .disconnecting:
-                                    break
-                                }
-                            }
-                        }) {
-                            CustomLottieView(vpnState: $viewModel.vpnDisplayState)
-                                .id(animationKey)
-                                .frame(width: UIScreen.main.bounds.width * (isLandscape ? 0.40 : 0.79), height: UIScreen.main.bounds.width * (isLandscape ? 0.40 : 0.79))
-                                .onReceive(NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)) { _ in
-                                    self.animationKey = UUID()
-                                }
-                        }
-                        .padding(.top, -UIScreen.main.bounds.height / 27)
-                        .padding(.bottom)
-
-                        Text(viewModel.extensionStateText)
-                            .foregroundColor(Color("TextSecondary"))
-                            .font(.system(size: 24, weight: .regular))
-
-                        Spacer()
-                    }
-                    .padding()
 
                     // Network warning banner – above tab bar
                     if viewModel.vpnDisplayState == .connected && !viewModel.isInternetConnected {


### PR DESCRIPTION
## What was done

On iOS the connect button was positioned in a separate `VStack` with a hardcoded
`.padding(.top, -height / 27)` offset that broke alignment on different screen
sizes and orientations.

The button is now placed in an `.overlay` directly on the background image,
mirroring the Android layout where `btn_connect` is a sibling of `bg_mask`
inside `bg_mask_container`. Vertical position is calculated from the image
geometry with `vertical_bias = 0.07`, the same value used on Android.

---

## How to test

> Test on a physical device; also verify in the simulator across several sizes.

1. Open the app in portrait — button should be centred on the arch image
2. Rotate to landscape — button stays anchored to the arch, no visual jump
3. Check on a small (iPhone SE) and large (iPhone Pro Max) screen — alignment
   is consistent on both
4. Connect and disconnect — all animation states work correctly