### PR TITLE
Allow maintainers to trigger TestFlight from fork PRs

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -106,13 +106,6 @@ jobs:
                 pull_number: context.payload.issue.number,
               });
 
-              // Block fork PRs — untrusted code must not run with privileged credentials
-              const baseRepo = `${context.repo.owner}/${context.repo.repo}`;
-              if (pr.head.repo.full_name !== baseRepo) {
-                core.info(`PR is from fork ${pr.head.repo.full_name} — skipping`);
-                return;
-              }
-
               core.setOutput('ref', pr.head.sha);
               core.setOutput('should-build', 'true');
               core.setOutput('upload', 'true');


### PR DESCRIPTION
## Description

Allow trusted maintainers to trigger TestFlight builds from fork PRs via /testflight comment. Previously, all fork PRs were blocked unconditionally. Now the permission check (write/admin access required) serves as the explicit approval gate — equivalent to GitHub's "Approve and run" button.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD workflow to streamline TestFlight build processing while maintaining necessary security permissions checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->