### PR TITLE
Fix route status indicator for dynamic (DNS) routes

### DIFF
--- a/NetBird/Source/App/Views/Components/RouteCard.swift
+++ b/NetBird/Source/App/Views/Components/RouteCard.swift
@@ -98,67 +98,74 @@ struct RouteCard: View {
     }
 
     private var statusIndicatorColor: Color {
-        let tag = "[RouteCard:\(route.name)]"
+        let decision = computeStatusIndicator()
+        logIndicatorDecision(decision)
+        return decision.color
+    }
 
+    private struct IndicatorDecision {
+        let color: Color
+        let label: String
+        let reason: String
+    }
+
+    private func computeStatusIndicator() -> IndicatorDecision {
         guard route.selected else {
-            NSLog("%@ -> GRAY: route not selected", tag)
-            return Color.gray.opacity(0.5)
+            return IndicatorDecision(color: Color.gray.opacity(0.5), label: "GRAY", reason: "not selected")
         }
 
-        let allPeers = peerViewModel.peerInfo
-        let peerStatuses = allPeers.map { "\($0.fqdn)=\($0.connStatus)" }
-        NSLog("%@ selected=true network=%@ totalPeers=%d peerStatuses=%@",
-              tag,
-              route.network ?? "nil",
-              allPeers.count,
-              "\(peerStatuses)")
+        let connectedPeers = peerViewModel.peerInfo.filter { $0.connStatus == "Connected" }
+        let peerStatusSummary = peerViewModel.peerInfo
+            .map { "\($0.fqdn)=\($0.connStatus)" }
+            .joined(separator: ",")
 
-        let connectedPeers = allPeers.filter { $0.connStatus == "Connected" }
-        NSLog("%@ connectedPeerCount=%d", tag, connectedPeers.count)
-        if connectedPeers.isEmpty {
-            NSLog("%@ -> YELLOW: selected but no peer with connStatus==\"Connected\" (peers=%@)", tag, "\(peerStatuses)")
-            return Color.yellow
+        guard !connectedPeers.isEmpty else {
+            return IndicatorDecision(color: Color.yellow, label: "YELLOW",
+                                     reason: "no Connected peer (peers=[\(peerStatusSummary)])")
         }
 
         let connectedPeerRoutes = connectedPeers.flatMap { $0.routes }
-        NSLog("%@ connectedPeerRoutes=%@", tag, "\(connectedPeerRoutes)")
-
         let isDynamic = (route.network ?? "") == "invalid Prefix"
-        NSLog("%@ isDynamic=%@", tag, isDynamic ? "true" : "false")
 
         if !isDynamic, let network = route.network {
-            let staticMatch = connectedPeerRoutes.contains(network)
-            NSLog("%@ static check: peer.routes contains \"%@\" -> %@", tag, network, staticMatch ? "YES" : "NO")
-            if staticMatch {
-                NSLog("%@ -> GREEN: static route matched on connected peer", tag)
-                return Color.green
+            if connectedPeerRoutes.contains(network) {
+                return IndicatorDecision(color: Color.green, label: "GREEN",
+                                         reason: "static match \(network) in peer routes")
             }
+            return IndicatorDecision(color: Color.yellow, label: "YELLOW",
+                                     reason: "static \(network) not in peer routes \(connectedPeerRoutes)")
         }
 
-        let domainList = route.domains?.map { $0.domain } ?? []
+        let domains = route.domains?.map { $0.domain } ?? []
         let resolvedIPs = (route.domains ?? []).flatMap { $0.resolvedIPs }
-        NSLog("%@ domains=%@ resolvedIPs=%@", tag, "\(domainList)", "\(resolvedIPs)")
 
-        if resolvedIPs.isEmpty {
-            NSLog("%@ -> YELLOW: dynamic route has no resolvedIPs (bridge returned empty list for domains=%@)", tag, "\(domainList)")
-            return Color.yellow
+        guard !resolvedIPs.isEmpty else {
+            return IndicatorDecision(color: Color.yellow, label: "YELLOW",
+                                     reason: "dynamic route, bridge returned empty resolvedIPs for domains=\(domains)")
         }
 
-        let connectedPeerRouteAddresses = connectedPeerRoutes.map {
+        let strippedPeerAddrs = connectedPeerRoutes.map {
             $0.split(separator: "/").first.map(String.init) ?? $0
         }
-        NSLog("%@ peerRoutes (CIDR-stripped)=%@", tag, "\(connectedPeerRouteAddresses)")
 
-        let dynamicMatch = resolvedIPs.first(where: { connectedPeerRouteAddresses.contains($0) })
-        if let hit = dynamicMatch {
-            NSLog("%@ -> GREEN: dynamic route IP \"%@\" matched a connected peer route", tag, hit)
-            return Color.green
+        if let hit = resolvedIPs.first(where: { strippedPeerAddrs.contains($0) }) {
+            return IndicatorDecision(color: Color.green, label: "GREEN",
+                                     reason: "dynamic match \(hit) in stripped peer routes \(strippedPeerAddrs)")
         }
 
-        NSLog("%@ -> YELLOW: dynamic route has resolvedIPs=%@ but none match connectedPeerRouteAddresses=%@",
-              tag, "\(resolvedIPs)", "\(connectedPeerRouteAddresses)")
-        return Color.yellow
+        return IndicatorDecision(color: Color.yellow, label: "YELLOW",
+                                 reason: "dynamic resolvedIPs=\(resolvedIPs) do not intersect peerRoutes=\(strippedPeerAddrs) (domains=\(domains))")
     }
+
+    private func logIndicatorDecision(_ decision: IndicatorDecision) {
+        let key = "\(decision.label)|\(decision.reason)"
+        if RouteCard.lastLoggedReasons[route.id] == key { return }
+        RouteCard.lastLoggedReasons[route.id] = key
+
+        AppLogger.shared.log("[RouteCard] \(route.name) -> \(decision.label): \(decision.reason)")
+    }
+
+    private static var lastLoggedReasons: [UUID: String] = [:]
 
     private var routeDisplayText: String {
         if route.network == "invalid Prefix" {

--- a/NetBird/Source/App/Views/Components/RouteCard.swift
+++ b/NetBird/Source/App/Views/Components/RouteCard.swift
@@ -98,58 +98,23 @@ struct RouteCard: View {
     }
 
     private var statusIndicatorColor: Color {
-        let decision = computeStatusIndicator()
-        logIndicatorDecision(decision)
-        return decision.color
-    }
+        guard route.selected else { return Color.gray.opacity(0.5) }
 
-    private struct IndicatorDecision {
-        let color: Color
-        let label: String
-        let reason: String
-    }
-
-    private func computeStatusIndicator() -> IndicatorDecision {
-        guard route.selected else {
-            return IndicatorDecision(color: Color.gray.opacity(0.5), label: "GRAY", reason: "not selected")
-        }
-
-        let connectedPeers = peerViewModel.peerInfo.filter { $0.connStatus == "Connected" }
-        guard !connectedPeers.isEmpty else {
-            let peerStatusSummary = peerViewModel.peerInfo
-                .map { "\($0.fqdn)=\($0.connStatus)" }
-                .joined(separator: ",")
-            return IndicatorDecision(color: Color.yellow, label: "YELLOW",
-                                     reason: "no Connected peer (peers=[\(peerStatusSummary)])")
-        }
-
-        let connectedPeerRoutes = connectedPeers.flatMap { $0.routes }
+        let connectedPeerRoutes = peerViewModel.peerInfo
+            .filter { $0.connStatus == "Connected" }
+            .flatMap { $0.routes }
 
         if let network = route.network, connectedPeerRoutes.contains(network) {
-            return IndicatorDecision(color: Color.green, label: "GREEN",
-                                     reason: "match \(network) in peer routes")
+            return Color.green
         }
 
         let resolvedIPs = (route.domains ?? []).flatMap { $0.resolvedIPs }
-        if !resolvedIPs.isEmpty,
-           let hit = resolvedIPs.first(where: { connectedPeerRoutes.contains($0) }) {
-            return IndicatorDecision(color: Color.green, label: "GREEN",
-                                     reason: "resolved IP \(hit) in peer routes")
+        if resolvedIPs.contains(where: connectedPeerRoutes.contains) {
+            return Color.green
         }
 
-        return IndicatorDecision(color: Color.yellow, label: "YELLOW",
-                                 reason: "no overlap (network=\(route.network ?? "nil") resolvedIPs=\(resolvedIPs) peerRoutes=\(connectedPeerRoutes))")
+        return Color.yellow
     }
-
-    private func logIndicatorDecision(_ decision: IndicatorDecision) {
-        let key = "\(decision.label)|\(decision.reason)"
-        if RouteCard.lastLoggedReasons[route.id] == key { return }
-        RouteCard.lastLoggedReasons[route.id] = key
-
-        AppLogger.shared.log("[RouteCard] \(route.name) -> \(decision.label): \(decision.reason)")
-    }
-
-    private static var lastLoggedReasons: [UUID: String] = [:]
 
     private var routeDisplayText: String {
         if let domains = route.domains, !domains.isEmpty {

--- a/NetBird/Source/App/Views/Components/RouteCard.swift
+++ b/NetBird/Source/App/Views/Components/RouteCard.swift
@@ -98,26 +98,65 @@ struct RouteCard: View {
     }
 
     private var statusIndicatorColor: Color {
-        guard route.selected else { return Color.gray.opacity(0.5) }
+        let tag = "[RouteCard:\(route.name)]"
 
-        let connectedPeerRoutes = peerViewModel.peerInfo
-            .filter { $0.connStatus == "Connected" }
-            .flatMap { $0.routes }
-
-        if let network = route.network, network != "invalid Prefix",
-           connectedPeerRoutes.contains(network) {
-            return Color.green
+        guard route.selected else {
+            NSLog("%@ -> GRAY: route not selected", tag)
+            return Color.gray.opacity(0.5)
         }
 
+        let allPeers = peerViewModel.peerInfo
+        let peerStatuses = allPeers.map { "\($0.fqdn)=\($0.connStatus)" }
+        NSLog("%@ selected=true network=%@ totalPeers=%d peerStatuses=%@",
+              tag,
+              route.network ?? "nil",
+              allPeers.count,
+              "\(peerStatuses)")
+
+        let connectedPeers = allPeers.filter { $0.connStatus == "Connected" }
+        NSLog("%@ connectedPeerCount=%d", tag, connectedPeers.count)
+        if connectedPeers.isEmpty {
+            NSLog("%@ -> YELLOW: selected but no peer with connStatus==\"Connected\" (peers=%@)", tag, "\(peerStatuses)")
+            return Color.yellow
+        }
+
+        let connectedPeerRoutes = connectedPeers.flatMap { $0.routes }
+        NSLog("%@ connectedPeerRoutes=%@", tag, "\(connectedPeerRoutes)")
+
+        let isDynamic = (route.network ?? "") == "invalid Prefix"
+        NSLog("%@ isDynamic=%@", tag, isDynamic ? "true" : "false")
+
+        if !isDynamic, let network = route.network {
+            let staticMatch = connectedPeerRoutes.contains(network)
+            NSLog("%@ static check: peer.routes contains \"%@\" -> %@", tag, network, staticMatch ? "YES" : "NO")
+            if staticMatch {
+                NSLog("%@ -> GREEN: static route matched on connected peer", tag)
+                return Color.green
+            }
+        }
+
+        let domainList = route.domains?.map { $0.domain } ?? []
         let resolvedIPs = (route.domains ?? []).flatMap { $0.resolvedIPs }
+        NSLog("%@ domains=%@ resolvedIPs=%@", tag, "\(domainList)", "\(resolvedIPs)")
+
+        if resolvedIPs.isEmpty {
+            NSLog("%@ -> YELLOW: dynamic route has no resolvedIPs (bridge returned empty list for domains=%@)", tag, "\(domainList)")
+            return Color.yellow
+        }
+
         let connectedPeerRouteAddresses = connectedPeerRoutes.map {
             $0.split(separator: "/").first.map(String.init) ?? $0
         }
+        NSLog("%@ peerRoutes (CIDR-stripped)=%@", tag, "\(connectedPeerRouteAddresses)")
 
-        if resolvedIPs.contains(where: connectedPeerRouteAddresses.contains) {
+        let dynamicMatch = resolvedIPs.first(where: { connectedPeerRouteAddresses.contains($0) })
+        if let hit = dynamicMatch {
+            NSLog("%@ -> GREEN: dynamic route IP \"%@\" matched a connected peer route", tag, hit)
             return Color.green
         }
 
+        NSLog("%@ -> YELLOW: dynamic route has resolvedIPs=%@ but none match connectedPeerRouteAddresses=%@",
+              tag, "\(resolvedIPs)", "\(connectedPeerRouteAddresses)")
         return Color.yellow
     }
 

--- a/NetBird/Source/App/Views/Components/RouteCard.swift
+++ b/NetBird/Source/App/Views/Components/RouteCard.swift
@@ -98,12 +98,27 @@ struct RouteCard: View {
     }
 
     private var statusIndicatorColor: Color {
-        if route.selected && peerViewModel.peerInfo.contains(where: { info in
-            info.connStatus == "Connected" && (info.routes.contains(route.network ?? "") || route.domains?.contains(where: { $0.domain.contains(route.network ?? "") }) == true)
-        }) {
+        guard route.selected else { return Color.gray.opacity(0.5) }
+
+        let connectedPeerRoutes = peerViewModel.peerInfo
+            .filter { $0.connStatus == "Connected" }
+            .flatMap { $0.routes }
+
+        if let network = route.network, network != "invalid Prefix",
+           connectedPeerRoutes.contains(network) {
             return Color.green
         }
-        return route.selected ? Color.yellow : Color.gray.opacity(0.5)
+
+        let resolvedIPs = (route.domains ?? []).flatMap { $0.resolvedIPs }
+        let connectedPeerRouteAddresses = connectedPeerRoutes.map {
+            $0.split(separator: "/").first.map(String.init) ?? $0
+        }
+
+        if resolvedIPs.contains(where: connectedPeerRouteAddresses.contains) {
+            return Color.green
+        }
+
+        return Color.yellow
     }
 
     private var routeDisplayText: String {
@@ -162,7 +177,7 @@ struct RouteTooltipView: View {
             if route.network == "invalid Prefix" {
                 if let domains = route.domains {
                     ForEach(domains, id: \.self) { domain in
-                        detailRow(label: domain.domain, value: domain.resolvedips ?? "")
+                        detailRow(label: domain.domain, value: domain.resolvedIPs.joined(separator: ", "))
                     }
                 }
             } else {

--- a/NetBird/Source/App/Views/Components/RouteCard.swift
+++ b/NetBird/Source/App/Views/Components/RouteCard.swift
@@ -115,46 +115,30 @@ struct RouteCard: View {
         }
 
         let connectedPeers = peerViewModel.peerInfo.filter { $0.connStatus == "Connected" }
-        let peerStatusSummary = peerViewModel.peerInfo
-            .map { "\($0.fqdn)=\($0.connStatus)" }
-            .joined(separator: ",")
-
         guard !connectedPeers.isEmpty else {
+            let peerStatusSummary = peerViewModel.peerInfo
+                .map { "\($0.fqdn)=\($0.connStatus)" }
+                .joined(separator: ",")
             return IndicatorDecision(color: Color.yellow, label: "YELLOW",
                                      reason: "no Connected peer (peers=[\(peerStatusSummary)])")
         }
 
         let connectedPeerRoutes = connectedPeers.flatMap { $0.routes }
-        let isDynamic = (route.network ?? "") == "invalid Prefix"
 
-        if !isDynamic, let network = route.network {
-            if connectedPeerRoutes.contains(network) {
-                return IndicatorDecision(color: Color.green, label: "GREEN",
-                                         reason: "static match \(network) in peer routes")
-            }
-            return IndicatorDecision(color: Color.yellow, label: "YELLOW",
-                                     reason: "static \(network) not in peer routes \(connectedPeerRoutes)")
-        }
-
-        let domains = route.domains?.map { $0.domain } ?? []
-        let resolvedIPs = (route.domains ?? []).flatMap { $0.resolvedIPs }
-
-        guard !resolvedIPs.isEmpty else {
-            return IndicatorDecision(color: Color.yellow, label: "YELLOW",
-                                     reason: "dynamic route, bridge returned empty resolvedIPs for domains=\(domains)")
-        }
-
-        let strippedPeerAddrs = connectedPeerRoutes.map {
-            $0.split(separator: "/").first.map(String.init) ?? $0
-        }
-
-        if let hit = resolvedIPs.first(where: { strippedPeerAddrs.contains($0) }) {
+        if let network = route.network, connectedPeerRoutes.contains(network) {
             return IndicatorDecision(color: Color.green, label: "GREEN",
-                                     reason: "dynamic match \(hit) in stripped peer routes \(strippedPeerAddrs)")
+                                     reason: "match \(network) in peer routes")
+        }
+
+        let resolvedIPs = (route.domains ?? []).flatMap { $0.resolvedIPs }
+        if !resolvedIPs.isEmpty,
+           let hit = resolvedIPs.first(where: { connectedPeerRoutes.contains($0) }) {
+            return IndicatorDecision(color: Color.green, label: "GREEN",
+                                     reason: "resolved IP \(hit) in peer routes")
         }
 
         return IndicatorDecision(color: Color.yellow, label: "YELLOW",
-                                 reason: "dynamic resolvedIPs=\(resolvedIPs) do not intersect peerRoutes=\(strippedPeerAddrs) (domains=\(domains))")
+                                 reason: "no overlap (network=\(route.network ?? "nil") resolvedIPs=\(resolvedIPs) peerRoutes=\(connectedPeerRoutes))")
     }
 
     private func logIndicatorDecision(_ decision: IndicatorDecision) {
@@ -168,11 +152,11 @@ struct RouteCard: View {
     private static var lastLoggedReasons: [UUID: String] = [:]
 
     private var routeDisplayText: String {
-        if route.network == "invalid Prefix" {
-            if let domains = route.domains, domains.count > 2 {
+        if let domains = route.domains, !domains.isEmpty {
+            if domains.count > 2 {
                 return "\(domains.count) Domains"
             }
-            return route.domains?.map { $0.domain }.joined(separator: ", ") ?? ""
+            return domains.map { $0.domain }.joined(separator: ", ")
         }
         return route.network ?? "Unknown"
     }
@@ -220,11 +204,9 @@ struct RouteTooltipView: View {
     @ViewBuilder
     func detailInfo() -> some View {
         Group {
-            if route.network == "invalid Prefix" {
-                if let domains = route.domains {
-                    ForEach(domains, id: \.self) { domain in
-                        detailRow(label: domain.domain, value: domain.resolvedIPs.joined(separator: ", "))
-                    }
+            if let domains = route.domains, !domains.isEmpty {
+                ForEach(domains, id: \.self) { domain in
+                    detailRow(label: domain.domain, value: domain.resolvedIPs.joined(separator: ", "))
                 }
             } else {
                 detailRow(label: "Network", value: route.network ?? "")

--- a/NetBird/Source/App/Views/TV/TVNetworksView.swift
+++ b/NetBird/Source/App/Views/TV/TVNetworksView.swift
@@ -177,11 +177,11 @@ struct TVNetworkCard: View {
     }
 
     private var routeDisplayText: String {
-        if route.network == "invalid Prefix" {
-            if let domains = route.domains, domains.count > 2 {
+        if let domains = route.domains, !domains.isEmpty {
+            if domains.count > 2 {
                 return "\(domains.count) Domains"
             }
-            return route.domains?.map { $0.domain }.joined(separator: ", ") ?? ""
+            return domains.map { $0.domain }.joined(separator: ", ")
         }
         return route.network ?? ""
     }

--- a/NetBirdTVNetworkExtension/PacketTunnelProvider.swift
+++ b/NetBirdTVNetworkExtension/PacketTunnelProvider.swift
@@ -613,7 +613,11 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
 
                 let domains = (0..<(route.domains?.size() ?? 0)).compactMap { domainIndex -> DomainDetails? in
                     guard let domain = route.domains?.get(domainIndex) else { return nil }
-                    return DomainDetails(domain: domain.domain, resolvedips: domain.resolvedIPs)
+                    let resolvedIPsRef = domain.getResolvedIPs()
+                    let resolvedIPs: [String] = (0..<(resolvedIPsRef?.size() ?? 0)).map { ipIndex in
+                        resolvedIPsRef?.get(ipIndex) ?? ""
+                    }.filter { !$0.isEmpty }
+                    return DomainDetails(domain: domain.domain, resolvedIPs: resolvedIPs)
                 }
 
                 return RoutesSelectionInfo(

--- a/NetbirdKit/RoutesSelectionDetails.swift
+++ b/NetbirdKit/RoutesSelectionDetails.swift
@@ -59,12 +59,12 @@ extension RoutesSelectionInfo: Equatable {
 
 struct DomainDetails: Codable, Hashable {
     let domain: String
-    let resolvedips: String?
+    let resolvedIPs: [String]
 }
 
 extension DomainDetails: Equatable {
     static func == (lhs: DomainDetails, rhs: DomainDetails) -> Bool {
         return lhs.domain == rhs.domain &&
-        lhs.resolvedips == rhs.resolvedips
+        lhs.resolvedIPs == rhs.resolvedIPs
     }
 }

--- a/NetbirdNetworkExtension/PacketTunnelProvider.swift
+++ b/NetbirdNetworkExtension/PacketTunnelProvider.swift
@@ -474,7 +474,11 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
 
                 let domains = (0..<(route.domains?.size() ?? 0)).compactMap { domainIndex -> DomainDetails? in
                     guard let domain = route.domains?.get(domainIndex) else { return nil }
-                    return DomainDetails(domain: domain.domain, resolvedips: domain.resolvedIPs)
+                    let resolvedIPsRef = domain.getResolvedIPs()
+                    let resolvedIPs: [String] = (0..<(resolvedIPsRef?.size() ?? 0)).map { ipIndex in
+                        resolvedIPsRef?.get(ipIndex) ?? ""
+                    }.filter { !$0.isEmpty }
+                    return DomainDetails(domain: domain.domain, resolvedIPs: resolvedIPs)
                 }
 
                 return RoutesSelectionInfo(


### PR DESCRIPTION
## Description

The route status indicator stayed yellow forever for dynamic (DNS) routes. The Swift code branched on a `route.network == "invalid Prefix"` sentinel and tried to substring-match domains against that sentinel, which never matched.

Realign the iOS pipeline with the Android client so a single check works for both static and dynamic routes:

**Bridge (`netbird-core`)**
- Expose `Domains.SafeString()` as the `Network` value for dynamic routes (matching `client/android/client.go`). The same string is what `dynamic.Route.String()` returns and is therefore what ends up in `peer.routes`, so `peer.routes.contains(route.network)` now matches directly.
- Group resolved IPs by `ParentDomain` (mirroring `client/server/network.go`). The `resolvedDomains` map is keyed by the *resolved* domain, not the configured pattern; the previous lookup `resolvedDomains[d]` could never hit for wildcard patterns.
- Switch the bridge DTO from a comma-joined `ResolvedIPs string` to a structured `ResolvedIPs` collection (`Add/Get/Size`), mirroring `client/android/network_domains.go`. Swift consumers no longer depend on Go-side string formatting.

**Swift app**
- `RouteCard.statusIndicatorColor` becomes a single, Android-equivalent check: `peer.routes.contains(route.network)`, with a resolved-IP fallback for IP-only static-IP routes.
- Drop the `"invalid Prefix"` sentinel from `RouteCard.swift` and `TVNetworksView.swift` — branch on `route.domains.isEmpty` instead.
- `RoutesSelectionDetails.DomainDetails` carries `resolvedIPs: [String]` instead of an optional CSV string.


Bumps `netbird-core` submodule (corresponding upstream PR contains the bridge changes).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved route status colors: selected routes show green when matched or resolved to connected peers, non-selected routes show gray, others show yellow.
  * Route display text now prefers domain names (or a count) and falls back to network when none exist.
  * Tooltips list each domain with their resolved IPs and omit a separate network row when domains are present.
* **Chores**
  * Updated core dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->