### PR TITLE
fix(iOS): Connection-state-flicker

### DIFF
--- a/NetBird/Source/App/ViewModels/MainViewModel.swift
+++ b/NetBird/Source/App/ViewModels/MainViewModel.swift
@@ -247,9 +247,14 @@ class ViewModel: ObservableObject {
             self.logger.info("connect: Task started, calling networkExtensionAdapter.start()")
             await self.networkExtensionAdapter.start()
             self.logger.info("connect: networkExtensionAdapter.start() completed")
-            // If start() returned but VPN never launched (e.g. IPC failed to get login URL)
-            // and the browser login sheet is not showing, the tunnel won't start on its own.
-            // Reset the stuck "Connecting..." state so the user can try again.
+            // start() returns as soon as startVPNTunnel() is called — the tunnel process
+            // hasn't launched yet and extensionState is still .disconnected at this point.
+            // Wait long enough for the tunnel to start and for the polling cycle to pick up
+            // the new NEVPNStatus before deciding whether the launch genuinely failed.
+            try? await Task.sleep(nanoseconds: 8_000_000_000) // 8 seconds
+            // If after the wait the state is still disconnected and no browser login sheet
+            // is visible, the tunnel failed to start (e.g. IPC error). Reset the stuck
+            // "Connecting..." state so the user can try again.
             if self.extensionState == .disconnected && !self.networkExtensionAdapter.showBrowser {
                 self.connectPressed = false
                 self.updateVPNDisplayState()


### PR DESCRIPTION
## Problem

During VPN connection, the UI briefly flashes a "Disconnected" state and then
jumps directly to "Connected", skipping the "Connecting..." animation entirely.

### Root cause

`networkExtensionAdapter.start()` is an async function that returns as soon as
`startVPNTunnel()` is called — the tunnel process hasn't actually launched yet.
At this exact moment:

- `extensionState` is still `.disconnected` (the polling cycle runs every 3s
  and hasn't fired yet)
- `showBrowser` is `false` (no login required)

So the fallback guard immediately fires:
```swift
if self.extensionState == .disconnected && !self.networkExtensionAdapter.showBrowser {
    self.connectPressed = false   // ← premature reset
    self.updateVPNDisplayState()  // ← shows Disconnected
}

With connectPressed = false, none of the intermediate NEVPNStatus states
(.disconnecting, .connecting) are suppressed, so the UI shows:


Disconnected → Disconnected (flash) → Connected
instead of the expected:


Disconnected → Connecting... → Connected
Fix
Delay the fallback check by 8 seconds — enough time for the tunnel to start
and for at least two polling cycles to complete. If after 8s the state is
still .disconnected with no browser sheet, the tunnel genuinely failed
(e.g. IPC error) and the stuck "Connecting..." is reset so the user can retry.

How to test
Start from a fully disconnected state
Tap Connect
Verify the button shows the "Connecting..." animation (not a flash of "Disconnected")
Verify it transitions smoothly to "Connected"
Disconnect and repeat — the animation should be consistent every time