### PR TITLE
Widget vpn transition states

### DIFF
--- a/NetBird.xcodeproj/project.pbxproj
+++ b/NetBird.xcodeproj/project.pbxproj
@@ -133,10 +133,6 @@
 		50E608132A7958B100BAF09B /* MainViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50E608122A7958B100BAF09B /* MainViewModel.swift */; };
 		50E608242A79966600BAF09B /* AboutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50E608232A79966600BAF09B /* AboutView.swift */; };
 		50E608262A79968500BAF09B /* AdvancedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50E608252A79968500BAF09B /* AdvancedView.swift */; };
-		5554ACC22F7E59700047BDAC /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 5554ACC12F7E59700047BDAC /* GoogleService-Info.plist */; };
-		5554ACC32F7E59700047BDAC /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 5554ACC12F7E59700047BDAC /* GoogleService-Info.plist */; };
-		5554ACC42F7E59700047BDAC /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 5554ACC12F7E59700047BDAC /* GoogleService-Info.plist */; };
-		5554ACC52F7E59700047BDAC /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 5554ACC12F7E59700047BDAC /* GoogleService-Info.plist */; };
 		55B5E81B2F39158200852AA7 /* InternetStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55B5E81A2F39158200852AA7 /* InternetStatusView.swift */; };
 		55D865852F70982000A2EFF8 /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 55D865842F70982000A2EFF8 /* WidgetKit.framework */; };
 		55D865872F70982000A2EFF8 /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 55D865862F70982000A2EFF8 /* SwiftUI.framework */; };
@@ -337,7 +333,6 @@
 		50E608232A79966600BAF09B /* AboutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutView.swift; sourceTree = "<group>"; };
 		50E608252A79968500BAF09B /* AdvancedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedView.swift; sourceTree = "<group>"; };
 		53CB9305A9DC6CAD1895495A /* SharedUserDefaultsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SharedUserDefaultsTests.swift; sourceTree = "<group>"; };
-		5554ACC12F7E59700047BDAC /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		55B5E81A2F39158200852AA7 /* InternetStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternetStatusView.swift; sourceTree = "<group>"; };
 		55D865832F70982000A2EFF8 /* NetBirdWidgetExtensionExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = NetBirdWidgetExtensionExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		55D865842F70982000A2EFF8 /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
@@ -549,7 +544,6 @@
 		50A8910E2A792A15007C48FC = {
 			isa = PBXGroup;
 			children = (
-				5554ACC12F7E59700047BDAC /* GoogleService-Info.plist */,
 				50D402932BD9143900D4AC5B /* NetBirdSDK.xcframework */,
 				50245A0A2A7AA9390034792B /* NetBird-Bridging-Header.h */,
 				50A891192A792A15007C48FC /* NetBird */,
@@ -913,7 +907,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5554ACC42F7E59700047BDAC /* GoogleService-Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -921,7 +914,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5554ACC32F7E59700047BDAC /* GoogleService-Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -931,7 +923,6 @@
 			files = (
 				501B0DCE2AE04DDE004BE7A7 /* button-disconnecting.json in Resources */,
 				501B0DD22AE04DDE004BE7A7 /* logo_NetBird.json in Resources */,
-				5554ACC22F7E59700047BDAC /* GoogleService-Info.plist in Resources */,
 				501B0DDC2AE04DDE004BE7A7 /* button-connected.json in Resources */,
 				501B0DD62AE04DDE004BE7A7 /* button-start-connecting.json in Resources */,
 				501B0DDA2AE04DDE004BE7A7 /* button-full.json in Resources */,
@@ -953,7 +944,6 @@
 				501B0DCD2AE04DDE004BE7A7 /* button-disconnecting.json in Resources */,
 				501B0DD12AE04DDE004BE7A7 /* logo_NetBird.json in Resources */,
 				501B0DDB2AE04DDE004BE7A7 /* button-connected.json in Resources */,
-				5554ACC52F7E59700047BDAC /* GoogleService-Info.plist in Resources */,
 				501B0DCF2AE04DDE004BE7A7 /* button-connecting-loop.json in Resources */,
 				501B0DD72AE04DDE004BE7A7 /* button-full2.json in Resources */,
 			);

--- a/NetBird/Source/App/NetBirdApp.swift
+++ b/NetBird/Source/App/NetBirdApp.swift
@@ -14,6 +14,7 @@ import Combine
 
 #if os(iOS)
 import FirebasePerformance
+import WidgetKit
 #endif
 
 #if os(iOS)
@@ -118,6 +119,13 @@ struct NetBirdApp: App {
                 viewModel.disconnectPressed = false
                 viewModel.extensionState = initialStatus
                 viewModel.updateVPNDisplayState()
+            } else {
+                // No matching VPN profile found — still force a widget timeline refresh so
+                // the widget doesn't stay stuck on a transitioning state from a prior
+                // widget-initiated disconnect/connect while the app was closed.
+                #if os(iOS)
+                WidgetCenter.shared.reloadAllTimelines()
+                #endif
             }
 
             guard isAppActive, !Task.isCancelled else { return }

--- a/NetBird/Source/App/NetBirdApp.swift
+++ b/NetBird/Source/App/NetBirdApp.swift
@@ -110,6 +110,12 @@ struct NetBirdApp: App {
             guard isAppActive, !Task.isCancelled else { return }
 
             if let initialStatus = await viewModel.networkExtensionAdapter.loadCurrentConnectionState() {
+                // Clear stale button-press flags before applying the fresh NE state.
+                // These flags are only valid for the brief gap between a button tap and
+                // the corresponding NE state change; any external change (widget action,
+                // On Demand trigger) makes them stale when returning to the foreground.
+                viewModel.connectPressed = false
+                viewModel.disconnectPressed = false
                 viewModel.extensionState = initialStatus
                 viewModel.updateVPNDisplayState()
             }

--- a/NetBirdWidgetExtension/Intents/VPNIntentHelpers.swift
+++ b/NetBirdWidgetExtension/Intents/VPNIntentHelpers.swift
@@ -8,7 +8,11 @@ enum VPNIntentHelpers {
 
     static func loadManager() async throws -> NETunnelProviderManager? {
         let managers = try await NETunnelProviderManager.loadAllFromPreferences()
-        return managers.first
+        if let first = managers.first { return first }
+
+        // On first widget process startup NE preferences can return empty; retry once.
+        try await Task.sleep(nanoseconds: 300_000_000)
+        return try await NETunnelProviderManager.loadAllFromPreferences().first
     }
 
     static var defaults: UserDefaults? {

--- a/NetBirdWidgetExtension/NetBirdWidgetExtension.entitlements
+++ b/NetBirdWidgetExtension/NetBirdWidgetExtension.entitlements
@@ -6,5 +6,9 @@
 	<array>
 		<string>group.io.netbird.app</string>
 	</array>
+	<key>com.apple.developer.networking.networkextension</key>
+	<array>
+		<string>packet-tunnel-provider</string>
+	</array>
 </dict>
 </plist>

--- a/NetBirdWidgetExtension/ToggleVPNIntent.swift
+++ b/NetBirdWidgetExtension/ToggleVPNIntent.swift
@@ -33,7 +33,17 @@ struct ToggleVPNIntent: AppIntent {
                 defaults?.set(WidgetVPNStatus.connecting.rawValue, forKey: WidgetConstants.keyVPNStatus)
                 defaults?.set(Date().timeIntervalSince1970, forKey: WidgetConstants.keyTransitionStartTime)
                 let session = manager.connection as? NETunnelProviderSession
-                try session?.startVPNTunnel()
+                // Pass the active profile paths so PacketTunnelProvider can find the
+                // config file when the main app is not running. The main app writes
+                // these to shared UserDefaults in NetworkExtensionAdapter.startVPNConnection().
+                var options: [String: NSObject] = [:]
+                if let p = defaults?.string(forKey: WidgetConstants.keyActiveConfigPath) {
+                    options["configPath"] = p as NSObject
+                }
+                if let p = defaults?.string(forKey: WidgetConstants.keyActiveStatePath) {
+                    options["statePath"] = p as NSObject
+                }
+                try session?.startVPNTunnel(options: options.isEmpty ? nil : options)
             }
         } else {
             let neStatus = manager.connection.status

--- a/NetBirdWidgetExtension/ToggleVPNIntent.swift
+++ b/NetBirdWidgetExtension/ToggleVPNIntent.swift
@@ -31,7 +31,7 @@ struct ToggleVPNIntent: AppIntent {
             let status = manager.connection.status
             if status == .disconnected || status == .invalid {
                 defaults?.set(WidgetVPNStatus.connecting.rawValue, forKey: WidgetConstants.keyVPNStatus)
-                WidgetCenter.shared.reloadAllTimelines()
+                defaults?.set(Date().timeIntervalSince1970, forKey: WidgetConstants.keyTransitionStartTime)
                 let session = manager.connection as? NETunnelProviderSession
                 try session?.startVPNTunnel()
             }
@@ -39,12 +39,14 @@ struct ToggleVPNIntent: AppIntent {
             let status = manager.connection.status
             if status == .connected || status == .connecting {
                 defaults?.set(WidgetVPNStatus.disconnecting.rawValue, forKey: WidgetConstants.keyVPNStatus)
-                WidgetCenter.shared.reloadAllTimelines()
+                defaults?.set(Date().timeIntervalSince1970, forKey: WidgetConstants.keyTransitionStartTime)
                 manager.connection.stopVPNTunnel()
             }
         }
 
-        await VPNIntentHelpers.waitForStableState(manager: manager)
+        // Return immediately so the widget re-renders the transitioning state right away.
+        // VPNStatusProvider polls every 2 s while transitioning and clears the state once NE stabilises.
+        WidgetCenter.shared.reloadAllTimelines()
         return .result()
     }
 }

--- a/NetBirdWidgetExtension/ToggleVPNIntent.swift
+++ b/NetBirdWidgetExtension/ToggleVPNIntent.swift
@@ -60,7 +60,8 @@ struct ToggleVPNIntent: AppIntent {
         }
 
         // Return immediately so the widget re-renders the transitioning state right away.
-        // VPNStatusProvider polls every 2 s while transitioning and clears the state once NE stabilises.
+        // VPNStatusProvider polls every transitionPollInterval (5 s) while transitioning
+        // and clears the state once NE stabilises.
         WidgetCenter.shared.reloadAllTimelines()
         return .result()
     }

--- a/NetBirdWidgetExtension/ToggleVPNIntent.swift
+++ b/NetBirdWidgetExtension/ToggleVPNIntent.swift
@@ -36,8 +36,13 @@ struct ToggleVPNIntent: AppIntent {
                 try session?.startVPNTunnel()
             }
         } else {
-            let status = manager.connection.status
-            if status == .connected || status == .connecting {
+            let neStatus = manager.connection.status
+            let persistedRaw = defaults?.string(forKey: WidgetConstants.keyVPNStatus) ?? "disconnected"
+            let persisted = WidgetVPNStatus(rawValue: persistedRaw) ?? .disconnected
+            // NE status can be stale on first widget process start; use persisted state as fallback.
+            let shouldDisconnect = neStatus == .connected || neStatus == .connecting
+                || persisted == .connected || persisted == .connecting
+            if shouldDisconnect {
                 defaults?.set(WidgetVPNStatus.disconnecting.rawValue, forKey: WidgetConstants.keyVPNStatus)
                 defaults?.set(Date().timeIntervalSince1970, forKey: WidgetConstants.keyTransitionStartTime)
                 manager.connection.stopVPNTunnel()

--- a/NetBirdWidgetExtension/VPNStatusProvider.swift
+++ b/NetBirdWidgetExtension/VPNStatusProvider.swift
@@ -20,17 +20,43 @@ struct VPNStatusProvider: TimelineProvider {
 
     func getTimeline(in context: Context, completion: @escaping (Timeline<VPNStatusEntry>) -> Void) {
         loadEntry { entry in
-            let nextUpdate: Date
             if entry.status.isTransitioning {
-                nextUpdate = entry.date.addingTimeInterval(WidgetConstants.transitionPollInterval)
+                let pollDate = entry.date.addingTimeInterval(WidgetConstants.transitionPollInterval)
+
+                // Bake in a hard-deadline fallback entry so the widget exits the
+                // transitioning state even when reloadAllTimelines() from the NE
+                // process is suppressed (app closed). The fallback shows "Disconnected"
+                // — the safest assumption for both connect and disconnect transitions.
+                // If the real outcome differs, the next getTimeline call (via .after
+                // policy or an NE push when the app opens) will correct it.
+                let defaults = UserDefaults(suiteName: WidgetConstants.appGroupSuite)
+                let startTime = defaults?.double(forKey: WidgetConstants.keyTransitionStartTime) ?? 0
+                let deadlineBase = startTime > 0
+                    ? Date(timeIntervalSince1970: startTime)
+                    : entry.date
+                let deadline = deadlineBase.addingTimeInterval(WidgetConstants.transitionMaxDuration)
+
+                if deadline > pollDate {
+                    let fallback = VPNStatusEntry(
+                        date: deadline,
+                        status: .disconnected,
+                        ip: entry.ip,
+                        fqdn: entry.fqdn,
+                        needsAppSetup: entry.needsAppSetup,
+                        loginRequired: entry.loginRequired
+                    )
+                    completion(Timeline(entries: [entry, fallback], policy: .after(pollDate)))
+                } else {
+                    completion(Timeline(entries: [entry], policy: .after(pollDate)))
+                }
             } else {
-                nextUpdate = Calendar.current.date(
+                let nextUpdate = Calendar.current.date(
                     byAdding: .minute,
                     value: WidgetConstants.timelineRefreshMinutes,
                     to: entry.date
                 ) ?? entry.date.addingTimeInterval(300)
+                completion(Timeline(entries: [entry], policy: .after(nextUpdate)))
             }
-            completion(Timeline(entries: [entry], policy: .after(nextUpdate)))
         }
     }
 
@@ -39,6 +65,9 @@ struct VPNStatusProvider: TimelineProvider {
         let ip = defaults?.string(forKey: WidgetConstants.keyIP) ?? ""
         let fqdn = defaults?.string(forKey: WidgetConstants.keyFQDN) ?? ""
         let loginRequired = defaults?.bool(forKey: WidgetConstants.keyLoginRequired) ?? false
+        // true when the main app has stored active profile paths (set on every successful connect).
+        // If missing, the intent cannot start the tunnel without paths → show "open app" link instead.
+        let configPathStored = defaults?.string(forKey: WidgetConstants.keyActiveConfigPath) != nil
 
         NETunnelProviderManager.loadAllFromPreferences { managers, error in
             let manager = (error == nil) ? managers?.first : nil
@@ -51,10 +80,20 @@ struct VPNStatusProvider: TimelineProvider {
             let elapsed = Date().timeIntervalSince1970 - startTime
             let snapbackExpired = elapsed > WidgetConstants.snapbackWindow
 
+            // Hard upper bound: after transitionMaxDuration always trust NE (or force
+            // disconnected if no manager). This is the last-resort safety net for the
+            // case where reloadAllTimelines() from the NE process was silently dropped
+            // (app closed) and WidgetKit did not honour the .after(pollInterval) policy.
+            let hardExpired = elapsed > WidgetConstants.transitionMaxDuration
+
             if let manager {
                 let neStatus = WidgetVPNStatus(neStatus: manager.connection.status)
 
-                if persisted.isTransitioning && !snapbackExpired {
+                if persisted.isTransitioning && hardExpired {
+                    // Past the hard limit — force NE as truth regardless of snap-back.
+                    status = neStatus
+                    defaults?.set(neStatus.rawValue, forKey: WidgetConstants.keyVPNStatus)
+                } else if persisted.isTransitioning && !snapbackExpired {
                     // NE caught up: it reports the same direction as our command (or the
                     // final settled state), or it moved in the opposite direction.
                     // In both cases NE has a definitive answer — trust it immediately.
@@ -90,9 +129,9 @@ struct VPNStatusProvider: TimelineProvider {
                 }
             } else {
                 // No NE manager (profile not configured, or NE error).
-                // Fall back to persisted state; if transitioning and snap-back expired,
-                // reset to disconnected so the widget never gets permanently stuck.
-                if persisted.isTransitioning && snapbackExpired {
+                // Fall back to persisted state; if transitioning and snap-back or hard
+                // deadline expired, reset to disconnected so the widget never gets stuck.
+                if persisted.isTransitioning && (snapbackExpired || hardExpired) {
                     status = .disconnected
                     defaults?.set(WidgetVPNStatus.disconnected.rawValue, forKey: WidgetConstants.keyVPNStatus)
                 } else {
@@ -105,7 +144,7 @@ struct VPNStatusProvider: TimelineProvider {
                 status: status,
                 ip: ip,
                 fqdn: fqdn,
-                needsAppSetup: manager == nil || effectiveLoginRequired,
+                needsAppSetup: manager == nil || !configPathStored || effectiveLoginRequired,
                 loginRequired: effectiveLoginRequired
             )
             completion(entry)

--- a/NetBirdWidgetExtension/VPNStatusProvider.swift
+++ b/NetBirdWidgetExtension/VPNStatusProvider.swift
@@ -20,12 +20,16 @@ struct VPNStatusProvider: TimelineProvider {
 
     func getTimeline(in context: Context, completion: @escaping (Timeline<VPNStatusEntry>) -> Void) {
         loadEntry { entry in
-            let nextUpdate = Calendar.current.date(
-                byAdding: .minute,
-                value: WidgetConstants.timelineRefreshMinutes,
-                to: entry.date
-            ) ?? entry.date.addingTimeInterval(300)
-
+            let nextUpdate: Date
+            if entry.status.isTransitioning {
+                nextUpdate = entry.date.addingTimeInterval(WidgetConstants.transitionPollInterval)
+            } else {
+                nextUpdate = Calendar.current.date(
+                    byAdding: .minute,
+                    value: WidgetConstants.timelineRefreshMinutes,
+                    to: entry.date
+                ) ?? entry.date.addingTimeInterval(300)
+            }
             completion(Timeline(entries: [entry], policy: .after(nextUpdate)))
         }
     }
@@ -45,13 +49,23 @@ struct VPNStatusProvider: TimelineProvider {
 
             if let manager {
                 let neStatus = WidgetVPNStatus(neStatus: manager.connection.status)
-                // Prefer a persisted transition state (.connecting/.disconnecting) when NE
-                // still reports the old stable state — this avoids the brief snap-back
-                // right after a widget-triggered toggle rewrites keyVPNStatus.
-                let usePersistedTransition = persisted.isTransitioning && neStatus.isStable &&
+
+                // Use the persisted transitioning state only within the snap-back window —
+                // the brief period right after a tap when NE still reports the old stable state.
+                // Outside this window NE is always the source of truth, preventing stuck states.
+                let startTime = defaults?.double(forKey: WidgetConstants.keyTransitionStartTime) ?? 0
+                let inSnapbackWindow = Date().timeIntervalSince1970 - startTime < WidgetConstants.snapbackWindow
+                let usePersistedTransition = inSnapbackWindow &&
+                    persisted.isTransitioning && neStatus.isStable &&
                     !(persisted == .connecting && neStatus == .connected) &&
                     !(persisted == .disconnecting && neStatus == .disconnected)
+
                 status = usePersistedTransition ? persisted : neStatus
+
+                // Keep the persisted key in sync with the resolved stable state.
+                if !usePersistedTransition && persisted.isTransitioning {
+                    defaults?.set(neStatus.rawValue, forKey: WidgetConstants.keyVPNStatus)
+                }
             } else {
                 status = persisted
             }

--- a/NetBirdWidgetExtension/VPNStatusProvider.swift
+++ b/NetBirdWidgetExtension/VPNStatusProvider.swift
@@ -77,14 +77,18 @@ struct VPNStatusProvider: TimelineProvider {
             let persistedRaw = defaults?.string(forKey: WidgetConstants.keyVPNStatus) ?? "disconnected"
             let persisted = WidgetVPNStatus(rawValue: persistedRaw) ?? .disconnected
             let startTime = defaults?.double(forKey: WidgetConstants.keyTransitionStartTime) ?? 0
-            let elapsed = Date().timeIntervalSince1970 - startTime
-            let snapbackExpired = elapsed > WidgetConstants.snapbackWindow
-
-            // Hard upper bound: after transitionMaxDuration always trust NE (or force
-            // disconnected if no manager). This is the last-resort safety net for the
-            // case where reloadAllTimelines() from the NE process was silently dropped
-            // (app closed) and WidgetKit did not honour the .after(pollInterval) policy.
-            let hardExpired = elapsed > WidgetConstants.transitionMaxDuration
+            // startTime == 0 means the key was never written; treat both windows as active
+            // (not expired) so snap-back protection is not bypassed on first load.
+            let snapbackExpired: Bool
+            let hardExpired: Bool
+            if startTime > 0 {
+                let elapsed = Date().timeIntervalSince1970 - startTime
+                snapbackExpired = elapsed > WidgetConstants.snapbackWindow
+                hardExpired     = elapsed > WidgetConstants.transitionMaxDuration
+            } else {
+                snapbackExpired = false
+                hardExpired     = false
+            }
 
             if let manager {
                 let neStatus = WidgetVPNStatus(neStatus: manager.connection.status)

--- a/NetBirdWidgetExtension/VPNStatusProvider.swift
+++ b/NetBirdWidgetExtension/VPNStatusProvider.swift
@@ -43,31 +43,61 @@ struct VPNStatusProvider: TimelineProvider {
         NETunnelProviderManager.loadAllFromPreferences { managers, error in
             let manager = (error == nil) ? managers?.first : nil
             let status: WidgetVPNStatus
+            var effectiveLoginRequired = loginRequired
 
             let persistedRaw = defaults?.string(forKey: WidgetConstants.keyVPNStatus) ?? "disconnected"
             let persisted = WidgetVPNStatus(rawValue: persistedRaw) ?? .disconnected
+            let startTime = defaults?.double(forKey: WidgetConstants.keyTransitionStartTime) ?? 0
+            let elapsed = Date().timeIntervalSince1970 - startTime
+            let snapbackExpired = elapsed > WidgetConstants.snapbackWindow
 
             if let manager {
                 let neStatus = WidgetVPNStatus(neStatus: manager.connection.status)
 
-                // Use the persisted transitioning state only within the snap-back window —
-                // the brief period right after a tap when NE still reports the old stable state.
-                // Outside this window NE is always the source of truth, preventing stuck states.
-                let startTime = defaults?.double(forKey: WidgetConstants.keyTransitionStartTime) ?? 0
-                let inSnapbackWindow = Date().timeIntervalSince1970 - startTime < WidgetConstants.snapbackWindow
-                let usePersistedTransition = inSnapbackWindow &&
-                    persisted.isTransitioning && neStatus.isStable &&
-                    !(persisted == .connecting && neStatus == .connected) &&
-                    !(persisted == .disconnecting && neStatus == .disconnected)
+                if persisted.isTransitioning && !snapbackExpired {
+                    // NE caught up: it reports the same direction as our command (or the
+                    // final settled state), or it moved in the opposite direction.
+                    // In both cases NE has a definitive answer — trust it immediately.
+                    let neResolved =
+                        (persisted == .connecting  && (neStatus == .connecting  || neStatus == .connected))    ||
+                        (persisted == .disconnecting && (neStatus == .disconnecting || neStatus == .disconnected)) ||
+                        (persisted == .connecting  && neStatus == .disconnecting) ||
+                        (persisted == .disconnecting && neStatus == .connecting)
 
-                status = usePersistedTransition ? persisted : neStatus
+                    if neResolved {
+                        status = neStatus
+                        defaults?.set(neStatus.rawValue, forKey: WidgetConstants.keyVPNStatus)
+                    } else {
+                        // NE still shows the old stable state — keep persisted transitioning
+                        // state so the widget doesn't flicker back to stable prematurely.
+                        status = persisted
+                    }
+                } else {
+                    // Snap-back window expired (or persisted is already stable).
+                    // NE is always the source of truth from here on.
+                    status = neStatus
+                    if persisted.isTransitioning {
+                        defaults?.set(neStatus.rawValue, forKey: WidgetConstants.keyVPNStatus)
+                    }
+                }
 
-                // Keep the persisted key in sync with the resolved stable state.
-                if !usePersistedTransition && persisted.isTransitioning {
-                    defaults?.set(neStatus.rawValue, forKey: WidgetConstants.keyVPNStatus)
+                // Safety net: if NE reports connected the login-required flag must be stale.
+                // PacketTunnelProvider also clears it in updateWidgetStatus("connected"), but
+                // clearing here too ensures the widget self-heals even if that push was missed.
+                if neStatus == .connected && loginRequired {
+                    defaults?.set(false, forKey: WidgetConstants.keyLoginRequired)
+                    effectiveLoginRequired = false
                 }
             } else {
-                status = persisted
+                // No NE manager (profile not configured, or NE error).
+                // Fall back to persisted state; if transitioning and snap-back expired,
+                // reset to disconnected so the widget never gets permanently stuck.
+                if persisted.isTransitioning && snapbackExpired {
+                    status = .disconnected
+                    defaults?.set(WidgetVPNStatus.disconnected.rawValue, forKey: WidgetConstants.keyVPNStatus)
+                } else {
+                    status = persisted
+                }
             }
 
             let entry = VPNStatusEntry(
@@ -75,8 +105,8 @@ struct VPNStatusProvider: TimelineProvider {
                 status: status,
                 ip: ip,
                 fqdn: fqdn,
-                needsAppSetup: manager == nil || loginRequired,
-                loginRequired: loginRequired
+                needsAppSetup: manager == nil || effectiveLoginRequired,
+                loginRequired: effectiveLoginRequired
             )
             completion(entry)
         }

--- a/NetBirdWidgetExtension/Views/MediumWidgetView.swift
+++ b/NetBirdWidgetExtension/Views/MediumWidgetView.swift
@@ -53,20 +53,15 @@ struct MediumWidgetView: View {
     }
 
     private var transitionIndicator: some View {
-        HStack(spacing: 5) {
-            ProgressView()
-                .scaleEffect(0.65)
-                .frame(width: 14, height: 14)
-            Text(entry.status.displayText)
-                .font(.system(size: 11, weight: .semibold))
-                .foregroundColor(.white)
-                .lineLimit(1)
-                .minimumScaleFactor(0.8)
-        }
-        .frame(maxWidth: .infinity)
-        .padding(.vertical, 8)
-        .background(Color.orange.opacity(0.85))
-        .cornerRadius(10)
+        Text(entry.status.displayText)
+            .font(.system(size: 11, weight: .semibold))
+            .foregroundColor(.white)
+            .lineLimit(1)
+            .minimumScaleFactor(0.8)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 8)
+            .background(Color.orange.opacity(0.85))
+            .cornerRadius(10)
     }
 
     private func iconLabel(isConnected: Bool) -> some View {

--- a/NetBirdWidgetExtension/Views/MediumWidgetView.swift
+++ b/NetBirdWidgetExtension/Views/MediumWidgetView.swift
@@ -53,11 +53,12 @@ struct MediumWidgetView: View {
     }
 
     private var transitionIndicator: some View {
-        VStack(spacing: 4) {
+        VStack(spacing: 6) {
             ProgressView()
             Text(entry.status.displayText)
-                .font(.system(size: 11))
-                .foregroundColor(.secondary)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundColor(.orange)
+                .multilineTextAlignment(.center)
         }
     }
 

--- a/NetBirdWidgetExtension/Views/MediumWidgetView.swift
+++ b/NetBirdWidgetExtension/Views/MediumWidgetView.swift
@@ -15,12 +15,12 @@ struct MediumWidgetView: View {
                 } label: { isConnected in
                     iconLabel(isConnected: isConnected)
                 }
-                .frame(width: 80)
+                .frame(width: 100)
             } else if let url = entry.fallbackDeepLink {
                 Link(destination: url) {
                     iconLabel(isConnected: entry.isConnected)
                 }
-                .frame(width: 80)
+                .frame(width: 100)
             }
         }
         .padding()
@@ -53,13 +53,20 @@ struct MediumWidgetView: View {
     }
 
     private var transitionIndicator: some View {
-        VStack(spacing: 6) {
+        HStack(spacing: 5) {
             ProgressView()
+                .scaleEffect(0.65)
+                .frame(width: 14, height: 14)
             Text(entry.status.displayText)
-                .font(.system(size: 11, weight: .medium))
-                .foregroundColor(.orange)
-                .multilineTextAlignment(.center)
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundColor(.white)
+                .lineLimit(1)
+                .minimumScaleFactor(0.8)
         }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 8)
+        .background(Color.orange.opacity(0.85))
+        .cornerRadius(10)
     }
 
     private func iconLabel(isConnected: Bool) -> some View {

--- a/NetBirdWidgetExtension/Views/SmallWidgetView.swift
+++ b/NetBirdWidgetExtension/Views/SmallWidgetView.swift
@@ -15,8 +15,7 @@ struct SmallWidgetView: View {
 
             if #available(iOS 17.0, *) {
                 WidgetActionButton(entry: entry) {
-                    ProgressView()
-                        .scaleEffect(0.7)
+                    transitionPill()
                 } label: { isConnected in
                     pillLabel(isConnected: isConnected)
                 }
@@ -27,6 +26,22 @@ struct SmallWidgetView: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func transitionPill() -> some View {
+        HStack(spacing: 6) {
+            ProgressView()
+                .scaleEffect(0.65)
+                .frame(width: 14, height: 14)
+            Text(entry.status.displayText)
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundColor(.white)
+                .lineLimit(1)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 6)
+        .background(Color.orange.opacity(0.85))
+        .cornerRadius(8)
     }
 
     private func pillLabel(isConnected: Bool) -> some View {

--- a/NetBirdWidgetExtension/Views/StatusIndicator.swift
+++ b/NetBirdWidgetExtension/Views/StatusIndicator.swift
@@ -6,15 +6,9 @@ struct StatusIndicator: View {
 
     var body: some View {
         HStack(spacing: 6) {
-            if status.isTransitioning {
-                ProgressView()
-                    .scaleEffect(0.6)
-                    .frame(width: 8, height: 8)
-            } else {
-                Circle()
-                    .fill(status.statusColor)
-                    .frame(width: 8, height: 8)
-            }
+            Circle()
+                .fill(status.statusColor)
+                .frame(width: 8, height: 8)
 
             Text(status.displayText)
                 .font(.system(size: fontSize, weight: .medium))

--- a/NetBirdWidgetExtension/Views/StatusIndicator.swift
+++ b/NetBirdWidgetExtension/Views/StatusIndicator.swift
@@ -6,9 +6,15 @@ struct StatusIndicator: View {
 
     var body: some View {
         HStack(spacing: 6) {
-            Circle()
-                .fill(status.statusColor)
-                .frame(width: 8, height: 8)
+            if status.isTransitioning {
+                ProgressView()
+                    .scaleEffect(0.6)
+                    .frame(width: 8, height: 8)
+            } else {
+                Circle()
+                    .fill(status.statusColor)
+                    .frame(width: 8, height: 8)
+            }
 
             Text(status.displayText)
                 .font(.system(size: fontSize, weight: .medium))

--- a/NetBirdWidgetExtension/Views/WidgetActionButton.swift
+++ b/NetBirdWidgetExtension/Views/WidgetActionButton.swift
@@ -11,12 +11,14 @@ struct WidgetActionButton<TransitionContent: View, Label: View>: View {
     let label: (_ isConnected: Bool) -> Label
 
     var body: some View {
-        if entry.status.isTransitioning {
-            transitionContent()
-        } else if entry.needsAppSetup && !entry.isConnected {
+        if entry.needsAppSetup && !entry.isConnected {
+            // Login required or VPN not configured — open the app regardless of
+            // any transitioning state so the user is never stuck on a spinner.
             openAppLink {
                 label(false)
             }
+        } else if entry.status.isTransitioning {
+            transitionContent()
         } else {
             Button(intent: ToggleVPNIntent(action: entry.isConnected ? "disconnect" : "connect")) {
                 label(entry.isConnected)

--- a/NetBirdWidgetExtension/Views/WidgetActionButton.swift
+++ b/NetBirdWidgetExtension/Views/WidgetActionButton.swift
@@ -11,14 +11,19 @@ struct WidgetActionButton<TransitionContent: View, Label: View>: View {
     let label: (_ isConnected: Bool) -> Label
 
     var body: some View {
-        if entry.needsAppSetup && !entry.isConnected {
-            // Login required or VPN not configured — open the app regardless of
-            // any transitioning state so the user is never stuck on a spinner.
-            openAppLink {
+        if entry.loginRequired && !entry.isConnected {
+            // Login required — open the app immediately even during a transitioning
+            // state so the user is never stuck on a spinner waiting for re-auth.
+            openAppLink(url: WidgetConstants.deepLinkLogin) {
                 label(false)
             }
         } else if entry.status.isTransitioning {
             transitionContent()
+        } else if entry.needsAppSetup && !entry.isConnected {
+            // VPN profile not configured yet — open the app for initial setup.
+            openAppLink(url: WidgetConstants.deepLinkConnect) {
+                label(false)
+            }
         } else {
             Button(intent: ToggleVPNIntent(action: entry.isConnected ? "disconnect" : "connect")) {
                 label(entry.isConnected)
@@ -28,8 +33,10 @@ struct WidgetActionButton<TransitionContent: View, Label: View>: View {
     }
 
     @ViewBuilder
-    private func openAppLink<Content: View>(@ViewBuilder content: () -> Content) -> some View {
-        let url = entry.loginRequired ? WidgetConstants.deepLinkLogin : WidgetConstants.deepLinkConnect
+    private func openAppLink<Content: View>(
+        url: URL?,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
         if let url {
             Link(destination: url, label: content)
         } else {

--- a/NetBirdWidgetExtension/WidgetConstants.swift
+++ b/NetBirdWidgetExtension/WidgetConstants.swift
@@ -17,8 +17,16 @@ enum WidgetConstants {
     static let timelineRefreshMinutes = 5
 
     static let keyTransitionStartTime = "netbird.widget.transitionStartTime"
-    static let transitionPollInterval: TimeInterval = 2.0
-    // How long to prefer the persisted transitioning state over NE snap-back.
-    // After this window, NE status is always the source of truth.
-    static let snapbackWindow: TimeInterval = 3.0
+    // Fallback poll interval while the VPN is transitioning.
+    // The primary update mechanism is a push from PacketTunnelProvider via
+    // WidgetCenter.reloadAllTimelines(). This poll is a safety net only, so keep
+    // it conservative to avoid exhausting the ~40-70 daily WidgetKit refresh budget.
+    static let transitionPollInterval: TimeInterval = 5.0
+    // How long to show the persisted transitioning state while NE still reports the
+    // old stable state. 8 s covers the typical delay between startVPNTunnel() and
+    // NE first reporting .connecting. After this window NE is always authoritative.
+    static let snapbackWindow: TimeInterval = 8.0
+    // Hard upper bound on a transitioning state. If the widget is still showing
+    // "Connecting…"/"Disconnecting…" after this many seconds, force NE as truth.
+    static let transitionMaxDuration: TimeInterval = 60.0
 }

--- a/NetBirdWidgetExtension/WidgetConstants.swift
+++ b/NetBirdWidgetExtension/WidgetConstants.swift
@@ -15,4 +15,10 @@ enum WidgetConstants {
     static let pollInterval: TimeInterval = 0.3
     static let pollTimeout: TimeInterval = 5.0
     static let timelineRefreshMinutes = 5
+
+    static let keyTransitionStartTime = "netbird.widget.transitionStartTime"
+    static let transitionPollInterval: TimeInterval = 2.0
+    // How long to prefer the persisted transitioning state over NE snap-back.
+    // After this window, NE status is always the source of truth.
+    static let snapbackWindow: TimeInterval = 3.0
 }

--- a/NetBirdWidgetExtension/WidgetConstants.swift
+++ b/NetBirdWidgetExtension/WidgetConstants.swift
@@ -11,6 +11,10 @@ enum WidgetConstants {
     static let keyIP = "netbird.widget.ip"
     static let keyFQDN = "netbird.widget.fqdn"
     static let keyLoginRequired = "netbird.loginRequired"
+    // Active profile paths written by the main app so the widget intent can pass
+    // them to startVPNTunnel(options:) without the main app being in-process.
+    static let keyActiveConfigPath = "netbird.widget.activeConfigPath"
+    static let keyActiveStatePath  = "netbird.widget.activeStatePath"
 
     static let pollInterval: TimeInterval = 0.3
     static let pollTimeout: TimeInterval = 5.0
@@ -26,7 +30,8 @@ enum WidgetConstants {
     // old stable state. 8 s covers the typical delay between startVPNTunnel() and
     // NE first reporting .connecting. After this window NE is always authoritative.
     static let snapbackWindow: TimeInterval = 8.0
-    // Hard upper bound on a transitioning state. If the widget is still showing
-    // "Connecting…"/"Disconnecting…" after this many seconds, force NE as truth.
-    static let transitionMaxDuration: TimeInterval = 60.0
+    // Hard upper bound on a transitioning state. A fallback timeline entry is baked
+    // in at this offset so the widget never shows "Connecting…"/"Disconnecting…" forever,
+    // even when the NE process cannot push reloadAllTimelines() (app closed).
+    static let transitionMaxDuration: TimeInterval = 15.0
 }

--- a/NetbirdKit/GlobalConstants.swift
+++ b/NetbirdKit/GlobalConstants.swift
@@ -25,6 +25,10 @@ struct GlobalConstants {
     static let keyWidgetVPNStatus = "netbird.widget.vpnStatus"
     static let keyWidgetIP = "netbird.widget.ip"
     static let keyWidgetFQDN = "netbird.widget.fqdn"
+    // Active profile paths stored by the main app so the widget intent can
+    // start the tunnel without the main app running (mirrors WidgetConstants).
+    static let keyWidgetActiveConfigPath = "netbird.widget.activeConfigPath"
+    static let keyWidgetActiveStatePath  = "netbird.widget.activeStatePath"
 
     static let configFileName = "netbird.cfg"
     static let stateFileName = "state.json"

--- a/NetbirdKit/NetworkExtensionAdapter.swift
+++ b/NetbirdKit/NetworkExtensionAdapter.swift
@@ -434,13 +434,21 @@ public class NetworkExtensionAdapter: ObservableObject {
         #if os(iOS)
         // Pass active profile paths so the extension can reinitialize the adapter
         // if the profile changed while the extension process was still alive.
-        if let configPath = Preferences.configFile() {
+        let configPath = Preferences.configFile()
+        let statePath  = Preferences.stateFile()
+        if let configPath {
             options["configPath"] = configPath as NSObject
         }
-        if let statePath = Preferences.stateFile() {
+        if let statePath {
             options["statePath"] = statePath as NSObject
         }
-        logger.info("startVPNConnection: configPath=\(Preferences.configFile() ?? "nil")")
+        logger.info("startVPNConnection: configPath=\(configPath ?? "nil")")
+
+        // Persist the active paths to the shared app group so the widget intent
+        // can pass them to startVPNTunnel(options:) when the main app is not running.
+        let sharedDefaults = UserDefaults(suiteName: GlobalConstants.userPreferencesSuiteName)
+        sharedDefaults?.set(configPath, forKey: GlobalConstants.keyWidgetActiveConfigPath)
+        sharedDefaults?.set(statePath,  forKey: GlobalConstants.keyWidgetActiveStatePath)
         #endif
 
         guard let session = self.session else {

--- a/NetbirdNetworkExtension/PacketTunnelProvider.swift
+++ b/NetbirdNetworkExtension/PacketTunnelProvider.swift
@@ -10,6 +10,7 @@ import Network
 import NetBirdSDK
 import os
 import UserNotifications
+import WidgetKit
 
 
 class PacketTunnelProvider: NEPacketTunnelProvider {
@@ -71,6 +72,9 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
 
         if adapter.needsLogin() {
             signalLoginRequired()
+            // Clear any transitioning widget state so the login button appears immediately
+            // instead of waiting for the snap-back window to expire.
+            updateWidgetStatus("disconnected")
             // Return the error immediately so iOS tears down the tunnel interface at once.
             // A deferred completionHandler keeps the tunnel interface alive (black-hole state)
             // and intercepts all network traffic — including ASWebAuthenticationSession requests
@@ -83,7 +87,14 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             return
         }
 
-        adapter.start(completionHandler: completionHandler)
+        adapter.start { [weak self] error in
+            completionHandler(error)
+            if error == nil {
+                self?.updateWidgetStatus("connected")
+            } else {
+                self?.updateWidgetStatus("disconnected")
+            }
+        }
     }
 
     override func stopTunnel(with reason: NEProviderStopReason, completionHandler: @escaping () -> Void) {
@@ -100,14 +111,16 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         adapter?.stop()
         guard let pathMonitor = self.pathMonitor else {
             AppLogger.shared.log("pathMonitor is nil; nothing to cancel.")
-            DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 2) { [weak self] in
+                self?.updateWidgetStatus("disconnected")
                 completionHandler()
             }
             return
         }
         pathMonitor.cancel()
         self.pathMonitor = nil
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) { [weak self] in
+            self?.updateWidgetStatus("disconnected")
             completionHandler()
         }
     }
@@ -529,6 +542,16 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     }
 
     override func wake() {
+    }
+
+    /// Writes the resolved VPN status to shared UserDefaults and triggers a widget reload.
+    /// Called from start/stop completion so the widget reflects the real tunnel state
+    /// without waiting for the widget's own polling cycle.
+    private func updateWidgetStatus(_ status: String) {
+        let defaults = UserDefaults(suiteName: GlobalConstants.userPreferencesSuiteName)
+        defaults?.set(status, forKey: GlobalConstants.keyWidgetVPNStatus)
+        WidgetCenter.shared.reloadAllTimelines()
+        AppLogger.shared.log("updateWidgetStatus: \(status)")
     }
 
     func setTunnelSettings(tunnelNetworkSettings: NEPacketTunnelNetworkSettings) {

--- a/NetbirdNetworkExtension/PacketTunnelProvider.swift
+++ b/NetbirdNetworkExtension/PacketTunnelProvider.swift
@@ -109,18 +109,17 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         adapter?.isNetworkUnavailable = false
         setNetworkUnavailableFlag(false)
         adapter?.stop()
+        updateWidgetStatus("disconnected")
         guard let pathMonitor = self.pathMonitor else {
             AppLogger.shared.log("pathMonitor is nil; nothing to cancel.")
-            DispatchQueue.main.asyncAfter(deadline: .now() + 2) { [weak self] in
-                self?.updateWidgetStatus("disconnected")
+            DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
                 completionHandler()
             }
             return
         }
         pathMonitor.cancel()
         self.pathMonitor = nil
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2) { [weak self] in
-            self?.updateWidgetStatus("disconnected")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
             completionHandler()
         }
     }

--- a/NetbirdNetworkExtension/PacketTunnelProvider.swift
+++ b/NetbirdNetworkExtension/PacketTunnelProvider.swift
@@ -319,6 +319,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             if self?.adapter?.needsLogin() == true {
                 AppLogger.shared.log("restartClient: login required — signaling main app, skipping restart")
                 self?.signalLoginRequired()
+                self?.updateWidgetStatus("disconnected")
                 self?.monitorQueue.async {
                     self?.adapter?.isRestarting = false
                     self?.isRestartInProgress = false
@@ -328,7 +329,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             }
 
             AppLogger.shared.log("restartClient: starting client")
-            self?.adapter?.start { error in
+            self?.adapter?.start { [weak self] error in
                 // Cancel timeout whether start succeeds or not
                 timeoutWorkItem.cancel()
 
@@ -339,8 +340,10 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
 
                 if let error = error {
                     AppLogger.shared.log("restartClient: start failed - \(error.localizedDescription)")
+                    self?.updateWidgetStatus("disconnected")
                 } else {
                     AppLogger.shared.log("restartClient: start completed successfully")
+                    self?.updateWidgetStatus("connected")
                 }
             }
         }
@@ -550,8 +553,16 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     private func updateWidgetStatus(_ status: String) {
         let defaults = UserDefaults(suiteName: GlobalConstants.userPreferencesSuiteName)
         defaults?.set(status, forKey: GlobalConstants.keyWidgetVPNStatus)
-        WidgetCenter.shared.reloadAllTimelines()
         AppLogger.shared.log("updateWidgetStatus: \(status)")
+        // For "connected", delay the reload by 1 s so the NE connection status has time
+        // to propagate from the tunnel process to the widget extension process before
+        // VPNStatusProvider queries NETunnelProviderManager.loadAllFromPreferences().
+        // Without this delay the widget briefly shows "Disconnected / Connect" right
+        // after a successful connect, then stays wrong until the next 5-minute poll.
+        let delay: TimeInterval = (status == "connected") ? 1.0 : 0.0
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+            WidgetCenter.shared.reloadAllTimelines()
+        }
     }
 
     func setTunnelSettings(tunnelNetworkSettings: NEPacketTunnelNetworkSettings) {


### PR DESCRIPTION
## Summary

When a user tapped **Connect** or **Disconnect** from the iOS widget, no visual
feedback was shown until the final VPN state was available. This left users
unsure whether their tap was registered.

This PR adds an immediate "Connecting…" / "Disconnecting…" loading state to
both small and medium widgets, backed by a reliable multi-layer update pipeline
from the tunnel process.

## Changes

### Visual feedback
- **Small widget** — orange pill with a spinner and status text ("Connecting…" / "Disconnecting…")
- **Medium widget** — orange rounded-rectangle pill with status text; button frame widened to 100 pt

### Immediate reload on intent fire
- `ToggleVPNIntent` now reloads widget timelines **immediately** on button tap,
  before waiting for the tunnel to settle
- A transition start timestamp is written to shared `UserDefaults`

### Snap-back prevention (`VPNStatusProvider`)
- Added an 8 s snap-back window: while NE still reports the old stable state,
  the persisted transitioning state is held to prevent UI flicker
- Hard expiry at 15 s resets to NE's value unconditionally

### Hard-deadline fallback timeline entry
- While transitioning, `getTimeline` polls every 5 s and bakes in a fallback
  `disconnected` entry at `transitionStartTime + 15 s` — the widget exits the
  loading state even when `reloadAllTimelines()` from NE is suppressed (app closed)

### `PacketTunnelProvider` push
- Added `updateWidgetStatus(_:)`: writes resolved status to shared `UserDefaults`
  and calls `WidgetCenter.shared.reloadAllTimelines()`
- Called from `startTunnel`, `stopTunnel`, `restartClient`, and `needsLogin` paths
- Connected result gets a 1 s reload delay so NE connection status propagates
  before `VPNStatusProvider` queries `NETunnelProviderManager`

### Widget-initiated connect without the main app
- `NetworkExtensionAdapter` now persists `configPath` / `statePath` to shared
  `UserDefaults` on every successful connect
- `ToggleVPNIntent` reads these paths and passes them as `startVPNTunnel(options:)`
  options — tunnel can start from a widget tap with the main app closed

### Login-required fix
- `WidgetActionButton` shows the login deep-link immediately when `loginRequired == true`,
  even during a transitioning state — user is never stuck on a spinner awaiting re-auth
- `PacketTunnelProvider` writes "disconnected" before returning the login-required error
  so the widget snaps to the login button instantly

### App foreground cleanup
- Clears stale `connectPressed` / `disconnectPressed` flags before applying fresh
  NE state on foreground to prevent races with widget-initiated actions
- Forces widget timeline reload even when no VPN profile is found

## Testing

- [ ] Tap **Connect** in widget → orange "Connecting…" pill appears immediately
- [ ] Tap **Disconnect** in widget → orange "Disconnecting…" pill appears immediately
- [ ] Widget transitions to correct final state after action completes
- [ ] Widget exits loading state within 15 s even with the main app closed
- [ ] Login-required flow opens the app immediately, even during transitioning state
- [ ] Widget-initiated connect works without the main app in the foreground

### Known issues

**Widget updates are not instant (2–6 s)**
- Connect: VPN handshake time (~2–5 s) + 1 s NE reload delay = 3–6 s total
- Disconnect: pre-existing 2 s delay in `stopTunnel` + NE reload = ~2–3 s
- Worst case if NE push is throttled by iOS: 5 s safety-net poll

**Brief "Disconnected" flash after connect**
Despite the 1 s delay, in rare cases XPC propagation hasn't completed by the
time WidgetKit calls `getTimeline()`. The widget momentarily shows "Disconnected"
and self-corrects on the next 5 s poll. Eliminating this entirely would require
blocking `perform()`, which removes the spinner.

**Fundamental iOS constraint**
Showing intermediate states requires `perform()` to return immediately — but
once it returns, iOS can kill the widget extension process at any time, making
background polling unreliable. The NE process push is the only truly reliable
update path; the 5 s poll and 15 s baked-in fallback entry exist precisely
because that push can be throttled.

### Why this happens

Widget updates involve three separate OS processes that cannot communicate
directly: the **widget extension process** (runs `ToggleVPNIntent.perform()`),
the **Network Extension daemon** (runs the VPN tunnel), and the **main app**.
Each process has its own limitations:

**Widget extension process** is killed by iOS shortly after `perform()` returns.
The original code blocked `perform()` with `await waitForStableState()` for up
to 5 s to keep the process alive long enough to write the final state. This
worked reliably — the process stayed alive, polled the NE status, wrote the
final state, and only then returned. However it caused iOS to batch both
`reloadAllTimelines()` calls into one, skipping the intermediate "Connecting…"
spinner entirely — the user only ever saw the final state.

To fix the missing spinner, a later commit changed `perform()` to return
immediately and moved the polling into a `Task.detached`. This introduced
the regression: iOS kills the widget extension process immediately after
`perform()` returns, which kills the detached task before it can write the
final state. At the same time, `PacketTunnelProvider` was not pushing any
status updates on its own. The result — `persisted` stayed stuck on
`"connecting"` or `"disconnecting"` indefinitely, with no process left alive
to clear it.

**Network Extension daemon** can call `WidgetCenter.shared.reloadAllTimelines()`
but iOS can silently throttle or drop these calls when the app is closed.
The previous `PacketTunnelProvider` did not call `reloadAllTimelines()` at all —
the widget had no push mechanism and relied entirely on WidgetKit's 5-minute
refresh cycle to pick up state changes.

**NE XPC propagation lag** — even after the NE daemon writes `"connected"` to
shared UserDefaults, `NETunnelProviderManager.loadAllFromPreferences()` in the
widget extension process can still return the old `.disconnected` status for up
to ~1 s due to the inter-process XPC round-trip. Without compensation this
causes the widget to briefly flash "Disconnected" immediately after a successful
connect, then stay wrong until the next scheduled refresh.

**WidgetKit refresh budget** is shared across all apps and limited to
approximately 40–70 `reloadAllTimelines()` calls per day. Polling too
aggressively during transitions can exhaust this budget.

These constraints make it impossible to have all three of: (1) an immediate
intermediate spinner, (2) instant final-state updates, and (3) a process that
stays alive to guarantee the update. The fix below layers multiple mechanisms
to get as close as possible to all three.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Widgets no longer get stuck in a transitioning UI; timelines refresh reliably.
  * Improved reconciliation between system VPN state and widget status to reduce flicker.
  * More robust disconnect eligibility and transition expiry handling.

* **New Features**
  * Widgets can start/stop VPN when the main app isn’t running by using persisted config/state.
  * Updated widget action UI and transition indicators for clearer connecting/disconnecting feedback.
  * Widget extension granted network-extension entitlement for packet-tunnel support.

* **Chores**
  * Firebase configuration removed from app bundle.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/netbirdio/ios-client/pull/125?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->