### PR TITLE
[debug] log iOS tunnel includedRoutes/DNS on route changes

### DIFF
--- a/NetbirdKit/AppLogger.swift
+++ b/NetbirdKit/AppLogger.swift
@@ -88,7 +88,9 @@ public class AppLogger {
     public func log(_ message: String, file: String = #file, function: String = #function, line: Int = #line) {
         let fileName = (file as NSString).lastPathComponent
         let timestamp = iso8601Formatter.string(from: Date())
-        let logMessage = "[\(timestamp)] [\(fileName):\(line)] \(message)\n"
+        var tid: UInt64 = 0
+        pthread_threadid_np(nil, &tid)
+        let logMessage = "[\(timestamp)] [tid:\(tid)] [\(fileName):\(line)] \(message)\n"
 
         print(logMessage, terminator: "")
 

--- a/NetbirdKit/NetworkChangeListener.swift
+++ b/NetbirdKit/NetworkChangeListener.swift
@@ -20,8 +20,13 @@ enum IPAddressType {
 class NetworkChangeListener: NSObject, NetBirdSDKNetworkChangeListenerProtocol {
     func onNetworkChanged(_ p0: String?) {
         let routesString = p0 ?? ""
+        // [DEBUG exit-node-off] Raw route list the core pushes. On exit-node OFF this
+        // should NOT contain 0.0.0.0/0 or ::/0. If it doesn't but traffic still goes
+        // into the tunnel, the bug is downstream (createTunnelSettings/state), not here.
+        AppLogger.shared.log("[DEBUG exit-node-off] onNetworkChanged: raw=\"\(routesString)\"")
         let (v4Routes, v6Routes, containsDefault) = parseRoutesToNESettings(routesString: routesString)
         if v4Routes.isEmpty && v6Routes.isEmpty && self.interfaceIP == nil {
+            AppLogger.shared.log("[DEBUG exit-node-off] onNetworkChanged: empty routes and no interfaceIP -> skipping setRoutes")
             return
         }
         self.tunnelManager.setRoutes(v4Routes: v4Routes, v6Routes: v6Routes, containsDefault: containsDefault)
@@ -87,6 +92,11 @@ class NetworkChangeListener: NSObject, NetBirdSDKNetworkChangeListenerProtocol {
         if let interfaceIPv6 = self.interfaceIPv6, let interfaceRoute = createIPv6RouteFromCIDR(cidr: interfaceIPv6) {
             v6Routes.append(interfaceRoute)
         }
+        // [DEBUG exit-node-off] Final parsed routes (core routes + the interface
+        // address route appended above). This is what gets handed to setRoutes.
+        let v4Desc = v4Routes.map { "\($0.destinationAddress)/\($0.destinationSubnetMask)" }.joined(separator: " ")
+        let v6Desc = v6Routes.map { "\($0.destinationAddress)/\($0.destinationNetworkPrefixLength)" }.joined(separator: " ")
+        AppLogger.shared.log("[DEBUG exit-node-off] parseRoutesToNESettings: containsDefault=\(containsDefault) v4=[\(v4Desc)] v6=[\(v6Desc)]")
         return (v4Routes, v6Routes, containsDefault)
     }
     

--- a/NetbirdNetworkExtension/PacketTunnelProviderSettingsManager.swift
+++ b/NetbirdNetworkExtension/PacketTunnelProviderSettingsManager.swift
@@ -44,6 +44,7 @@ class PacketTunnelProviderSettingsManager {
             self.ipv4Routes = v4Routes
             self.ipv6Routes = v6Routes
             self.updateTunnel()
+            AppLogger.shared.log("[DEBUG exit-node-off] setRoutes: updateTunnel() called")
     }
 
     func setDNS(config: HostDNSConfig) {
@@ -69,8 +70,9 @@ class PacketTunnelProviderSettingsManager {
 
         self.dnsSettings = dnsSettings
         self.updateTunnel()
+        AppLogger.shared.log("[DEBUG exit-node-off] setDNS: server=\(config.serverIP) searchDomains=[\(searchDomains.joined(separator: ","))] updateTunnel() called")
     }
-    
+
     func setInterfaceIP(interfaceIP: String) {
         // [DEBUG exit-node-off] Track interface address changes. interfaceIPv6 is
         // never cleared once set (see NetworkChangeListener), so a stale v6 address

--- a/NetbirdNetworkExtension/PacketTunnelProviderSettingsManager.swift
+++ b/NetbirdNetworkExtension/PacketTunnelProviderSettingsManager.swift
@@ -31,6 +31,14 @@ class PacketTunnelProviderSettingsManager {
     }
 
     func setRoutes(v4Routes: [NEIPv4Route], v6Routes: [NEIPv6Route], containsDefault: Bool) {
+            // [DEBUG exit-node-off] Log exactly what the core asks us to install.
+            // Compare this against the "createTunnelSettings" line to see whether the
+            // default route is correctly dropped from includedRoutes when the exit
+            // node is turned off.
+            let v4Desc = v4Routes.map { "\($0.destinationAddress)/\($0.destinationSubnetMask)" }.joined(separator: " ")
+            let v6Desc = v6Routes.map { "\($0.destinationAddress)/\($0.destinationNetworkPrefixLength)" }.joined(separator: " ")
+            AppLogger.shared.log("[DEBUG exit-node-off] setRoutes: containsDefault=\(containsDefault) v4(\(v4Routes.count))=[\(v4Desc)] v6(\(v6Routes.count))=[\(v6Desc)]")
+
             self.needFallbackNS = containsDefault
             self.containsDefaultRoute = containsDefault
             self.ipv4Routes = v4Routes
@@ -64,10 +72,15 @@ class PacketTunnelProviderSettingsManager {
     }
     
     func setInterfaceIP(interfaceIP: String) {
+        // [DEBUG exit-node-off] Track interface address changes. interfaceIPv6 is
+        // never cleared once set (see NetworkChangeListener), so a stale v6 address
+        // surviving a profile switch would show up by comparing these lines.
+        AppLogger.shared.log("[DEBUG exit-node-off] setInterfaceIP: \(interfaceIP) (prev=\(self.interfaceIP ?? "nil"))")
         self.interfaceIP = interfaceIP
     }
 
     func setInterfaceIPv6(interfaceIPv6: String) {
+        AppLogger.shared.log("[DEBUG exit-node-off] setInterfaceIPv6: \(interfaceIPv6) (prev=\(self.interfaceIPv6 ?? "nil"))")
         self.interfaceIPv6 = interfaceIPv6
     }
 
@@ -124,15 +137,32 @@ class PacketTunnelProviderSettingsManager {
                 }
                 
                 tunnelNetworkSettings.mtu = 1280
-                
+
                 if self.dnsSettings != nil {
                     tunnelNetworkSettings.dnsSettings = self.dnsSettings
                 }
-                
+
+                // [DEBUG exit-node-off] This is the single most important line for
+                // the "exit node off -> no connectivity" bug: it shows the exact
+                // includedRoutes that iOS will install. If a v4 0.0.0.0/0 (or a v6
+                // ::/0 that isn't the intended blackhole) is still present here while
+                // the exit node is OFF, all internet traffic is funneled into the
+                // tunnel with no way out (black hole). Cross-check with the core's
+                // "Calling remove for key 0.0.0.0/0" in client.log.
+                let v4Included = (ipv4Settings.includedRoutes ?? []).map { "\($0.destinationAddress)/\($0.destinationSubnetMask)" }.joined(separator: " ")
+                let v6Included = v6Routes.map { "\($0.destinationAddress)/\($0.destinationNetworkPrefixLength)" }.joined(separator: " ")
+                let v6AddrDesc = zip(v6Addresses, v6PrefixLengths).map { "\($0)/\($1)" }.joined(separator: " ")
+                let matchDomains = (self.dnsSettings?.matchDomains ?? []).map { $0.isEmpty ? "<root \"\">" : $0 }.joined(separator: ",")
+                let dnsServers = (self.dnsSettings?.servers ?? []).joined(separator: ",")
+                AppLogger.shared.log("[DEBUG exit-node-off] createTunnelSettings: containsDefaultRoute=\(self.containsDefaultRoute) v4addr=\(ipAddress)/\(subnetMask) v4Included=[\(v4Included)] v6addr=[\(v6AddrDesc)] v6Included=[\(v6Included)] dnsServers=[\(dnsServers)] matchDomains=[\(matchDomains)]")
+
                 return tunnelNetworkSettings
             }
         }
 
+        // [DEBUG exit-node-off] interfaceIP missing or unparseable -> settings not
+        // updated, the previous (possibly default-routed) settings stay in effect.
+        AppLogger.shared.log("[DEBUG exit-node-off] createTunnelSettings: returning nil (interfaceIP=\(self.interfaceIP ?? "nil")), tunnel settings NOT updated")
         return nil
     }
 


### PR DESCRIPTION
Add targeted diagnostic logging (AppLogger -> swift-log.log) to pin down the "exit node off -> no connectivity" bug. The Go core correctly removes 0.0.0.0/0 and ::/0 on exit-node deselect, yet client.log shows internet traffic still entering utun10 (src = NetBird tunnel IP) and dying with in:0 pkts. That can only happen if the iOS NEPacketTunnelNetworkSettings includedRoutes still carry default coverage after OFF. swift-log.log currently never logs the actual routes/DNS it installs (only a contentless "Routes set successfully"), so the bug is invisible in the debug bundle.

Logging added:
- NetworkChangeListener.onNetworkChanged: raw route string from the core.
- NetworkChangeListener.parseRoutesToNESettings: final parsed v4/v6 routes
  + containsDefault (includes the appended interface-address route).
- PacketTunnelProviderSettingsManager.setRoutes: what the core asked to install.
- setInterfaceIP / setInterfaceIPv6: address state (interfaceIPv6 is never cleared, so a stale v6 surviving a profile switch would be visible).
- createTunnelSettings: the decisive line — the exact v4/v6 includedRoutes, v6 addresses, DNS servers and matchDomains actually being installed.

No behavior change; logging only. Go core untouched.

## Description




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced diagnostic logging across the networking stack, including route parsing decisions, default-route detection, IPv4/IPv6 route lists, and DNS/interface configuration details to improve troubleshooting.
  * Added thread identifiers to each log line for easier correlation of concurrent events.
  * Updated the pinned `netbird-core` dependency to a newer revision.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->