### PR TITLE
fix(ios): prevent extension crash from late Go callbacks during network flapping

### DIFF
--- a/NetbirdKit/DNSManager.swift
+++ b/NetbirdKit/DNSManager.swift
@@ -22,17 +22,38 @@ struct HostDNSConfig: Codable {
 }
 
 class DNSManager: NSObject, NetBirdSDKDnsManagerProtocol {
-    
-    private var tunnelManager: PacketTunnelProviderSettingsManager
-    
+
+    // See NetworkChangeListener for the full rationale: the Go engine retains this
+    // manager for the SDK client's lifetime and can fire applyDns late, after the
+    // adapter has been swapped/torn down. Guard against dereferencing a freed
+    // tunnelManager (EXC_BAD_ACCESS / 0x28) and serialize with invalidate().
+    private let callbackQueue = DispatchQueue(label: "io.netbird.DNSManager")
+    private var isValid = true
+
+    private var tunnelManager: PacketTunnelProviderSettingsManager?
+
     init(with tunnelManager: PacketTunnelProviderSettingsManager) {
         self.tunnelManager = tunnelManager
     }
-    
+
+    /// Detach from the tunnel manager. After this call every Go callback is dropped.
+    /// Must be called before the owning adapter/provider is torn down.
+    func invalidate() {
+        callbackQueue.sync {
+            self.isValid = false
+            self.tunnelManager = nil
+        }
+    }
+
     func applyDns(_ p0: String?) {
-        if let p0 = p0, !p0.isEmpty {
-            if let config = parseDNSSettingsString(inputString: p0) {
-                self.tunnelManager.setDNS(config: config)
+        callbackQueue.sync {
+            guard self.isValid, let tunnelManager = self.tunnelManager else {
+                return
+            }
+            if let p0 = p0, !p0.isEmpty {
+                if let config = parseDNSSettingsString(inputString: p0) {
+                    tunnelManager.setDNS(config: config)
+                }
             }
         }
     }

--- a/NetbirdKit/NetworkChangeListener.swift
+++ b/NetbirdKit/NetworkChangeListener.swift
@@ -18,17 +18,21 @@ enum IPAddressType {
 }
 
 class NetworkChangeListener: NSObject, NetBirdSDKNetworkChangeListenerProtocol {
-    func onNetworkChanged(_ p0: String?) {
-        let routesString = p0 ?? ""
-        let (v4Routes, v6Routes, containsDefault) = parseRoutesToNESettings(routesString: routesString)
-        if v4Routes.isEmpty && v6Routes.isEmpty && self.interfaceIP == nil {
-            return
-        }
-        self.tunnelManager.setRoutes(v4Routes: v4Routes, v6Routes: v6Routes, containsDefault: containsDefault)
-    }
-    
-    private var tunnelManager: PacketTunnelProviderSettingsManager
-    
+    // The Go engine retains this listener for the lifetime of the SDK client it was
+    // created with. When the adapter is swapped/torn down (e.g. profile switch or a
+    // restart triggered by wifi<->cellular flapping) the OLD client can still be
+    // spinning down and fire a late callback into THIS (now-stale) listener. Without
+    // a guard that callback would reach into a tunnelManager whose owning provider has
+    // already been deallocated, dereferencing a freed object -> EXC_BAD_ACCESS (0x28).
+    //
+    // `invalidate()` is called before the adapter is discarded so any in-flight or
+    // late Go callback becomes a no-op. All Go callbacks are serialized onto a single
+    // queue so invalidation and callback handling can't race.
+    private let callbackQueue = DispatchQueue(label: "io.netbird.NetworkChangeListener")
+    private var isValid = true
+
+    private var tunnelManager: PacketTunnelProviderSettingsManager?
+
     var interfaceIP: String?
     var interfaceIPv6: String?
 
@@ -36,21 +40,53 @@ class NetworkChangeListener: NSObject, NetBirdSDKNetworkChangeListenerProtocol {
         self.tunnelManager = tunnelManager
     }
 
-    func setInterfaceIP(_ p0: String?) {
-        guard let validIP = p0, !validIP.isEmpty else {
-            return
+    /// Detach this listener from its tunnel manager. After this call every Go callback
+    /// is dropped. Must be called before the owning adapter/provider is torn down.
+    func invalidate() {
+        callbackQueue.sync {
+            self.isValid = false
+            self.tunnelManager = nil
         }
+    }
 
-        self.interfaceIP = validIP
-        self.tunnelManager.setInterfaceIP(interfaceIP: validIP)
+    func onNetworkChanged(_ p0: String?) {
+        callbackQueue.sync {
+            guard self.isValid, let tunnelManager = self.tunnelManager else {
+                return
+            }
+            let routesString = p0 ?? ""
+            let (v4Routes, v6Routes, containsDefault) = parseRoutesToNESettings(routesString: routesString)
+            if v4Routes.isEmpty && v6Routes.isEmpty && self.interfaceIP == nil {
+                return
+            }
+            tunnelManager.setRoutes(v4Routes: v4Routes, v6Routes: v6Routes, containsDefault: containsDefault)
+        }
+    }
+
+    func setInterfaceIP(_ p0: String?) {
+        callbackQueue.sync {
+            guard self.isValid, let tunnelManager = self.tunnelManager else {
+                return
+            }
+            guard let validIP = p0, !validIP.isEmpty else {
+                return
+            }
+            self.interfaceIP = validIP
+            tunnelManager.setInterfaceIP(interfaceIP: validIP)
+        }
     }
 
     func setInterfaceIPv6(_ p0: String?) {
-        guard let validIPv6 = p0, !validIPv6.isEmpty else {
-            return
+        callbackQueue.sync {
+            guard self.isValid, let tunnelManager = self.tunnelManager else {
+                return
+            }
+            guard let validIPv6 = p0, !validIPv6.isEmpty else {
+                return
+            }
+            self.interfaceIPv6 = validIPv6
+            tunnelManager.setInterfaceIPv6(interfaceIPv6: validIPv6)
         }
-        self.interfaceIPv6 = validIPv6
-        self.tunnelManager.setInterfaceIPv6(interfaceIPv6: validIPv6)
     }
     
     func parseRoutesToNESettings(routesString: String) -> ([NEIPv4Route], [NEIPv6Route], Bool) {

--- a/NetbirdNetworkExtension/NetBirdAdapter.swift
+++ b/NetbirdNetworkExtension/NetBirdAdapter.swift
@@ -538,6 +538,17 @@ public class NetBirdAdapter {
         }
     }
 
+    /// Permanently detach the listeners the Go engine holds for this adapter's client so
+    /// that any late callback fired while the old client spins down becomes a no-op instead
+    /// of dereferencing a torn-down tunnel manager/provider (EXC_BAD_ACCESS / 0x28).
+    /// Call this when the adapter is being DISCARDED (profile switch / replacement) — not
+    /// on a plain stop()/restart, where the same adapter is reused and must keep delivering
+    /// route/DNS callbacks afterwards. Safe to call multiple times.
+    func invalidateListeners() {
+        self.networkChangeListener.invalidate()
+        self.dnsManager.invalidate()
+    }
+
     public func stop(completionHandler: (() -> Void)? = nil) {
         stopLock.lock()
 

--- a/NetbirdNetworkExtension/PacketTunnelProvider.swift
+++ b/NetbirdNetworkExtension/PacketTunnelProvider.swift
@@ -44,6 +44,10 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         let statePath  = (options?["statePath"]  as? String).flatMap { $0.isEmpty ? nil : $0 }
         if adapter == nil || (configPath != nil && configPath != adapter?.initializedConfigPath) {
             AppLogger.shared.log("PacketTunnelProvider: (re)creating adapter for configPath=\(configPath ?? "default")")
+            // Detach the outgoing adapter's Go callbacks before discarding it so a late
+            // callback from the old client can't reach into the tunnel manager once the
+            // new adapter has replaced it (EXC_BAD_ACCESS / 0x28 during profile switch).
+            adapter?.invalidateListeners()
             adapter = NetBirdAdapter(with: tunnelManager, configPath: configPath, statePath: statePath)
         }
         #else
@@ -185,6 +189,8 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
 
                 if configPath != adapter?.initializedConfigPath || configRestored {
                     AppLogger.shared.log("handleAppMessage: (re)creating adapter for \(configPath)")
+                    // Detach the outgoing adapter's Go callbacks before discarding it (see startTunnel).
+                    adapter?.invalidateListeners()
                     adapter = NetBirdAdapter(with: tunnelManager, configPath: configPath, statePath: statePath)
                 }
             }


### PR DESCRIPTION
## Problem

On wifi↔cellular path flapping the packet-tunnel extension crash-loops: it connects briefly, then is killed and relaunched every ~6–12 s, so no IP / device name renders and iOS never activates the VPN. Customer-reported, multiple iOS devices, build 7 / 0.2.0, iOS 26.5.

Crash signature from the device `.ips` reports: `EXC_BAD_ACCESS` / `KERN_INVALID_ADDRESS at 0x28`, `com.apple.main-thread`, in the gomobile bridge.

## Root cause (code-derived)

> ⚠️ **Not yet confirmed against a symbolicated build-7 crash** — the build-7 dSYM was not obtainable (the GH Actions runner deletes the `.xcarchive` after upload; ASC shows "Includes Symbols: Yes" but offers no download). This fix is derived from the code path + three OLD symbolicated extension crashes (0.0.9 / 0.0.10) that all crash on the same `onNetworkChanged` path.

The Go engine retains `NetworkChangeListener` and `DNSManager` for the lifetime of the SDK client they were created with. When the adapter is swapped/torn down (profile switch, or a `restartClient()` triggered by flapping), the **old** client can still fire a late `onNetworkChanged` / `applyDns` into the now-stale listener, which dereferences a `tunnelManager` whose owning provider has already been deallocated → use-after-free → `0x28`. The listener/adapter swap had no synchronization against in-flight Go callbacks.

## Fix

Make the Go-held listeners null-safe and explicitly detachable.

- **`NetworkChangeListener.swift` / `DNSManager.swift`**: `tunnelManager` is now optional; every Go callback (`onNetworkChanged`, `setInterfaceIP`, `setInterfaceIPv6`, `applyDns`) runs on a serial queue behind a `guard isValid, let tunnelManager` — late/in-flight callbacks become no-ops instead of crashing. Added `invalidate()` (serialized on the same queue).
- **`NetBirdAdapter.swift`**: added `invalidateListeners()`. **Deliberately NOT called from `stop()`/restart** — the same adapter is reused there and must keep delivering callbacks; only invalidated when the adapter is actually discarded.
- **`PacketTunnelProvider.swift`**: invalidate the outgoing adapter's listeners before replacing it at the two reconfigure sites (`startTunnel`, `handleAppMessage`).

## Risk / things to watch

- Callbacks now run via `callbackQueue.sync` — fine today (no reentrant call back onto the queue; `setTunnelNetworkSettings` completion is async, so no deadlock), but a future reentrant caller would deadlock. Flagging for reviewer awareness.
- Main regression risk is **functional, not a new crash**: confirm that after a restart route/DNS callbacks still arrive, and after a profile switch the new adapter's listener works.

## Testing — NOT yet done (needs macOS/CI; no swiftc on the dev box)

- [ ] Builds on CI
- [ ] No crash under wifi↔cellular flapping (Network Link Conditioner / toggle interfaces)
- [ ] Connection + routes + DNS recover **after** flapping
- [ ] Works after a profile switch

## Follow-up suggestion

Add an `actions/upload-artifact` step for `$RUNNER_TEMP/NetBird.xcarchive/dSYMs` in `build-upload.yml` so future extension crashes symbolicate without an ASC dSYM hunt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced stability during VPN profile switching by properly detaching network and DNS callbacks
  * Improved callback serialization to prevent issues when switching profiles or during tunnel state transitions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->