### PR TITLE
Backport single exit node selection

### DIFF
--- a/NetBird/Source/App/ViewModels/RoutesViewModel.swift
+++ b/NetBird/Source/App/ViewModels/RoutesViewModel.swift
@@ -61,8 +61,21 @@ class RoutesViewModel: ObservableObject {
     
     func selectRoute(route: RoutesSelectionInfo) {
         guard let index = self.routeInfo.firstIndex(where: { $0.id == route.id }) else { return }
+
+        // Exit nodes are mutually exclusive. Mirror the desktop behaviour: activating an
+        // exit node deselects every other selected exit node, so 0.0.0.0/0 can't stay
+        // pinned to the previously selected peer while the UI shows only the new one.
+        // Non-exit route selections are left untouched. Deselect the siblings first so
+        // the core drops the old exit node before adding the new one.
+        if route.isExitNode {
+            let siblings = routeInfo.filter { $0.id != route.id && $0.selected && $0.isExitNode }
+            for sibling in siblings {
+                deselectRoute(route: sibling)
+            }
+        }
+
         self.routeInfo[index].selected = true
-        networkExtensionAdapter.selectRoutes(id: route.name) { details in
+        networkExtensionAdapter.selectRoutes(id: route.name) { _ in
             print("selected route")
         }
     }

--- a/NetBird/Source/App/ViewModels/RoutesViewModel.swift
+++ b/NetBird/Source/App/ViewModels/RoutesViewModel.swift
@@ -86,6 +86,11 @@ class RoutesViewModel: ObservableObject {
 
         let group = DispatchGroup()
         for sibling in siblings {
+            // `selected` is a plain property on the ObservableObject (kept non-@Published so
+            // the class stays trivially Codable), so mutating it emits nothing on its own.
+            // Notify the observing RouteCard explicitly so the sibling's toggle flips off now
+            // instead of only after the getRoutes reconcile round-trip.
+            sibling.objectWillChange.send()
             sibling.selected = false
             group.enter()
             networkExtensionAdapter.deselectRoutes(id: sibling.name) { _ in

--- a/NetBird/Source/App/ViewModels/RoutesViewModel.swift
+++ b/NetBird/Source/App/ViewModels/RoutesViewModel.swift
@@ -62,21 +62,50 @@ class RoutesViewModel: ObservableObject {
     func selectRoute(route: RoutesSelectionInfo) {
         guard let index = self.routeInfo.firstIndex(where: { $0.id == route.id }) else { return }
 
+        self.routeInfo[index].selected = true
+
+        // Non-exit routes select independently.
+        guard route.isExitNode else {
+            sendSelectAndReconcile(route: route)
+            return
+        }
+
         // Exit nodes are mutually exclusive. Mirror the desktop behaviour: activating an
         // exit node deselects every other selected exit node, so 0.0.0.0/0 can't stay
         // pinned to the previously selected peer while the UI shows only the new one.
-        // Non-exit route selections are left untouched. Deselect the siblings first so
-        // the core drops the old exit node before adding the new one.
-        if route.isExitNode {
-            let siblings = routeInfo.filter { $0.id != route.id && $0.selected && $0.isExitNode }
-            for sibling in siblings {
-                deselectRoute(route: sibling)
+        // Non-exit route selections are left untouched. The siblings must be fully
+        // deselected in the core BEFORE the new node is added: selectRoutes/deselectRoutes
+        // are independent async round-trips, so firing the select without waiting lets it
+        // race the deselects and the core can drop the node we just added. Wait for every
+        // deselect to complete, then select.
+        let siblings = routeInfo.filter { $0.id != route.id && $0.selected && $0.isExitNode }
+        guard !siblings.isEmpty else {
+            sendSelectAndReconcile(route: route)
+            return
+        }
+
+        let group = DispatchGroup()
+        for sibling in siblings {
+            sibling.selected = false
+            group.enter()
+            networkExtensionAdapter.deselectRoutes(id: sibling.name) { _ in
+                group.leave()
             }
         }
 
-        self.routeInfo[index].selected = true
-        networkExtensionAdapter.selectRoutes(id: route.name) { _ in
-            print("selected route")
+        group.notify(queue: .main) { [weak self] in
+            self?.sendSelectAndReconcile(route: route)
+        }
+    }
+
+    // Sends the select for `route`, then reconciles the optimistic UI selection with the
+    // core's real state. Select/Deselect messages don't report the applied result (the
+    // extension swallows errors and always replies "true"), so re-read the truth via
+    // GetRoutes: if the core rejected the change the toggle reverts instead of leaving a
+    // stale optimistic selection in place.
+    private func sendSelectAndReconcile(route: RoutesSelectionInfo) {
+        networkExtensionAdapter.selectRoutes(id: route.name) { [weak self] _ in
+            self?.getRoutes()
         }
     }
     

--- a/NetbirdKit/NetworkExtensionAdapter.swift
+++ b/NetbirdKit/NetworkExtensionAdapter.swift
@@ -963,7 +963,13 @@ public class NetworkExtensionAdapter: ObservableObject {
     }
 
     func deselectRoutes(id: String, completion: @escaping (RoutesSelectionDetails) -> Void) {
+        // Callers (e.g. RoutesViewModel.selectRoute) balance a DispatchGroup enter/leave
+        // around this call, so completion must fire on every exit path or the group hangs
+        // and the pending select is never sent.
+        let routes = RoutesSelectionDetails(all: false, append: false, routeSelectionInfo: [])
+
         guard let session = self.session else {
+            completion(routes)
             return
         }
 
@@ -971,14 +977,15 @@ public class NetworkExtensionAdapter: ObservableObject {
         if let messageData = messageString.data(using: .utf8) {
             do {
                 try session.sendProviderMessage(messageData) { response in
-                    let routes = RoutesSelectionDetails(all: false, append: false, routeSelectionInfo: [])
                     completion(routes)
                 }
             } catch {
                 print("Failed to send Provider message")
+                completion(routes)
             }
         } else {
             print("Error converting message to Data")
+            completion(routes)
         }
     }
     

--- a/NetbirdKit/RoutesSelectionDetails.swift
+++ b/NetbirdKit/RoutesSelectionDetails.swift
@@ -48,6 +48,16 @@ class RoutesSelectionInfo: ObservableObject, Codable, Identifiable {
         self.status = status
     }
 
+    // A route that covers all traffic (0.0.0.0/0 or ::/0) is an exit node. The core
+    // may merge a v4+v6 pair into a single comma-joined range string.
+    var isExitNode: Bool {
+        guard let network else { return false }
+        return network.split(separator: ",").contains { part in
+            let trimmed = part.trimmingCharacters(in: .whitespaces)
+            return trimmed == "0.0.0.0/0" || trimmed == "::/0"
+        }
+    }
+
     enum CodingKeys: String, CodingKey {
         case id, name, network, domains, selected, status
     }


### PR DESCRIPTION
## Description




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved route selection so selecting an exit node automatically deselects other exit nodes to prevent conflicting selections.
  * Enhanced UI responsiveness by reconciling selection state correctly after asynchronous updates.
  * Improved exit-node detection for routes with multiple network entries and inconsistent spacing.
  * Ensured route deselection reliably completes even when errors occur.

* **New Features**
  * Added more accurate exit-node identification to support the updated selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->