### PR TITLE
Clear stale interfaceIPv6 on new engine session

### DIFF
--- a/NetbirdKit/NetworkChangeListener.swift
+++ b/NetbirdKit/NetworkChangeListener.swift
@@ -72,6 +72,10 @@ class NetworkChangeListener: NSObject, NetBirdSDKNetworkChangeListenerProtocol {
                 return
             }
             self.interfaceIP = validIP
+            // New engine session boundary: drop the previous session's v6 address. The
+            // engine re-announces it via setInterfaceIPv6 only when the session actually
+            // has one, so a v4-only session must not keep a stale value around.
+            self.interfaceIPv6 = nil
             tunnelManager.setInterfaceIP(interfaceIP: validIP)
         }
     }

--- a/NetbirdNetworkExtension/PacketTunnelProviderSettingsManager.swift
+++ b/NetbirdNetworkExtension/PacketTunnelProviderSettingsManager.swift
@@ -65,6 +65,14 @@ class PacketTunnelProviderSettingsManager {
     
     func setInterfaceIP(interfaceIP: String) {
         self.interfaceIP = interfaceIP
+        // A new engine session always pushes setInterfaceIP first, then setInterfaceIPv6
+        // only when the session actually has a v6 address. Drop any previous session's v6
+        // here so a v4-only session (IPv6 disabled or a v4-only profile) can't keep applying
+        // a stale interfaceIPv6 — which would send createTunnelSettings down the dual-stack
+        // branch and skip the ::/0 blackhole, leaking IPv6 past a selected exit node. This
+        // manager outlives individual engine sessions (it is owned by the extension process),
+        // so the reset has to happen at the session boundary rather than on teardown.
+        self.interfaceIPv6 = nil
     }
 
     func setInterfaceIPv6(interfaceIPv6: String) {


### PR DESCRIPTION
The settings manager outlives individual engine sessions, and the engine only pushes setInterfaceIPv6 when a session has a v6 address. After IPv6 is disabled or a v4-only profile is selected, a stale v6 address kept createTunnelSettings on the dual-stack branch and skipped the ::/0 blackhole, leaking IPv6 past a selected exit node. Reset interfaceIPv6 at the setInterfaceIP session boundary so a v4-only session can't reuse it.

## Description


