### PR TITLE
fix: preserve peer identity on re-login

### DIFF
--- a/NetbirdKit/NetworkExtensionAdapter.swift
+++ b/NetbirdKit/NetworkExtensionAdapter.swift
@@ -548,7 +548,13 @@ public class NetworkExtensionAdapter: ObservableObject {
                     DispatchQueue.main.async { self?.pendingAuth = nil }
                     resume(nil)
                 }
-                auth.login(errListener, urlOpener: urlOpener, forceDeviceAuth: false)
+                // Pass the device name explicitly. The plain login() path uses an empty
+                // device name, which makes the management server register the peer under
+                // the machine hostname fallback instead of the user's device name
+                // (UIDevice.current.name). This only affects first-time registration —
+                // a re-login reuses the persisted config/identity — but that first peer
+                // would otherwise show up as "hostname".
+                auth.login(withDeviceName: errListener, urlOpener: urlOpener, forceDeviceAuth: false, deviceName: Device.getName())
             }
 
             if let url = receivedURL, !url.isEmpty {

--- a/NetbirdKit/NetworkExtensionAdapter.swift
+++ b/NetbirdKit/NetworkExtensionAdapter.swift
@@ -473,7 +473,20 @@ public class NetworkExtensionAdapter: ObservableObject {
         // — and be written back to — the wrong server. Pass the active profile's real
         // management URL so login targets the user's own server and the config keeps it.
         let activeProfile = ProfileManager.shared.getActiveProfileName()
-        let activeManagementURL = ProfileManager.shared.managementURL(for: activeProfile) ?? ""
+        // managementURL(for:) already recovers the URL from the config file, the
+        // logout-surviving server URL file, and the connection cache in turn. A nil
+        // result therefore means no server URL is persisted anywhere — which only
+        // happens on a genuine first-time login, where falling back to the default
+        // cloud server is correct. For a re-login the config file exists and its URL
+        // is preserved even when "" is passed (SDK's apply() only overrides the
+        // config URL when a non-empty one is provided). Log the nil case so a rare
+        // corrupted state (own-server profile that lost every URL source, which would
+        // silently fall back to the default cloud) is visible in diagnostics.
+        let resolvedURL = ProfileManager.shared.managementURL(for: activeProfile)
+        if resolvedURL == nil {
+            logger.warning("performLogin: no persisted management URL for '\(activeProfile, privacy: .public)' — login will use the default cloud server")
+        }
+        let activeManagementURL = resolvedURL ?? ""
         logger.info("performLogin: using management URL '\(activeManagementURL, privacy: .public)' for profile '\(activeProfile, privacy: .public)'")
         if let configPath = Preferences.configFile(), !configPath.isEmpty,
            let auth = NetBirdSDKNewAuth(configPath, activeManagementURL, nil) {

--- a/NetbirdKit/NetworkExtensionAdapter.swift
+++ b/NetbirdKit/NetworkExtensionAdapter.swift
@@ -462,13 +462,16 @@ public class NetworkExtensionAdapter: ObservableObject {
         // (after startTunnel fails with login-required), which kills the WaitToken
         // goroutine before the HTTP server can receive the OAuth callback.
         // Running it here keeps the HTTP server alive for the full browser session.
-        // NetBirdSDKNewAuth does NOT read the config file at configPath — it only
-        // uses that path for writing the config back after login. The second argument
-        // is the management URL used to build the in-memory config; passing "" makes
-        // the Go SDK fall back to the default cloud server (api.netbird.io) and the
-        // login runs against — and is then written back to — the wrong server.
-        // Pass the active profile's real management URL so login targets the user's
-        // own server and the resulting config keeps it.
+        // NetBirdSDKNewAuth loads the existing config file at configPath when one is
+        // present, so an interactive re-login reuses the peer's persisted WireGuard
+        // private key (its identity) instead of generating a fresh one. A fresh key
+        // would register a brand-new peer on the management server on every re-auth
+        // (named after the fallback hostname). Only a first-time login with no config
+        // yet builds a new in-memory config from the URL argument.
+        // The second argument is the management URL: passing "" makes the Go SDK fall
+        // back to the default cloud server (api.netbird.io), so login would run against
+        // — and be written back to — the wrong server. Pass the active profile's real
+        // management URL so login targets the user's own server and the config keeps it.
         let activeProfile = ProfileManager.shared.getActiveProfileName()
         let activeManagementURL = ProfileManager.shared.managementURL(for: activeProfile) ?? ""
         logger.info("performLogin: using management URL '\(activeManagementURL, privacy: .public)' for profile '\(activeProfile, privacy: .public)'")

--- a/NetbirdNetworkExtension/NetBirdAdapter.swift
+++ b/NetbirdNetworkExtension/NetBirdAdapter.swift
@@ -528,12 +528,11 @@ public class NetBirdAdapter {
         if let auth = NetBirdSDKNewAuth(configPath, managementURL, nil) {
             authRef = auth
 
-            #if os(tvOS)
+            // Always pass the device name so the peer registers under the user's
+            // device name (UIDevice.current.name on iOS, the generated apple-tv-* name
+            // on tvOS) instead of the plain login() path's empty-name hostname fallback.
             let deviceName = Device.getName()
             auth.login(withDeviceName: errListener, urlOpener: urlOpener, forceDeviceAuth: forceDeviceAuth, deviceName: deviceName)
-            #else
-            auth.login(errListener, urlOpener: urlOpener, forceDeviceAuth: forceDeviceAuth)
-            #endif
         } else {
             handleError(NSError(domain: "io.netbird", code: 1002, userInfo: [NSLocalizedDescriptionKey: "Failed to create Auth object"]))
         }


### PR DESCRIPTION
preserve peer identity on re-login, stop creating duplicatepeers

Every interactive re-authentication registered a brand-new peer on the management server (named after the fallback hostname) instead of re-using the existing one. Root cause was in the netbird-core iOS SDK: NewAuth built a fresh in-memory config that generated a new WireGuard private key, and performLogin() wrote that config (with the new key) back to netbird.cfg on login success — replacing the peer's persisted identity. Regression from the login flow moving into the main-app process (#138), where OAuth switched from the config-reading IPC path to NewAuth.

- Bump netbird-core to fix/ios-relogin: NewAuth now loads the existing config (preserving the private key) when a config file is present, only generating a fresh key for first-time login / after logout when no file exists.
- Update the stale performLogin() comment that claimed NewAuth does not read the config file.

## Description




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sign-in reliability by consistently registering the peer using an explicit, non-empty device name across all supported platforms.
  * Enhanced iOS re-login by resolving the correct management server for the active profile, warning when no saved value is available, and safely falling back when needed.
* **Documentation**
  * Updated iOS sign-in and interactive re-login guidance to better explain credential reuse and correct server targeting for custom profiles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->