### PR TITLE
make connect/disconnect toggle accessible to VoiceOver

### DIFF
--- a/NetBird/Source/App/Views/Components/VPNToggleView.swift
+++ b/NetBird/Source/App/Views/Components/VPNToggleView.swift
@@ -42,17 +42,19 @@ struct VPNToggleView: View {
     }
 
     // Mirror the .onTapGesture logic so VoiceOver activation (double-tap) works.
+    // Decide from the optimistic visual state (isOn) rather than vpnState, which
+    // lags behind the OS: rapid taps would otherwise re-read a stale
+    // .disconnected/.connected and fire duplicate onConnect/onDisconnect calls.
     private func toggle() {
         guard !isLocked else { return }
-        switch vpnState {
-        case .disconnected:
-            optimisticIsOn = true
-            onConnect()
-        case .connected, .connecting:
+        // Preserve the original behavior of ignoring taps mid-teardown.
+        guard vpnState != .disconnecting else { return }
+        if isOn {
             optimisticIsOn = false
             onDisconnect()
-        case .disconnecting:
-            break
+        } else {
+            optimisticIsOn = true
+            onConnect()
         }
     }
 

--- a/NetBird/Source/App/Views/Components/VPNToggleView.swift
+++ b/NetBird/Source/App/Views/Components/VPNToggleView.swift
@@ -41,6 +41,20 @@ struct VPNToggleView: View {
         }
     }
 
+    // VoiceOver: describe the action activation performs. No hint while
+    // disconnecting, since the toggle is inert mid-teardown and announcing a
+    // connect action would be misleading.
+    private var accessibilityHintText: String {
+        switch vpnState {
+        case .disconnecting:
+            return ""
+        default:
+            return isOn
+                ? NSLocalizedString("Disconnects the VPN", comment: "VoiceOver hint for VPN toggle when connected")
+                : NSLocalizedString("Connects the VPN", comment: "VoiceOver hint for VPN toggle when disconnected")
+        }
+    }
+
     // Mirror the .onTapGesture logic so VoiceOver activation (double-tap) works.
     // Decide from the optimistic visual state (isOn) rather than vpnState, which
     // lags behind the OS: rapid taps would otherwise re-read a stale
@@ -84,9 +98,7 @@ struct VPNToggleView: View {
         .accessibilityValue(Text(accessibilityValueText))
         .accessibilityAddTraits(.isButton)
         .accessibilityAddTraits(isOn ? .isSelected : [])
-        .accessibilityHint(Text(isOn
-            ? NSLocalizedString("Disconnects the VPN", comment: "VoiceOver hint for VPN toggle when connected")
-            : NSLocalizedString("Connects the VPN", comment: "VoiceOver hint for VPN toggle when disconnected")))
+        .accessibilityHint(Text(accessibilityHintText))
         .accessibilityRespondsToUserInteraction(!isLocked)
         .accessibilityAction {
             toggle()

--- a/NetBird/Source/App/Views/Components/VPNToggleView.swift
+++ b/NetBird/Source/App/Views/Components/VPNToggleView.swift
@@ -27,6 +27,35 @@ struct VPNToggleView: View {
     private var thumbDiameter: CGFloat { trackHeight - 8 }
     private var thumbTravel: CGFloat { (trackWidth - thumbDiameter) / 2 - 4 }
 
+    // VoiceOver: describe the current connection state as the toggle's value.
+    private var accessibilityValueText: String {
+        switch vpnState {
+        case .connected:
+            return NSLocalizedString("Connected", comment: "VoiceOver value for VPN toggle when connected")
+        case .connecting:
+            return NSLocalizedString("Connecting", comment: "VoiceOver value for VPN toggle while connecting")
+        case .disconnecting:
+            return NSLocalizedString("Disconnecting", comment: "VoiceOver value for VPN toggle while disconnecting")
+        case .disconnected:
+            return NSLocalizedString("Disconnected", comment: "VoiceOver value for VPN toggle when disconnected")
+        }
+    }
+
+    // Mirror the .onTapGesture logic so VoiceOver activation (double-tap) works.
+    private func toggle() {
+        guard !isLocked else { return }
+        switch vpnState {
+        case .disconnected:
+            optimisticIsOn = true
+            onConnect()
+        case .connected, .connecting:
+            optimisticIsOn = false
+            onDisconnect()
+        case .disconnecting:
+            break
+        }
+    }
+
     var body: some View {
         ZStack {
             Capsule()
@@ -44,17 +73,21 @@ struct VPNToggleView: View {
         }
         .contentShape(Rectangle())
         .onTapGesture {
-            guard !isLocked else { return }
-            switch vpnState {
-            case .disconnected:
-                optimisticIsOn = true
-                onConnect()
-            case .connected, .connecting:
-                optimisticIsOn = false
-                onDisconnect()
-            case .disconnecting:
-                break
-            }
+            toggle()
+        }
+        // Accessibility: expose the custom shapes as a single toggle control so
+        // VoiceOver can focus, announce, and activate it.
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(Text(NSLocalizedString("VPN Connection", comment: "VoiceOver label for the main connect/disconnect toggle")))
+        .accessibilityValue(Text(accessibilityValueText))
+        .accessibilityAddTraits(.isButton)
+        .accessibilityAddTraits(isOn ? .isSelected : [])
+        .accessibilityHint(Text(isOn
+            ? NSLocalizedString("Disconnects the VPN", comment: "VoiceOver hint for VPN toggle when connected")
+            : NSLocalizedString("Connects the VPN", comment: "VoiceOver hint for VPN toggle when disconnected")))
+        .accessibilityRespondsToUserInteraction(!isLocked)
+        .accessibilityAction {
+            toggle()
         }
         // Clear optimistic as soon as the OS confirms any state change
         .onChange(of: vpnState) { _ in


### PR DESCRIPTION
The main VPN toggle is a custom SwiftUI view built from Capsule/Circle shapes with a bare .onTapGesture, so it had no accessibility semantics. VoiceOver saw only anonymous shapes and could not focus or activate it.

Expose the toggle as a single control: ignore child shapes, add a label, value (connection state), .isButton trait, an action-based hint, and an accessibilityAction wired to the shared toggle() logic so VoiceOver activation matches tap. Mark it non-interactive while locked.

## Description

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/ios-client/pr/168"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787142979&installation_id=146802194&pr_number=168&repository=netbirdio%2Fios-client&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Fios-client%2Fpull%2F168&signature=30b0e279224d761295c0ad6f881416bcada661ccb927bdca6f420fe3ca27cac6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Added VoiceOver announcements for VPN connection states, including connecting, connected, disconnecting, and disconnected.
  * Improved the VPN toggle’s label, status value, usage hint, and on/off state reporting.
  * Added VoiceOver action support for activating the toggle.
  * Locked VPN controls are now correctly announced as unavailable and prevent interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->