### PR TITLE
debug: capture Go panic output by redirecting stderr to netbird.err

### DIFF
--- a/NetbirdNetworkExtension/PacketTunnelProvider.swift
+++ b/NetbirdNetworkExtension/PacketTunnelProvider.swift
@@ -12,8 +12,55 @@ import os
 import UserNotifications
 import WidgetKit
 
+/// One-time (per process) redirect of stderr (fd 2) into "netbird.err" in the app
+/// group container. The Go runtime writes panic messages and fatal-error goroutine
+/// dumps to fd 2, which an app extension otherwise discards — after a SIGABRT crash
+/// this file is the only place the panic reason can be recovered from.
+/// The file lives next to logfile.log, so the debug bundle generator picks it up
+/// automatically as "netbird.err" (see BundleGenerator.addLogfile in netbird-core).
+private let stderrRedirectOnce: Void = {
+    let fileManager = FileManager.default
+    guard let groupURL = fileManager.containerURL(forSecurityApplicationGroupIdentifier: GlobalConstants.userPreferencesSuiteName) else {
+        AppLogger.shared.log("stderr redirect: app group container unavailable")
+        return
+    }
+    let errLogURL = groupURL.appendingPathComponent("netbird.err")
+
+    // Cap growth across sessions: reset once it grows beyond 5 MB.
+    if let attrs = try? fileManager.attributesOfItem(atPath: errLogURL.path),
+       let size = attrs[.size] as? UInt64, size > 5 * 1024 * 1024 {
+        try? fileManager.removeItem(at: errLogURL)
+    }
+
+    // Surface a previous session's crash output before appending to it.
+    if let attrs = try? fileManager.attributesOfItem(atPath: errLogURL.path),
+       let size = attrs[.size] as? UInt64, size > 0 {
+        AppLogger.shared.log("stderr redirect: netbird.err has \(size) bytes from a previous session (possible crash dump)")
+    }
+
+    let fd = open(errLogURL.path, O_WRONLY | O_CREAT | O_APPEND, 0o644)
+    guard fd >= 0 else {
+        AppLogger.shared.log("stderr redirect: failed to open \(errLogURL.path), errno=\(errno)")
+        return
+    }
+    dup2(fd, STDERR_FILENO)
+    if fd != STDERR_FILENO {
+        close(fd)
+    }
+
+    let marker = "\n=== stderr redirect active pid=\(getpid()) at \(ISO8601DateFormatter().string(from: Date())) ===\n"
+    marker.withCString { _ = write(STDERR_FILENO, $0, strlen($0)) }
+    AppLogger.shared.log("stderr redirect: fd 2 -> netbird.err in app group container")
+}()
+
 
 class PacketTunnelProvider: NEPacketTunnelProvider {
+
+    override init() {
+        // Must run before any Go SDK call so a Go panic during startup is captured too.
+        _ = stderrRedirectOnce
+        super.init()
+    }
 
     private lazy var tunnelManager: PacketTunnelProviderSettingsManager = {
         return PacketTunnelProviderSettingsManager(with: self)

--- a/NetbirdNetworkExtension/PacketTunnelProvider.swift
+++ b/NetbirdNetworkExtension/PacketTunnelProvider.swift
@@ -26,16 +26,15 @@ private let stderrRedirectOnce: Void = {
     }
     let errLogURL = groupURL.appendingPathComponent("netbird.err")
 
-    // Cap growth across sessions: reset once it grows beyond 5 MB.
-    if let attrs = try? fileManager.attributesOfItem(atPath: errLogURL.path),
-       let size = attrs[.size] as? UInt64, size > 5 * 1024 * 1024 {
-        try? fileManager.removeItem(at: errLogURL)
-    }
-
-    // Surface a previous session's crash output before appending to it.
     if let attrs = try? fileManager.attributesOfItem(atPath: errLogURL.path),
        let size = attrs[.size] as? UInt64, size > 0 {
+        // Surface a previous session's crash output before appending to it.
         AppLogger.shared.log("stderr redirect: netbird.err has \(size) bytes from a previous session (possible crash dump)")
+        // Cap growth across sessions: reset once it grows beyond 5 MB.
+        if size > 5 * 1024 * 1024 {
+            AppLogger.shared.log("stderr redirect: netbird.err exceeds 5 MB cap, resetting")
+            try? fileManager.removeItem(at: errLogURL)
+        }
     }
 
     let fd = open(errLogURL.path, O_WRONLY | O_CREAT | O_APPEND, 0o644)


### PR DESCRIPTION
The NE extension crashes with SIGABRT ~1.7s after connect (during network map application). The Go runtime writes the fatal error message and goroutine dump to fd 2, which an app extension discards, so the crash reason is unrecoverable from the .ips report alone (the unwinder cannot walk Go stacks).

Redirect stderr once per process (before any Go SDK call) into netbird.err in the app group container, next to logfile.log. The debug bundle generator already picks up netbird.err from the log directory on iOS (BundleGenerator.addLogfile), on both the extension IPC path and the main-app fallback path, so the next crash's panic message lands in the bundle automatically.

## Description

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/ios-client/pr/169"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787220329&installation_model_id=427504&pr_number=169&repository=netbirdio%2Fios-client&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Fios-client%2Fpull%2F169&signature=d3c4f120706732a6e1717e294f861bde065faba0131bcf4174679554117aa32f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved capture of critical startup errors and crash output so they’re easier to diagnose.
  * Added automatic capping of stored diagnostic output (limits growth to 5 MB) to prevent unbounded log file size.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->