### PR TITLE
Show the Go core version alongside the app version

### DIFF
--- a/NetBird/Source/App/Views/AboutView.swift
+++ b/NetBird/Source/App/Views/AboutView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import NetBirdSDK
 
 struct AboutView: View {
     @EnvironmentObject var viewModel: ViewModel
@@ -20,9 +21,14 @@ struct AboutView: View {
                             .resizable()
                             .aspectRatio(contentMode: .fit)
                             .frame(width: 120)
-                        Text("Version \(appVersion)")
-                            .font(.subheadline)
-                            .foregroundColor(Color("TextSecondary"))
+                        VStack(spacing: 4) {
+                            Text("Version \(appVersion)")
+                                .font(.subheadline)
+                                .foregroundColor(Color("TextSecondary"))
+                            Text("Core \(goVersion)")
+                                .font(.caption)
+                                .foregroundColor(Color("TextSecondary"))
+                        }
                     }
                     Spacer()
                 }
@@ -93,6 +99,12 @@ struct AboutView: View {
 
     private var appVersion: String {
         Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
+    }
+
+    /// Version of the Go client baked into NetBirdSDK.xcframework at compile time.
+    private var goVersion: String {
+        let version = NetBirdSDKGoClientVersion()
+        return version.isEmpty ? "unknown" : version
     }
 }
 

--- a/NetBird/Source/App/Views/TV/TVSettingsView.swift
+++ b/NetBird/Source/App/Views/TV/TVSettingsView.swift
@@ -10,6 +10,7 @@
 
 import SwiftUI
 import UIKit
+import NetBirdSDK
 
 #if os(tvOS)
 
@@ -125,7 +126,7 @@ struct TVSettingsView: View {
                             TVSettingsInfoRow(
                                 icon: "info.circle.fill",
                                 title: "Version",
-                                subtitle: appVersion
+                                subtitle: "\(appVersion) (core \(goVersion))"
                             )
                         }
                     }
@@ -170,6 +171,12 @@ struct TVSettingsView: View {
     
     private var appVersion: String {
         Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
+    }
+
+    /// Version of the Go client baked into NetBirdSDK.xcframework at compile time.
+    private var goVersion: String {
+        let version = NetBirdSDKGoClientVersion()
+        return version.isEmpty ? "unknown" : version
     }
 }
 

--- a/NetBird/Source/App/Views/iOS/iOSSettingsView.swift
+++ b/NetBird/Source/App/Views/iOS/iOSSettingsView.swift
@@ -116,21 +116,12 @@ struct iOSSettingsView: View {
                 }
 
                 Section {
-                    VStack(spacing: 2) {
-                        HStack {
-                            Spacer()
-                            Text("Version \(appVersion)")
-                                .font(.system(size: 14))
-                                .foregroundColor(Color("TextSecondary"))
-                            Spacer()
-                        }
-                        HStack {
-                            Spacer()
-                            Text("Core \(goVersion)")
-                                .font(.system(size: 12))
-                                .foregroundColor(Color("TextSecondary"))
-                            Spacer()
-                        }
+                    HStack {
+                        Spacer()
+                        Text("Version: \(appVersion) (core \(goVersion))")
+                            .font(.system(size: 14))
+                            .foregroundColor(Color("TextSecondary"))
+                        Spacer()
                     }
                 }
             }

--- a/NetBird/Source/App/Views/iOS/iOSSettingsView.swift
+++ b/NetBird/Source/App/Views/iOS/iOSSettingsView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import NetBirdSDK
 
 #if os(iOS)
 
@@ -115,12 +116,21 @@ struct iOSSettingsView: View {
                 }
 
                 Section {
-                    HStack {
-                        Spacer()
-                        Text("Version \(appVersion)")
-                            .font(.system(size: 14))
-                            .foregroundColor(Color("TextSecondary"))
-                        Spacer()
+                    VStack(spacing: 2) {
+                        HStack {
+                            Spacer()
+                            Text("Version \(appVersion)")
+                                .font(.system(size: 14))
+                                .foregroundColor(Color("TextSecondary"))
+                            Spacer()
+                        }
+                        HStack {
+                            Spacer()
+                            Text("Core \(goVersion)")
+                                .font(.system(size: 12))
+                                .foregroundColor(Color("TextSecondary"))
+                            Spacer()
+                        }
                     }
                 }
             }
@@ -131,6 +141,12 @@ struct iOSSettingsView: View {
 
     private var appVersion: String {
         Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
+    }
+
+    /// Version of the Go client baked into NetBirdSDK.xcframework at compile time.
+    private var goVersion: String {
+        let version = NetBirdSDKGoClientVersion()
+        return version.isEmpty ? "unknown" : version
     }
 }
 


### PR DESCRIPTION
The About screen and both settings screens showed only the app's bundle version, which says nothing about the netbird-core build the framework was compiled from. Read the compile-time core version through the new NetBirdSDKGoClientVersion() binding and display it next to the app version.

## Description

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/ios-client/pr/176"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787750696&installation_model_id=427504&pr_number=176&repository=netbirdio%2Fios-client&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Fios-client%2Fpull%2F176&signature=244887854bd06b1d4cac45c1f6b54a58f1a8608b39715a9db3b1e641ffcaa448"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Version information now includes both the app version and the embedded NetBird core version.
  * Added version details to the About screen and iOS and TV settings.
  * Displays “unknown” when the core version is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->