### PR TITLE
feat(tvos): tvOS UI redesign

### DIFF
--- a/NetBird/Source/App/Views/TV/TVMainView.swift
+++ b/NetBird/Source/App/Views/TV/TVMainView.swift
@@ -359,6 +359,18 @@ struct TVVPNToggleView: View {
         .onChange(of: vpnState) { _ in
             optimisticIsOn = nil
         }
+        // Bounded fallback. A disconnect tap does not always move vpnState: when the
+        // extension is .connected or .connecting, updateVPNDisplayState() maps back to
+        // the same display state, so onChange never fires. That is fine while the OS
+        // reports the teardown a moment later — but if stop() is silently dropped, the
+        // override would hold the thumb in the wrong position and keep the pulse
+        // looping forever. Expire it so the UI falls back to the real state.
+        .task(id: optimisticIsOn) {
+            guard optimisticIsOn != nil else { return }
+            try? await Task.sleep(nanoseconds: 5_000_000_000)
+            guard !Task.isCancelled else { return }
+            optimisticIsOn = nil
+        }
         // Drive the pulse loop with a cancellable async task keyed to transitioning state
         .task(id: isTransitioning) {
             guard isTransitioning else {

--- a/NetBird/Source/App/Views/TV/TVMainView.swift
+++ b/NetBird/Source/App/Views/TV/TVMainView.swift
@@ -132,6 +132,8 @@ struct TVMainView: View {
 struct TVConnectionView: View {
     @EnvironmentObject var viewModel: ViewModel
 
+    @State private var showAddressDetails = false
+
     var body: some View {
         ZStack {
             TVGradientBackground(showAccentGlow: false)
@@ -140,23 +142,14 @@ struct TVConnectionView: View {
             VStack(spacing: 0) {
                 Spacer()
 
-                // Device info — fixed height so button position stays stable
-                VStack(spacing: 12) {
-                    Text(viewModel.fqdn.isEmpty ? " " : viewModel.fqdn)
-                        .font(.system(size: 34, weight: .semibold))
-                        .foregroundColor(TVColors.textSecondary)
-                        .opacity(viewModel.fqdn.isEmpty ? 0 : 1)
-
-                    Text(viewModel.ip.isEmpty ? " " : viewModel.ip)
-                        .font(.system(size: 30, weight: .medium, design: .monospaced))
-                        .foregroundColor(TVColors.textSecondary.opacity(0.7))
-                        .opacity(viewModel.ip.isEmpty ? 0 : 1)
-                }
-                .padding(.bottom, 28)
-
-                // Button + status — always at the same vertical position
-                TVConnectionButton(viewModel: viewModel)
-                    .padding(.vertical, 16)
+                // Toggle + status — always at the same vertical position
+                TVVPNToggleView(
+                    vpnState: viewModel.vpnDisplayState,
+                    isLocked: viewModel.buttonLock,
+                    onConnect: { viewModel.connect() },
+                    onDisconnect: { viewModel.close() }
+                )
+                .padding(.vertical, 16)
 
                 HStack(spacing: 10) {
                     Circle()
@@ -169,6 +162,36 @@ struct TVConnectionView: View {
                         .foregroundColor(statusColor)
                 }
                 .padding(.top, 28)
+
+                // Device info sits below the toggle (mirrors the iOS layout) so the
+                // expanding address dropdown grows into the empty area underneath
+                // instead of pushing the toggle off-centre.
+                VStack(spacing: 12) {
+                    Text(viewModel.fqdn.isEmpty ? " " : viewModel.fqdn)
+                        .font(.system(size: 34, weight: .semibold))
+                        .foregroundColor(TVColors.textSecondary)
+                        .opacity(viewModel.fqdn.isEmpty ? 0 : 1)
+
+                    // Reserve the collapsed row height so the block keeps a stable
+                    // position, but keep the control out of the view tree entirely
+                    // while there is no address — a merely transparent button would
+                    // still swallow Siri Remote focus.
+                    ZStack {
+                        Color.clear.frame(height: 62)
+
+                        if !viewModel.ip.isEmpty {
+                            TVAddressDropdown(
+                                ipv4: viewModel.ip,
+                                ipv6: viewModel.ipv6,
+                                isExpanded: $showAddressDetails
+                            )
+                        }
+                    }
+                }
+                .padding(.top, 36)
+                .onChange(of: viewModel.ip) { newValue in
+                    if newValue.isEmpty { showAddressDetails = false }
+                }
 
                 Spacer()
 
@@ -251,6 +274,7 @@ struct TVConnectionView: View {
 }
 
 /// Custom button style that adds a press-down scale animation for tactile feedback.
+/// Applied to the toggle so tvOS does not wrap it in its default focusable card.
 struct TVConnectButtonStyle: ButtonStyle {
     let isFocused: Bool
 
@@ -263,90 +287,212 @@ struct TVConnectButtonStyle: ButtonStyle {
     }
 }
 
-struct TVConnectionButton: View {
-    @ObservedObject var viewModel: ViewModel
+/// tvOS counterpart of the iOS `VPNToggleView`: a pill toggle driven by the Siri
+/// Remote instead of a tap, sized for the 10-foot experience.
+///
+/// Differences from the iOS version that matter on TV:
+/// - Wrapped in a `Button` so the focus engine can reach it (`onTapGesture` never
+///   fires on tvOS — there is no touch input).
+/// - Never `.disabled()`. A disabled view is dropped from the focus tree, so
+///   locking the toggle mid-connect would yank focus up into the tab bar and
+///   leave the user stranded. The lock is enforced inside the action instead.
+/// - Carries an explicit focus ring, because the custom `ButtonStyle` opts out of
+///   the system focus treatment.
+struct TVVPNToggleView: View {
+    let vpnState: VPNDisplayState
+    let isLocked: Bool
+    let onConnect: () -> Void
+    let onDisconnect: () -> Void
 
-    /// Track focus state for visual feedback
     @FocusState private var isFocused: Bool
+    @State private var pulseOpacity: Double = 1.0
+    // Optimistic override: set immediately on select so the thumb moves without
+    // waiting for the OS to report the new tunnel state
+    @State private var optimisticIsOn: Bool? = nil
+
+    private var isOn: Bool {
+        optimisticIsOn ?? (vpnState == .connected || vpnState == .connecting)
+    }
+
+    private var isTransitioning: Bool {
+        optimisticIsOn != nil || vpnState == .connecting || vpnState == .disconnecting
+    }
+
+    private let trackWidth: CGFloat = 220
+    private let trackHeight: CGFloat = 112
+    private var thumbDiameter: CGFloat { trackHeight - 16 }
+    private var thumbTravel: CGFloat { (trackWidth - thumbDiameter) / 2 - 8 }
 
     var body: some View {
-        Button(action: handleTap) {
-            HStack(spacing: 20) {
-                Image(systemName: buttonIcon)
-                    .font(.system(size: 40))
+        Button(action: handleSelect) {
+            ZStack {
+                Capsule()
+                    .fill(isOn ? Color.orange : Color.white.opacity(0.22))
+                    .opacity(pulseOpacity)
+                    .frame(width: trackWidth, height: trackHeight)
+                    .animation(.easeInOut(duration: 0.3), value: isOn)
 
-                Text(buttonText)
-                    .font(.system(size: 32, weight: .semibold))
+                Circle()
+                    .fill(Color.white)
+                    .frame(width: thumbDiameter, height: thumbDiameter)
+                    .offset(x: isOn ? thumbTravel : -thumbTravel)
+                    .shadow(color: .black.opacity(0.35), radius: 8, x: 0, y: 4)
+                    .animation(.spring(response: 0.38, dampingFraction: 0.75), value: isOn)
             }
-            .foregroundColor(buttonColor)
-            .padding(.horizontal, 80)
-            .padding(.vertical, 30)
-            .background(
-                RoundedRectangle(cornerRadius: 20)
-                    .fill(Color.white.opacity(0.06))
-            )
             .overlay(
-                RoundedRectangle(cornerRadius: 20)
-                    .stroke(
-                        buttonColor.opacity(isFocused ? 0.8 : 0.4),
-                        lineWidth: isFocused ? 2.5 : 1.5
-                    )
+                Capsule()
+                    .stroke(Color.white.opacity(isFocused ? 0.9 : 0), lineWidth: 5)
+                    .frame(width: trackWidth, height: trackHeight)
             )
             .shadow(
-                color: isFocused ? buttonColor.opacity(0.5) : .clear,
-                radius: isFocused ? 24 : 0,
-                y: isFocused ? 6 : 0
+                color: isFocused ? (isOn ? Color.orange : Color.white).opacity(0.45) : .clear,
+                radius: isFocused ? 28 : 0,
+                y: isFocused ? 8 : 0
             )
+            .animation(.easeInOut(duration: 0.2), value: isFocused)
         }
         .buttonStyle(TVConnectButtonStyle(isFocused: isFocused))
         .focused($isFocused)
-        .disabled(viewModel.buttonLock)
-    }
-    
-    private var isConnected: Bool {
-        viewModel.extensionStateText == "Connected"
-    }
-
-    private var buttonText: String {
-        switch viewModel.extensionStateText {
-        case "Connected": return "Disconnect"
-        case "Connecting...": return "Connecting..."
-        case "Disconnecting...": return "Disconnecting..."
-        default: return "Connect"
+        .accessibilityLabel("VPN connection")
+        .accessibilityValue(isOn ? "On" : "Off")
+        // Clear optimistic as soon as the OS confirms any state change
+        .onChange(of: vpnState) { _ in
+            optimisticIsOn = nil
+        }
+        // Drive the pulse loop with a cancellable async task keyed to transitioning state
+        .task(id: isTransitioning) {
+            guard isTransitioning else {
+                withAnimation(.easeInOut(duration: 0.25)) { pulseOpacity = 1.0 }
+                return
+            }
+            while !Task.isCancelled {
+                withAnimation(.easeInOut(duration: 0.85)) { pulseOpacity = 0.45 }
+                try? await Task.sleep(nanoseconds: 850_000_000)
+                guard !Task.isCancelled else { break }
+                withAnimation(.easeInOut(duration: 0.85)) { pulseOpacity = 1.0 }
+                try? await Task.sleep(nanoseconds: 850_000_000)
+            }
         }
     }
 
-    private var buttonIcon: String {
-        switch viewModel.extensionStateText {
-        case "Connected": return "stop.fill"
-        case "Connecting...", "Disconnecting...": return "hourglass"
-        default: return "play.fill"
-        }
-    }
-
-    private var buttonColor: Color {
-        switch viewModel.extensionStateText {
-        case "Connected": return .red.opacity(0.8)
-        case "Connecting...", "Disconnecting...": return .orange
-        default: return .accentColor
-        }
-    }
-    
-    private func handleTap() {
-        buttonLogger.info("handleTap: called, buttonLock=\(viewModel.buttonLock), extensionStateText=\(viewModel.extensionStateText)")
-        guard !viewModel.buttonLock else {
-            buttonLogger.info("handleTap: buttonLock is true, returning early")
+    private func handleSelect() {
+        buttonLogger.info("handleSelect: called, isLocked=\(isLocked), vpnState=\(String(describing: vpnState))")
+        guard !isLocked else {
+            buttonLogger.info("handleSelect: toggle is locked, returning early")
             return
         }
 
-        if viewModel.extensionStateText == "Connected" ||
-           viewModel.extensionStateText == "Connecting..." {
-            buttonLogger.info("handleTap: calling viewModel.close()")
-            viewModel.close()
-        } else {
-            buttonLogger.info("handleTap: calling viewModel.connect()")
-            viewModel.connect()
+        switch vpnState {
+        case .disconnected:
+            optimisticIsOn = true
+            onConnect()
+        case .connected, .connecting:
+            optimisticIsOn = false
+            onDisconnect()
+        case .disconnecting:
+            break
         }
+    }
+}
+
+/// Expandable IPv4 / IPv6 readout for the tvOS connection screen.
+///
+/// The iOS version pairs each address with a copy-to-clipboard button; tvOS has no
+/// pasteboard and nothing to paste into, so the rows are read-only. Keeping them
+/// non-focusable also means the expanded panel cannot trap Siri Remote focus — only
+/// the disclosure row itself participates in focus navigation.
+///
+/// The panel is an overlay rather than part of the stack flow, so expanding it does
+/// not resize the centred block and shift the toggle above it.
+struct TVAddressDropdown: View {
+    let ipv4: String
+    let ipv6: String
+    @Binding var isExpanded: Bool
+
+    @FocusState private var isFocused: Bool
+
+    var body: some View {
+        Button {
+            withAnimation(.easeInOut(duration: 0.2)) {
+                isExpanded.toggle()
+            }
+        } label: {
+            HStack(spacing: 14) {
+                Text(ipv4.isEmpty ? "—" : ipv4)
+                    .font(.system(size: 30, weight: .medium, design: .monospaced))
+                    .foregroundColor(isFocused ? .black : TVColors.textSecondary.opacity(0.7))
+
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 22, weight: .semibold))
+                    .foregroundColor(isFocused ? .black.opacity(0.6) : TVColors.textSecondary.opacity(0.7))
+                    .rotationEffect(.degrees(isExpanded ? 180 : 0))
+            }
+            .padding(.horizontal, 28)
+            .padding(.vertical, 14)
+            // Card fill at rest, white fill when focused — the established
+            // treatment for rows across the tvOS screens (see TVSettingsRow).
+            .background(
+                RoundedRectangle(cornerRadius: TVLayout.cornerRadiusSmall)
+                    .fill(isFocused ? Color.white : Color.white.opacity(0.05))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: TVLayout.cornerRadiusSmall)
+                    .stroke(Color.white.opacity(isFocused ? 0 : 0.08), lineWidth: 1)
+            )
+            .animation(.easeInOut(duration: 0.2), value: isFocused)
+        }
+        .buttonStyle(TVSettingsButtonStyle())
+        .focused($isFocused)
+        .accessibilityLabel("IP addresses")
+        .overlay(alignment: .top) {
+            if isExpanded {
+                VStack(spacing: 0) {
+                    addressRow(label: "IPv4", value: ipv4)
+
+                    Divider()
+                        .overlay(Color.white.opacity(0.12))
+                        .padding(.horizontal, 24)
+
+                    addressRow(label: "IPv6", value: ipv6)
+                }
+                .frame(width: 760)
+                // Same card treatment as the bottom stats bar, so the panel reads
+                // as part of the tvOS layout rather than a pop-up menu.
+                .background(
+                    RoundedRectangle(cornerRadius: TVLayout.cornerRadiusMedium)
+                        .fill(Color.white.opacity(0.05))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: TVLayout.cornerRadiusMedium)
+                                .stroke(Color.white.opacity(0.08), lineWidth: 1)
+                        )
+                )
+                .offset(y: 74)
+                .transition(.opacity)
+            }
+        }
+    }
+
+    /// Single-line row: the address is the payload, so it carries the large type
+    /// while the family label stays a quiet caption. Keeping rows to one line also
+    /// keeps the expanded panel clear of the bottom stats bar.
+    @ViewBuilder
+    private func addressRow(label: String, value: String) -> some View {
+        HStack(spacing: 18) {
+            Text(label)
+                .font(.system(size: 22, weight: .medium))
+                .foregroundColor(TVColors.textSecondary)
+
+            Spacer(minLength: 20)
+
+            Text(value.isEmpty ? "Not assigned" : value)
+                .font(.system(size: 30, weight: .medium, design: .monospaced))
+                .foregroundColor(value.isEmpty ? TVColors.textSecondary : TVColors.textPrimary)
+                .lineLimit(1)
+                .minimumScaleFactor(0.55)
+                .truncationMode(.middle)
+        }
+        .padding(.horizontal, 28)
+        .padding(.vertical, 14)
     }
 }
 


### PR DESCRIPTION
## Description

Brings the tvOS connection screen in line with the iOS UI redesign from #140.
The toggle switch and the IPv4/IPv6 dropdown existed only on iOS — both are
guarded by `#if os(iOS)` and `VPNToggleView.swift` is not a member of the
`NetBird TV` target — so tvOS was still showing the old Connect/Disconnect
button and no IPv6 at all.

No backend or view-model changes: `viewModel.ipv6` is already populated on tvOS
(the polling code in `MainViewModel` is not platform-guarded — only the profile
cache write is), so this is a view-layer change confined to `TVMainView.swift`.

### Changes

- **`TVVPNToggleView`** replaces `TVConnectionButton` — a pill toggle sized for
  the 10-foot experience, keeping the optimistic thumb movement and the pulse
  animation from the iOS version.
- **`TVAddressDropdown`** — expandable IPv4/IPv6 readout, styled to match the
  bottom stats card (same fill, stroke and corner radius). The address is the
  payload, so it carries the large monospaced type; the family label stays a
  quiet caption.
- **Layout** — the device info block moved below the toggle (mirroring iOS) so
  the expanding panel grows into empty space instead of shifting the centred
  content.

### Testing

Built and run on the Apple TV 4K simulator (tvOS 26.4). Verified:

- both states render correctly — collapsed with no address, and expanded with
  IPv4 + IPv6;
- the expanded panel clears the bottom stats bar;
- the disconnected screen shows no empty row or stray focusable element.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/ios-client/pr/179"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787830336&installation_model_id=427504&pr_number=179&repository=netbirdio%2Fios-client&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Fios-client%2Fpull%2F179&signature=c3f6ab91d23abf6349f9aa0ec60bd27f9c241857142715ef195cdfd21916a71c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a redesigned tvOS VPN connection control optimized for Siri Remote focus navigation.
  * Added an expandable device address panel showing IPv4 and IPv6 details.
  * Added visual connection-transition feedback with responsive on/off state updates.

* **Bug Fixes**
  * Improved focus handling to prevent navigation traps and preserve centered layout when address details expand.
  * Automatically collapses address details when no device IP is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->