### PR TITLE
Pass an anonymization level to the debug bundle SDK call

### DIFF
--- a/NetBird/Source/App/ViewModels/MainViewModel.swift
+++ b/NetBird/Source/App/ViewModels/MainViewModel.swift
@@ -1052,7 +1052,7 @@ class ViewModel: ObservableObject {
             return .error(message: "Failed to initialize client")
         }
         var sdkError: NSError?
-        let key = client.debugBundle(anonymize, error: &sdkError)
+        let key = client.debugBundle(anonymize, anonymizeLevel: NetBirdSDKAnonymizeLevelDefault, error: &sdkError)
         if let sdkError {
             return .error(message: sdkError.localizedDescription)
         }

--- a/NetbirdNetworkExtension/PacketTunnelProvider.swift
+++ b/NetbirdNetworkExtension/PacketTunnelProvider.swift
@@ -664,7 +664,9 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         }
         DispatchQueue.global(qos: .utility).async {
             var error: NSError?
-            let key = adapter.client.debugBundle(anonymize, error: &error)
+            // The strict level stays unused until the troubleshoot screen
+            // grows an option for it.
+            let key = adapter.client.debugBundle(anonymize, anonymizeLevel: NetBirdSDKAnonymizeLevelDefault, error: &error)
             if let error = error {
                 completionHandler("error:\(error.localizedDescription)".data(using: .utf8))
             } else {


### PR DESCRIPTION
Adapts the app to the debug bundle anonymization level introduced in netbirdio/netbird#7102 and bumps the netbird-core submodule to include it.

- Pass the SDK-exported default level constant to the debug bundle calls (network extension and the direct fallback); behavior is unchanged
- Bump the netbird-core submodule to the netbirdio/netbird#7102 merge commit

Companion PR: netbirdio/android-client#234
