### PR TITLE
fix: clear lingering IPv6 blackhole after exit node deselect

### DIFF
--- a/NetbirdNetworkExtension/PacketTunnelProviderSettingsManager.swift
+++ b/NetbirdNetworkExtension/PacketTunnelProviderSettingsManager.swift
@@ -134,7 +134,10 @@ class PacketTunnelProviderSettingsManager {
                     // makes setTunnelNetworkSettings KEEP the previously applied IPv6
                     // config, so the ::/0 blackhole installed while an exit node was
                     // selected would linger after deselect and keep black-holing traffic.
-                    tunnelNetworkSettings.ipv6Settings = NEIPv6Settings(addresses: [], networkPrefixLengths: [])
+                    let ipv6Settings = NEIPv6Settings(addresses: [Self.ipv6BlackholeAddress], networkPrefixLengths: [Self.ipv6BlackholePrefix])
+                    // Explicitly clear any previously-applied IPv6 routes.
+                    ipv6Settings.includedRoutes = []
+                    tunnelNetworkSettings.ipv6Settings = ipv6Settings
                 }
                 
                 tunnelNetworkSettings.mtu = 1280

--- a/NetbirdNetworkExtension/PacketTunnelProviderSettingsManager.swift
+++ b/NetbirdNetworkExtension/PacketTunnelProviderSettingsManager.swift
@@ -129,6 +129,12 @@ class PacketTunnelProviderSettingsManager {
                         ipv6Settings.includedRoutes = v6Routes
                     }
                     tunnelNetworkSettings.ipv6Settings = ipv6Settings
+                } else {
+                    // Always assign IPv6 settings explicitly: leaving the property nil
+                    // makes setTunnelNetworkSettings KEEP the previously applied IPv6
+                    // config, so the ::/0 blackhole installed while an exit node was
+                    // selected would linger after deselect and keep black-holing traffic.
+                    tunnelNetworkSettings.ipv6Settings = NEIPv6Settings(addresses: [], networkPrefixLengths: [])
                 }
                 
                 tunnelNetworkSettings.mtu = 1280


### PR DESCRIPTION
## What this fixes
After deselecting an IPv6 exit node, traffic could still hit a leftover `::/0` blackhole. `NEPacketTunnelNetworkSettings` keeps the previous IPv6 configuration when the IPv6 property is left `nil` on the next `setTunnelNetworkSettings` call, so the exit-node routes never fully cleared.

## Change
Always assign an explicit empty IPv6 settings object when there is no IPv6 config, forcing the system to drop the previous blackhole.

## Closes
- Closes https://github.com/netbirdio/ios-client/issues/188
- Closes https://github.com/netbirdio/netbird/issues/7132
- https://github.com/netbirdio/netbird/discussions/6840

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented outdated IPv6 configuration from being retained when IPv6 routing is not required.
  * Tunnel settings now correctly clear IPv6 configuration when applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->