### PR TITLE
fix(tvOS): refresh Resources toggles when routes are selected

### DIFF
--- a/NetBird/Source/App/ViewModels/RoutesViewModel.swift
+++ b/NetBird/Source/App/ViewModels/RoutesViewModel.swift
@@ -151,7 +151,8 @@ class RoutesViewModel: ObservableObject {
     func selectRoute(route: RoutesSelectionInfo) {
         guard let index = self.routeInfo.firstIndex(where: { $0.id == route.id }) else { return }
 
-        // `selected` is not @Published (kept for Codable); notify observers explicitly.
+        // `selected` is not @Published (kept for Codable); notify both observers explicitly.
+        self.objectWillChange.send()
         self.routeInfo[index].objectWillChange.send()
         self.routeInfo[index].selected = true
 
@@ -223,6 +224,7 @@ class RoutesViewModel: ObservableObject {
     
     func deselectRoute(route: RoutesSelectionInfo) {
         guard let index = self.routeInfo.firstIndex(where: { $0.id == route.id }) else { return }
+        self.objectWillChange.send()
         self.routeInfo[index].objectWillChange.send()
         self.routeInfo[index].selected = false
         // Reconcile with the core's real state, mirroring selectRoute.

--- a/NetBird/Source/App/ViewModels/RoutesViewModel.swift
+++ b/NetBird/Source/App/ViewModels/RoutesViewModel.swift
@@ -62,6 +62,8 @@ class RoutesViewModel: ObservableObject {
     func selectRoute(route: RoutesSelectionInfo) {
         guard let index = self.routeInfo.firstIndex(where: { $0.id == route.id }) else { return }
 
+        // `selected` is not @Published (kept for Codable); notify observers explicitly.
+        self.routeInfo[index].objectWillChange.send()
         self.routeInfo[index].selected = true
 
         // Non-exit routes select independently.
@@ -122,9 +124,11 @@ class RoutesViewModel: ObservableObject {
     
     func deselectRoute(route: RoutesSelectionInfo) {
         guard let index = self.routeInfo.firstIndex(where: { $0.id == route.id }) else { return }
+        self.routeInfo[index].objectWillChange.send()
         self.routeInfo[index].selected = false
-        networkExtensionAdapter.deselectRoutes(id: route.name) { details in
-            print("deselect route")
+        // Reconcile with the core's real state, mirroring selectRoute.
+        networkExtensionAdapter.deselectRoutes(id: route.name) { [weak self] _ in
+            self?.getRoutes()
         }
     }
     

--- a/NetBird/Source/App/ViewModels/RoutesViewModel.swift
+++ b/NetBird/Source/App/ViewModels/RoutesViewModel.swift
@@ -53,9 +53,13 @@ class RoutesViewModel: ObservableObject {
         }
     
     func getRoutes() {
-        networkExtensionAdapter.getRoutes { details in
-            self.routeInfo = details.routeSelectionInfo
-            print("Route count: \(details.routeSelectionInfo.count)")
+        // sendProviderMessage completions are not guaranteed on the main queue;
+        // hop before mutating @Published routeInfo so all reconcile call sites are safe.
+        networkExtensionAdapter.getRoutes { [weak self] details in
+            DispatchQueue.main.async {
+                self?.routeInfo = details.routeSelectionInfo
+                print("Route count: \(details.routeSelectionInfo.count)")
+            }
         }
     }
     

--- a/NetBird/Source/App/ViewModels/RoutesViewModel.swift
+++ b/NetBird/Source/App/ViewModels/RoutesViewModel.swift
@@ -151,6 +151,8 @@ class RoutesViewModel: ObservableObject {
     func selectRoute(route: RoutesSelectionInfo) {
         guard let index = self.routeInfo.firstIndex(where: { $0.id == route.id }) else { return }
 
+        // `selected` is not @Published (kept for Codable); notify observers explicitly.
+        self.routeInfo[index].objectWillChange.send()
         self.routeInfo[index].selected = true
 
         // Non-exit routes select independently.
@@ -207,7 +209,9 @@ class RoutesViewModel: ObservableObject {
     // stale optimistic selection in place.
     private func sendSelectAndReconcile(route: RoutesSelectionInfo) {
         networkExtensionAdapter.selectRoutes(id: route.name) { [weak self] _ in
-            self?.getRoutes()
+            DispatchQueue.main.async {
+                self?.getRoutes()
+            }
         }
     }
     
@@ -219,9 +223,13 @@ class RoutesViewModel: ObservableObject {
     
     func deselectRoute(route: RoutesSelectionInfo) {
         guard let index = self.routeInfo.firstIndex(where: { $0.id == route.id }) else { return }
+        self.routeInfo[index].objectWillChange.send()
         self.routeInfo[index].selected = false
-        networkExtensionAdapter.deselectRoutes(id: route.name) { details in
-            print("deselect route")
+        // Reconcile with the core's real state, mirroring selectRoute.
+        networkExtensionAdapter.deselectRoutes(id: route.name) { [weak self] _ in
+            DispatchQueue.main.async {
+                self?.getRoutes()
+            }
         }
     }
     
@@ -232,4 +240,3 @@ class RoutesViewModel: ObservableObject {
     }
     
 }
-

--- a/NetBird/Source/App/Views/TV/TVNetworksView.swift
+++ b/NetBird/Source/App/Views/TV/TVNetworksView.swift
@@ -129,7 +129,9 @@ struct TVNetworkListContent: View {
 
 // Individual Network Card
 struct TVNetworkCard: View {
-    let route: RoutesSelectionInfo
+    // Must be @ObservedObject: `selected` is a plain var on RoutesSelectionInfo,
+    // so the view only re-renders when objectWillChange fires.
+    @ObservedObject var route: RoutesSelectionInfo
     @ObservedObject var routeViewModel: RoutesViewModel
 
     @FocusState private var isFocused: Bool

--- a/NetBird/Source/App/Views/TV/TVNetworksView.swift
+++ b/NetBird/Source/App/Views/TV/TVNetworksView.swift
@@ -133,7 +133,9 @@ struct TVNetworkListContent: View {
 
 // Individual Network Card
 struct TVNetworkCard: View {
-    let route: RoutesSelectionInfo
+    // Must be @ObservedObject: `selected` is a plain var on RoutesSelectionInfo,
+    // so the view only re-renders when objectWillChange fires.
+    @ObservedObject var route: RoutesSelectionInfo
     @ObservedObject var routeViewModel: RoutesViewModel
 
     @FocusState private var isFocused: Bool

--- a/NetBird/Source/App/Views/TV/TVNetworksView.swift
+++ b/NetBird/Source/App/Views/TV/TVNetworksView.swift
@@ -23,7 +23,7 @@ struct TVNetworksView: View {
 
             if viewModel.extensionStateText == "Connected" &&
                viewModel.routeViewModel.routeInfo.count > 0 {
-                TVNetworkListContent()
+                TVNetworkListContent(routeViewModel: viewModel.routeViewModel)
             } else {
                 TVNoNetworksView()
             }
@@ -35,7 +35,7 @@ struct TVNetworksView: View {
 }
 
 struct TVNetworkListContent: View {
-    @EnvironmentObject var viewModel: ViewModel
+    @ObservedObject var routeViewModel: RoutesViewModel
     
     /// Refresh animation state
     @State private var isRefreshing = false
@@ -62,7 +62,7 @@ struct TVNetworkListContent: View {
             HStack {
                 TVFilterBar(
                     options: ["All", "Enabled", "Disabled"],
-                    selected: $viewModel.routeViewModel.selectionFilter
+                    selected: $routeViewModel.selectionFilter
                 )
 
                 Spacer()
@@ -88,10 +88,10 @@ struct TVNetworkListContent: View {
             // Network list
             ScrollView {
                 LazyVStack(spacing: 4) {
-                    ForEach(viewModel.routeViewModel.filteredResourceRoutes, id: \.id) { route in
+                    ForEach(routeViewModel.filteredResourceRoutes, id: \.id) { route in
                         TVNetworkCard(
                             route: route,
-                            routeViewModel: viewModel.routeViewModel
+                            routeViewModel: routeViewModel
                         )
                     }
                 }
@@ -112,18 +112,18 @@ struct TVNetworkListContent: View {
 
     // Exit nodes are counted by their own selector, not by this list.
     private var activeCount: Int {
-        viewModel.routeViewModel.resourceRouteInfo.filter { $0.selected }.count
+        routeViewModel.resourceRouteInfo.filter { $0.selected }.count
     }
 
     private var totalCount: Int {
-        viewModel.routeViewModel.resourceRouteInfo.count
+        routeViewModel.resourceRouteInfo.count
     }
     
     // Actions
     
     private func refresh() {
         isRefreshing = true
-        viewModel.routeViewModel.getRoutes()
+        routeViewModel.getRoutes()
         
         DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
             isRefreshing = false
@@ -253,5 +253,3 @@ struct TVNetworksView_Previews: PreviewProvider {
 }
 
 #endif
-
-


### PR DESCRIPTION
## What this fixes
On the tvOS Resources screen, selecting or deselecting a route did not update the card toggle. `TVNetworkCard` held `RoutesSelectionInfo` as a plain `let`, so SwiftUI never observed `selected` changes and the UI stayed stale.

Fixes part of #188 

## Change
Observe the route object in the card and emit `objectWillChange` from the routes view model when selection changes, so toggles re-render immediately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Route selections now update the interface reliably after selecting or deselecting routes.
  * Route lists refresh automatically after a route is deselected.
  * Network cards now immediately reflect changes to route status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->