### PR TITLE
fix(tvOS): use writable local paths for prefs, auth config, and Go state

### DIFF
--- a/NetbirdKit/Device.swift
+++ b/NetbirdKit/Device.swift
@@ -26,14 +26,12 @@ class Device {
 
     #if os(tvOS)
     /// Generate a unique device name for tvOS
-    /// The name is persisted so it remains consistent across app launches
+    /// The name is persisted so it remains consistent across app launches.
     private static func generateTVDeviceName() -> String {
         let key = "netbird_device_name"
-        let appGroup = GlobalConstants.userPreferencesSuiteName
 
         // Return cached name if it exists
-        if let defaults = UserDefaults(suiteName: appGroup),
-           let cachedName = defaults.string(forKey: key), !cachedName.isEmpty {
+        if let cachedName = Preferences.sharedUserDefaults()?.string(forKey: key), !cachedName.isEmpty {
             return cachedName
         }
 
@@ -43,10 +41,8 @@ class Device {
         let name = "apple-tv-\(randomString)"
 
         // Cache the name for future use
-        if let defaults = UserDefaults(suiteName: appGroup) {
-            defaults.set(name, forKey: key)
-            defaults.synchronize()
-        }
+        Preferences.sharedUserDefaults()?.set(name, forKey: key)
+        Preferences.sharedUserDefaults()?.synchronize()
 
         return name
     }

--- a/NetbirdKit/Device.swift
+++ b/NetbirdKit/Device.swift
@@ -29,9 +29,10 @@ class Device {
     /// The name is persisted so it remains consistent across app launches.
     private static func generateTVDeviceName() -> String {
         let key = "netbird_device_name"
+        let defaults = Preferences.sharedUserDefaults()
 
         // Return cached name if it exists
-        if let cachedName = Preferences.sharedUserDefaults()?.string(forKey: key), !cachedName.isEmpty {
+        if let cachedName = defaults?.string(forKey: key), !cachedName.isEmpty {
             return cachedName
         }
 
@@ -41,8 +42,8 @@ class Device {
         let name = "apple-tv-\(randomString)"
 
         // Cache the name for future use
-        Preferences.sharedUserDefaults()?.set(name, forKey: key)
-        Preferences.sharedUserDefaults()?.synchronize()
+        defaults?.set(name, forKey: key)
+        defaults?.synchronize()
 
         return name
     }

--- a/NetbirdKit/Preferences.swift
+++ b/NetbirdKit/Preferences.swift
@@ -107,10 +107,18 @@ class Preferences {
     }
 
     /// Returns a writable directory for debug bundle ZIP generation.
-    /// iOS: App Group container's Caches subdir. tvOS: system temp dir.
+    /// iOS: App Group container's Caches subdir. tvOS: process-local Caches.
     static func cacheDirectory() -> String {
         let fileManager = FileManager.default
         #if os(tvOS)
+        if let cacheURL = fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first {
+            do {
+                try fileManager.createDirectory(at: cacheURL, withIntermediateDirectories: true)
+                return cacheURL.path
+            } catch {
+                return fileManager.temporaryDirectory.path
+            }
+        }
         return fileManager.temporaryDirectory.path
         #else
         if let groupURL = fileManager.containerURL(forSecurityApplicationGroupIdentifier: GlobalConstants.userPreferencesSuiteName) {

--- a/NetbirdKit/Preferences.swift
+++ b/NetbirdKit/Preferences.swift
@@ -61,9 +61,15 @@ class Preferences {
         }
 
         #if DEBUG
-        // Fallback for testing when app group is not available
+        // Fallback for testing when app group is not available.
+        // On tvOS ~/Library/Application Support is read-only in the sandbox —
+        // use Caches (writable) so the Go SDK doesn't fail with EPERM.
+        #if os(tvOS)
+        let baseURL = fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first
+        #else
         let baseURL = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
             ?? fileManager.urls(for: .documentDirectory, in: .userDomainMask).first
+        #endif
         return (baseURL ?? fileManager.temporaryDirectory).appendingPathComponent(fileName).path
         #else
         AppLogger.shared.log("ERROR: App group '\(GlobalConstants.userPreferencesSuiteName)' not available. Check entitlements.")
@@ -125,9 +131,16 @@ class Preferences {
     private static let configJSONKey = "netbird_config_json"
 
     /// Get the App Group UserDefaults.
-    /// Note: On tvOS, this is app-local only - NOT shared with extension.
+    /// Note: On tvOS, app-group suites don't work at all — cfprefsd detaches
+    /// ("Using kCFPreferencesAnyUser with a container is only allowed for System
+    /// Containers") and every read returns nil. Use process-local standard defaults
+    /// there; the app↔extension transfer happens via IPC instead.
     static func sharedUserDefaults() -> UserDefaults? {
+        #if os(tvOS)
+        return UserDefaults.standard
+        #else
         return UserDefaults(suiteName: GlobalConstants.userPreferencesSuiteName)
+        #endif
     }
 
     /// Save config JSON to UserDefaults (app-local storage).

--- a/NetbirdKit/Preferences.swift
+++ b/NetbirdKit/Preferences.swift
@@ -96,6 +96,11 @@ class Preferences {
         #if os(iOS)
         // Use profile-aware paths on iOS
         return ProfileManager.shared.activeStatePath()
+        #elseif os(tvOS)
+        // App Group container is not writable from the extension on tvOS.
+        // The Go state manager writes temp files next to this path, so it must
+        // live in a writable directory or every persist fails with EPERM.
+        return URL(fileURLWithPath: cacheDirectory()).appendingPathComponent(GlobalConstants.stateFileName).path
         #else
         return getFilePath(fileName: GlobalConstants.stateFileName)
         #endif

--- a/NetbirdKit/Preferences.swift
+++ b/NetbirdKit/Preferences.swift
@@ -81,6 +81,12 @@ class Preferences {
         #if os(iOS)
         // Use profile-aware paths on iOS
         return ProfileManager.shared.activeConfigPath()
+        #elseif os(tvOS)
+        // App Group container is not writable on tvOS, so the config path handed
+        // to NetBirdSDKNewAuth must live in a writable directory — otherwise the
+        // SDK's config create/update fails with EPERM before the SSO flow starts.
+        // Persistence on tvOS goes through UserDefaults + IPC, not this file.
+        return URL(fileURLWithPath: cacheDirectory()).appendingPathComponent(GlobalConstants.configFileName).path
         #else
         return getFilePath(fileName: GlobalConstants.configFileName)
         #endif

--- a/NetbirdNetworkExtension/NetBirdAdapter.swift
+++ b/NetbirdNetworkExtension/NetBirdAdapter.swift
@@ -273,8 +273,12 @@ public class NetBirdAdapter {
 
         #if os(tvOS)
         // On tvOS, the filesystem is blocked for the App Group container.
-        // Create the client with empty paths and load config from local storage instead.
-        guard let client = NetBirdSDKNewClient("", "", Preferences.cacheDirectory(), "", deviceName, osVersion, osName, self.networkChangeListener, self.dnsManager) else {
+        // Create the client with an empty config path and load config from local storage instead.
+        // State path must be writable: the Go state manager persists next to it and fails
+        // with EPERM if it is empty or read-only. Log path stays empty here; engine logging
+        // is wired in a follow-up PR.
+        let statePath = Preferences.stateFile() ?? ""
+        guard let client = NetBirdSDKNewClient("", statePath, Preferences.cacheDirectory(), "", deviceName, osVersion, osName, self.networkChangeListener, self.dnsManager) else {
             adapterLogger.error("init: tvOS - Failed to create NetBird SDK client")
             return nil
         }

--- a/NetbirdNetworkExtension/NetBirdAdapter.swift
+++ b/NetbirdNetworkExtension/NetBirdAdapter.swift
@@ -277,7 +277,10 @@ public class NetBirdAdapter {
         // State path must be writable: the Go state manager persists next to it and fails
         // with EPERM if it is empty or read-only. Log path stays empty here; engine logging
         // is wired in a follow-up PR.
-        let statePath = Preferences.stateFile() ?? ""
+        guard let statePath = Preferences.stateFile(), !statePath.isEmpty else {
+            adapterLogger.error("init: tvOS - writable state path is unavailable")
+            return nil
+        }
         guard let client = NetBirdSDKNewClient("", statePath, Preferences.cacheDirectory(), "", deviceName, osVersion, osName, self.networkChangeListener, self.dnsManager) else {
             adapterLogger.error("init: tvOS - Failed to create NetBird SDK client")
             return nil


### PR DESCRIPTION
## What this fixes
Several tvOS failures share one root cause: App Group containers and related default paths are not usable the way they are on iOS.

1. **Preferences / device name** — App-group `UserDefaults` do not work on tvOS (`cfprefsd` detaches), so shared prefs and the cached device name silently read as nil. DEBUG fallbacks under Application Support also fail because that directory is read-only in the sandbox.
2. **Management server / auth** — `NetBirdSDKNewAuth` creates/updates `netbird.cfg` at the given path before SSO. That path came from the App Group container, so changing the management server failed with `EPERM` before UserDefaults/IPC fallbacks ran.
3. **Extension state persistence** — The Go client was created with an empty state path, so the state manager wrote temp files into the extension CWD (read-only) and logged repeating `EPERM` errors about every 10 seconds.

## Change
- Use `UserDefaults.standard` on tvOS and writable Caches for DEBUG file-path fallbacks.
- Point `configFile()` at caches as scratch space for NewAuth (persistence stays UserDefaults + IPC).
- Point `stateFile()` at caches and pass it into `NetBirdSDKNewClient` so the Go state manager has a writable location.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tvOS device-name persistence and synchronization.
  * Updated tvOS configuration and state storage to use writable cache locations.
  * Added safer fallback handling when cache directories are unavailable.
  * Prevented network services from starting without a valid writable state location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->