### PR TITLE
fix(tvOS): reliable device-code login and VPN profile selection

### DIFF
--- a/NetBird/Source/App/ViewModels/MainViewModel.swift
+++ b/NetBird/Source/App/ViewModels/MainViewModel.swift
@@ -998,7 +998,7 @@ class ViewModel: ObservableObject {
 
     /// Checks shared app-group container for login required flag set by the network extension.
     /// Shows the authentication UI. Notification was already delivered via NEVPNStatusDidChange observer.
-    /// iOS only — tvOS uses IPC via `checkLoginError` in TVAuthView.
+    /// iOS only — tvOS uses IPC via `checkLoginDiagnostics` in TVAuthView.
     func checkLoginRequiredFlag() {
         #if os(iOS)
         let userDefaults = UserDefaults(suiteName: GlobalConstants.userPreferencesSuiteName)

--- a/NetBird/Source/App/Views/TV/TVAuthView.swift
+++ b/NetBird/Source/App/Views/TV/TVAuthView.swift
@@ -37,7 +37,7 @@ struct TVAuthView: View {
     var onError: ((String) -> Void)?
 
     /// Reference to fetch login diagnostics (async - calls completion with diagnostics, or nil on IPC failure)
-    var checkLoginDiagnostics: ((@escaping (LoginDiagnostics?) -> Void) -> Void)?
+    var checkLoginDiagnostics: (@escaping (LoginDiagnostics?) -> Void) -> Void
 
     /// Polling timer to check if login completed
     @State private var pollTimer: Timer?
@@ -274,13 +274,6 @@ struct TVAuthView: View {
             print("TVAuthView: Poll tick - checking login status via extension IPC...")
             #endif
 
-            guard let checkDiagnostics = checkDiagnostics else {
-                #if DEBUG
-                print("TVAuthView: No checkLoginDiagnostics closure provided")
-                #endif
-                return
-            }
-
             checkDiagnostics { diag in
                 DispatchQueue.main.async {
                     // nil means transient IPC failure - try again on the next tick
@@ -310,12 +303,6 @@ struct TVAuthView: View {
         #if DEBUG
         print("TVAuthView: Performing initial login check...")
         #endif
-        guard let checkDiagnostics = checkDiagnostics else {
-            #if DEBUG
-            print("TVAuthView: No checkLoginDiagnostics closure provided")
-            #endif
-            return
-        }
         checkDiagnostics { diag in
             DispatchQueue.main.async {
                 let isComplete = diag?.isComplete ?? false
@@ -357,5 +344,4 @@ struct TVAuthView_Previews: PreviewProvider {
 }
 
 #endif
-
 

--- a/NetBird/Source/App/Views/TV/TVAuthView.swift
+++ b/NetBird/Source/App/Views/TV/TVAuthView.swift
@@ -36,11 +36,8 @@ struct TVAuthView: View {
     /// Called when authentication fails (e.g., device code expires, server rejects)
     var onError: ((String) -> Void)?
 
-    /// Reference to check login status (async - calls completion with true if login is complete)
-    var checkLoginComplete: ((@escaping (Bool) -> Void) -> Void)?
-
-    /// Reference to check for login errors (async - calls completion with error message or nil)
-    var checkLoginError: ((@escaping (String?) -> Void) -> Void)?
+    /// Reference to fetch login diagnostics (async - calls completion with diagnostics, or nil on IPC failure)
+    var checkLoginDiagnostics: ((@escaping (LoginDiagnostics?) -> Void) -> Void)?
 
     /// Polling timer to check if login completed
     @State private var pollTimer: Timer?
@@ -267,8 +264,7 @@ struct TVAuthView: View {
 
         // Capture the closures and bindings we need
         // SwiftUI structs are value types, so we capture these by value
-        let checkComplete = self.checkLoginComplete
-        let checkError = self.checkLoginError
+        let checkDiagnostics = self.checkLoginDiagnostics
         let onCompleteHandler = self.onComplete
         let onErrorHandler = self.onError
 
@@ -278,36 +274,34 @@ struct TVAuthView: View {
             print("TVAuthView: Poll tick - checking login status via extension IPC...")
             #endif
 
-            // First check for errors (if error checker provided)
-            if let checkError = checkError {
-                checkError { errorMsg in
-                    DispatchQueue.main.async {
-                        if let errorMsg = errorMsg {
-                            #if DEBUG
-                            print("TVAuthView: Login error detected: \(errorMsg)")
-                            #endif
-                            self.errorMessage = errorMsg
-                            timer.invalidate()
-                            onErrorHandler?(errorMsg)
-                        } else {
-                            // No error - check for completion
-                            self.checkCompletionStatus(
-                                timer: timer,
-                                checkComplete: checkComplete,
-                                onCompleteHandler: onCompleteHandler
-                            )
-                        }
-                    }
-                }
+            guard let checkDiagnostics = checkDiagnostics else {
+                #if DEBUG
+                print("TVAuthView: No checkLoginDiagnostics closure provided")
+                #endif
                 return
             }
 
-            // Fallback if no error checker provided - just check completion
-            self.checkCompletionStatus(
-                timer: timer,
-                checkComplete: checkComplete,
-                onCompleteHandler: onCompleteHandler
-            )
+            checkDiagnostics { diag in
+                DispatchQueue.main.async {
+                    // nil means transient IPC failure - try again on the next tick
+                    guard let diag = diag else { return }
+
+                    if let errorMsg = diag.friendlyError {
+                        #if DEBUG
+                        print("TVAuthView: Login error detected: \(errorMsg)")
+                        #endif
+                        self.errorMessage = errorMsg
+                        timer.invalidate()
+                        onErrorHandler?(errorMsg)
+                    } else if diag.isComplete {
+                        #if DEBUG
+                        print("TVAuthView: Login detected as complete, dismissing auth view")
+                        #endif
+                        timer.invalidate()
+                        onCompleteHandler?()
+                    }
+                }
+            }
         }
         RunLoop.main.add(timer, forMode: .common)
         pollTimer = timer
@@ -316,14 +310,15 @@ struct TVAuthView: View {
         #if DEBUG
         print("TVAuthView: Performing initial login check...")
         #endif
-        guard let checkComplete = checkComplete else {
+        guard let checkDiagnostics = checkDiagnostics else {
             #if DEBUG
-            print("TVAuthView: No checkLoginComplete closure provided")
+            print("TVAuthView: No checkLoginDiagnostics closure provided")
             #endif
             return
         }
-        checkComplete { isComplete in
+        checkDiagnostics { diag in
             DispatchQueue.main.async {
+                let isComplete = diag?.isComplete ?? false
                 #if DEBUG
                 print("TVAuthView: Initial check - login complete = \(isComplete)")
                 #endif
@@ -337,34 +332,6 @@ struct TVAuthView: View {
         }
     }
 
-    /// Helper to check completion status - ensures mutual exclusivity with error checking
-    private func checkCompletionStatus(
-        timer: Timer,
-        checkComplete: (((@escaping (Bool) -> Void) -> Void))?,
-        onCompleteHandler: (() -> Void)?
-    ) {
-        guard let checkComplete = checkComplete else {
-            #if DEBUG
-            print("TVAuthView: No checkLoginComplete closure provided")
-            #endif
-            return
-        }
-
-        checkComplete { isComplete in
-            DispatchQueue.main.async {
-                #if DEBUG
-                print("TVAuthView: Login complete = \(isComplete)")
-                #endif
-                if isComplete {
-                    #if DEBUG
-                    print("TVAuthView: Login detected as complete, dismissing auth view")
-                    #endif
-                    timer.invalidate()
-                    onCompleteHandler?()
-                }
-            }
-        }
-    }
 }
 
 /// Preview provider for development
@@ -373,9 +340,17 @@ struct TVAuthView_Previews: PreviewProvider {
         TVAuthView(
             loginURL: "https://app.netbird.io/device?user_code=ABCD-1234",
             isPresented: .constant(true),
-            checkLoginComplete: { completion in
-                // Preview always returns false (not logged in)
-                completion(false)
+            checkLoginDiagnostics: { completion in
+                // Preview always returns not-logged-in diagnostics
+                completion(LoginDiagnostics(
+                    isComplete: false,
+                    isExecuting: false,
+                    loginRequired: true,
+                    configExists: false,
+                    stateExists: false,
+                    lastResult: "",
+                    lastError: ""
+                ))
             }
         )
     }

--- a/NetBird/Source/App/Views/TV/TVAuthView.swift
+++ b/NetBird/Source/App/Views/TV/TVAuthView.swift
@@ -163,6 +163,7 @@ struct TVAuthView: View {
                     // Cancel button
                     Button(action: {
                         pollTimer?.invalidate()
+                        pollTimer = nil
                         onCancel?()
                         isPresented = false
                     }) {
@@ -192,6 +193,7 @@ struct TVAuthView: View {
         }
         .onDisappear {
             pollTimer?.invalidate()
+            pollTimer = nil
         }
     }
 
@@ -280,17 +282,21 @@ struct TVAuthView: View {
                     guard let diag = diag else { return }
 
                     if let errorMsg = diag.friendlyError {
+                        guard timer.isValid else { return }
                         #if DEBUG
                         print("TVAuthView: Login error detected: \(errorMsg)")
                         #endif
                         self.errorMessage = errorMsg
                         timer.invalidate()
+                        self.pollTimer = nil
                         onErrorHandler?(errorMsg)
                     } else if diag.isComplete {
+                        guard timer.isValid else { return }
                         #if DEBUG
                         print("TVAuthView: Login detected as complete, dismissing auth view")
                         #endif
                         timer.invalidate()
+                        self.pollTimer = nil
                         onCompleteHandler?()
                     }
                 }
@@ -310,9 +316,12 @@ struct TVAuthView: View {
                 print("TVAuthView: Initial check - login complete = \(isComplete)")
                 #endif
                 if isComplete {
+                    guard timer.isValid else { return }
                     #if DEBUG
                     print("TVAuthView: Login already complete, dismissing auth view")
                     #endif
+                    timer.invalidate()
+                    self.pollTimer = nil
                     onCompleteHandler?()
                 }
             }
@@ -344,4 +353,3 @@ struct TVAuthView_Previews: PreviewProvider {
 }
 
 #endif
-

--- a/NetBird/Source/App/Views/TV/TVMainView.swift
+++ b/NetBird/Source/App/Views/TV/TVMainView.swift
@@ -189,7 +189,7 @@ struct TVConnectionView: View {
                     }
                 }
                 .padding(.top, 36)
-                .onChange(of: viewModel.ip) { newValue in
+                .onChange(of: viewModel.ip) { _, newValue in
                     if newValue.isEmpty { showAddressDetails = false }
                 }
 
@@ -356,7 +356,7 @@ struct TVVPNToggleView: View {
         .accessibilityLabel("VPN connection")
         .accessibilityValue(isOn ? "On" : "Off")
         // Clear optimistic as soon as the OS confirms any state change
-        .onChange(of: vpnState) { _ in
+        .onChange(of: vpnState) {
             optimisticIsOn = nil
         }
         // Bounded fallback. A disconnect tap does not always move vpnState: when the

--- a/NetBird/Source/App/Views/TV/TVMainView.swift
+++ b/NetBird/Source/App/Views/TV/TVMainView.swift
@@ -121,6 +121,9 @@ struct TVMainView: View {
                     },
                     checkLoginDiagnostics: { completion in
                         viewModel.networkExtensionAdapter.checkLoginDiagnostics { diagnostics in
+                            if let diagnostics, diagnostics.isComplete {
+                                viewModel.networkExtensionAdapter.persistLoginConfiguration(from: diagnostics)
+                            }
                             #if DEBUG
                             print("TVMainView: checkLoginDiagnostics returned isComplete=\(diagnostics?.isComplete ?? false)")
                             #endif
@@ -557,5 +560,4 @@ struct TVMainView_Previews: PreviewProvider {
 }
 
 #endif
-
 

--- a/NetBird/Source/App/Views/TV/TVMainView.swift
+++ b/NetBird/Source/App/Views/TV/TVMainView.swift
@@ -75,6 +75,9 @@ struct TVMainView: View {
                     onCancel: {
                         viewModel.networkExtensionAdapter.showBrowser = false
                         viewModel.connectPressed = false
+                        // The extension is parked in startTunnel waiting for this login —
+                        // tear it down so it doesn't linger until the watchdog fires.
+                        viewModel.close()
                         viewModel.updateVPNDisplayState()
                     },
                     onComplete: {
@@ -83,7 +86,13 @@ struct TVMainView: View {
                         #endif
                         viewModel.networkExtensionAdapter.showBrowser = false
 
-                        // After login completes, ensure config is transferred to extension before connecting
+                        // The extension already holds the post-login config (loginAsync
+                        // saved it and loaded it into the client) and continues the
+                        // parked startTunnel by itself. Only push the config and start
+                        // the tunnel if it isn't already coming up — calling
+                        // startVPNTunnel on a .connecting session can disrupt it.
+                        guard viewModel.extensionState == .disconnected else { return }
+
                         // On tvOS, shared UserDefaults doesn't work, so we must send via IPC
                         if let configJSON = Preferences.loadConfigFromUserDefaults(), !configJSON.isEmpty {
                             #if DEBUG

--- a/NetBird/Source/App/Views/TV/TVMainView.swift
+++ b/NetBird/Source/App/Views/TV/TVMainView.swift
@@ -119,17 +119,12 @@ struct TVMainView: View {
                         #endif
                         // Error is displayed in the auth view - user can dismiss manually
                     },
-                    checkLoginComplete: { completion in
-                        viewModel.networkExtensionAdapter.checkLoginComplete { isComplete in
+                    checkLoginDiagnostics: { completion in
+                        viewModel.networkExtensionAdapter.checkLoginDiagnostics { diagnostics in
                             #if DEBUG
-                            print("TVMainView: checkLoginComplete returned \(isComplete)")
+                            print("TVMainView: checkLoginDiagnostics returned isComplete=\(diagnostics?.isComplete ?? false)")
                             #endif
-                            completion(isComplete)
-                        }
-                    },
-                    checkLoginError: { completion in
-                        viewModel.networkExtensionAdapter.checkLoginError { errorMessage in
-                            completion(errorMessage)
+                            completion(diagnostics)
                         }
                     }
                 )

--- a/NetBirdTVNetworkExtension/PacketTunnelProvider.swift
+++ b/NetBirdTVNetworkExtension/PacketTunnelProvider.swift
@@ -94,14 +94,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         // interface is owned by the provider and outlives the Go engine, so without
         // an explicit teardown it lingers with the default route and black-holes
         // all traffic (same pattern the iOS provider handles).
-        adapter.onLoginRequired = { [weak self] in
-            logger.error("onLoginRequired: session expired mid-tunnel — tearing down")
-            self?.cancelTunnelWithError(NSError(
-                domain: "io.netbird.NetBirdTVNetworkExtension",
-                code: 1001,
-                userInfo: [NSLocalizedDescriptionKey: "Login required."]
-            ))
-        }
+        configureLoginRequiredHandler(for: adapter)
 
         adapter.start { error in
             if let error = error {
@@ -139,7 +132,11 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
 
     private func parkStartUntilLogin(completionHandler: @escaping (Error?) -> Void) {
         pendingStartWatchdog?.cancel()
-        pendingStartCompletion = completionHandler
+        let previousCompletion = pendingStartCompletion
+        pendingStartCompletion = { error in
+            previousCompletion?(error)
+            completionHandler(error)
+        }
 
         let watchdog = DispatchWorkItem { [weak self] in
             guard let self = self, self.pendingStartCompletion != nil else { return }
@@ -171,6 +168,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             return
         }
 
+        configureLoginRequiredHandler(for: adapter)
         logger.info("startTunnel: login completed, starting engine for parked tunnel")
         adapter.start { error in
             if let error = error {
@@ -186,6 +184,17 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         guard let pending = pendingStartCompletion else { return }
         pendingStartCompletion = nil
         pending(error)
+    }
+
+    private func configureLoginRequiredHandler(for adapter: NetBirdAdapter) {
+        adapter.onLoginRequired = { [weak self] in
+            logger.error("onLoginRequired: session expired mid-tunnel — tearing down")
+            self?.cancelTunnelWithError(NSError(
+                domain: "io.netbird.NetBirdTVNetworkExtension",
+                code: 1001,
+                userInfo: [NSLocalizedDescriptionKey: "Login required."]
+            ))
+        }
     }
 
     override func handleAppMessage(_ messageData: Data, completionHandler: ((Data?) -> Void)?) {
@@ -512,7 +521,10 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             configExists: configExists,
             stateExists: stateExists,
             lastResult: lastResult,
-            lastError: lastError
+            lastError: lastError,
+            configJSON: isComplete
+                ? UserDefaults.standard.string(forKey: "netbird_config_json_local")
+                : nil
         )
 
         do {

--- a/NetBirdTVNetworkExtension/PacketTunnelProvider.swift
+++ b/NetBirdTVNetworkExtension/PacketTunnelProvider.swift
@@ -44,8 +44,12 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     /// here instead of failing: the extension process stays alive so the main app can
     /// drive the device-auth flow via the "LoginTV" IPC message (IPC only reaches a
     /// running extension). The pending start is completed once loginTV succeeds.
+    /// Owns all access to the parked-start state. Network Extension lifecycle calls,
+    /// SDK callbacks, IPC handlers, and the watchdog can all run on different threads.
+    private let parkedStartQueue = DispatchQueue(label: "io.netbird.tv.parkedStart")
     private var pendingStartCompletion: ((Error?) -> Void)?
     private var pendingStartWatchdog: DispatchWorkItem?
+    private var pendingStartGeneration: UInt = 0
 
     override func startTunnel(options: [String : NSObject]?, completionHandler: @escaping (Error?) -> Void) {
         // CRITICAL: Log immediately to confirm startTunnel is being called
@@ -131,33 +135,60 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     private static let parkedStartTimeout: TimeInterval = 5 * 60
 
     private func parkStartUntilLogin(completionHandler: @escaping (Error?) -> Void) {
-        pendingStartWatchdog?.cancel()
-        let previousCompletion = pendingStartCompletion
-        pendingStartCompletion = { error in
-            previousCompletion?(error)
-            completionHandler(error)
+        let watchdog = parkedStartQueue.sync { () -> DispatchWorkItem in
+            pendingStartWatchdog?.cancel()
+            pendingStartGeneration &+= 1
+            let generation = pendingStartGeneration
+            let previousCompletion = pendingStartCompletion
+            pendingStartCompletion = { error in
+                previousCompletion?(error)
+                completionHandler(error)
+            }
+
+            let watchdog = DispatchWorkItem { [weak self] in
+                guard let self = self else { return }
+                let didFail = self.failPendingStartIfParked(NSError(
+                    domain: "io.netbird.NetBirdTVNetworkExtension",
+                    code: 1001,
+                    userInfo: [NSLocalizedDescriptionKey: "Login required."]
+                ), expectedGeneration: generation)
+                if didFail {
+                    logger.error("startTunnel: parked start timed out waiting for login")
+                }
+            }
+            pendingStartWatchdog = watchdog
+            return watchdog
         }
 
-        let watchdog = DispatchWorkItem { [weak self] in
-            guard let self = self, self.pendingStartCompletion != nil else { return }
-            logger.error("startTunnel: parked start timed out waiting for login")
-            self.failPendingStartIfParked(NSError(
-                domain: "io.netbird.NetBirdTVNetworkExtension",
-                code: 1001,
-                userInfo: [NSLocalizedDescriptionKey: "Login required."]
-            ))
-        }
-        pendingStartWatchdog = watchdog
+        // Keep the watchdog off parkedStartQueue because it atomically claims state
+        // through takePendingStart(), which synchronously enters that queue.
         DispatchQueue.global().asyncAfter(deadline: .now() + Self.parkedStartTimeout, execute: watchdog)
+    }
+
+    /// Atomically claims the parked start. Only one competing lifecycle or SDK
+    /// callback can receive the completion closure.
+    private func takePendingStart(expectedGeneration: UInt? = nil) -> ((Error?) -> Void)? {
+        parkedStartQueue.sync {
+            if let expectedGeneration,
+               expectedGeneration != pendingStartGeneration {
+                return nil
+            }
+            pendingStartWatchdog?.cancel()
+            pendingStartWatchdog = nil
+            let pending = pendingStartCompletion
+            pendingStartCompletion = nil
+            return pending
+        }
+    }
+
+    private var hasPendingStart: Bool {
+        parkedStartQueue.sync { pendingStartCompletion != nil }
     }
 
     /// Called when the device-auth login succeeded: the adapter's client now holds the
     /// post-login config (set by NetBirdAdapter.loginAsync), so the tunnel can start.
     private func continuePendingStart() {
-        pendingStartWatchdog?.cancel()
-        pendingStartWatchdog = nil
-        guard let pending = pendingStartCompletion else { return }
-        pendingStartCompletion = nil
+        guard let pending = takePendingStart() else { return }
 
         guard let adapter = adapter else {
             pending(NSError(
@@ -178,12 +209,14 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         }
     }
 
-    private func failPendingStartIfParked(_ error: Error) {
-        pendingStartWatchdog?.cancel()
-        pendingStartWatchdog = nil
-        guard let pending = pendingStartCompletion else { return }
-        pendingStartCompletion = nil
+    @discardableResult
+    private func failPendingStartIfParked(
+        _ error: Error,
+        expectedGeneration: UInt? = nil
+    ) -> Bool {
+        guard let pending = takePendingStart(expectedGeneration: expectedGeneration) else { return false }
         pending(error)
+        return true
     }
 
     private func configureLoginRequiredHandler(for adapter: NetBirdAdapter) {
@@ -494,7 +527,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
 
         // While the start is parked (no config yet) a full needsLogin() would run a
         // doomed config-load + Login RPC on every poll tick — use the cached check.
-        let loginRequired = pendingStartCompletion != nil ? adapter.needsLoginCached() : adapter.needsLogin()
+        let loginRequired = hasPendingStart ? adapter.needsLoginCached() : adapter.needsLogin()
 
         // Also check if config file exists now (written after successful auth)
         let configPath = Preferences.configFile() ?? ""

--- a/NetBirdTVNetworkExtension/PacketTunnelProvider.swift
+++ b/NetBirdTVNetworkExtension/PacketTunnelProvider.swift
@@ -40,6 +40,13 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     let monitorQueue = DispatchQueue(label: "NetworkMonitor")
     var currentNetworkType: NWInterface.InterfaceType?
 
+    /// When startTunnel runs before the user is authenticated, the start is "parked"
+    /// here instead of failing: the extension process stays alive so the main app can
+    /// drive the device-auth flow via the "LoginTV" IPC message (IPC only reaches a
+    /// running extension). The pending start is completed once loginTV succeeds.
+    private var pendingStartCompletion: ((Error?) -> Void)?
+    private var pendingStartWatchdog: DispatchWorkItem?
+
     override func startTunnel(options: [String : NSObject]?, completionHandler: @escaping (Error?) -> Void) {
         // CRITICAL: Log immediately to confirm startTunnel is being called
         // Use privacy: .public to avoid log redaction
@@ -73,15 +80,27 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         let needsLogin = adapter.needsLogin()
 
         if needsLogin {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-                let error = NSError(
-                    domain: "io.netbird.NetBirdTVNetworkExtension",
-                    code: 1001,
-                    userInfo: [NSLocalizedDescriptionKey: "Login required."]
-                )
-                completionHandler(error)
-            }
+            // Don't fail the start: the device-auth flow needs a RUNNING extension to
+            // receive the app's "LoginTV" IPC, and failing startTunnel would kill this
+            // process before the app can ask. Park the completion and wait for login
+            // (loginTV calls continuePendingStart() on success). No routes or addresses
+            // are assigned while parked, so no traffic is affected.
+            logger.info("startTunnel: login required — parking start until device auth completes")
+            parkStartUntilLogin(completionHandler: completionHandler)
             return
+        }
+
+        // Tear the tunnel down if the auth session expires mid-session. The utun
+        // interface is owned by the provider and outlives the Go engine, so without
+        // an explicit teardown it lingers with the default route and black-holes
+        // all traffic (same pattern the iOS provider handles).
+        adapter.onLoginRequired = { [weak self] in
+            logger.error("onLoginRequired: session expired mid-tunnel — tearing down")
+            self?.cancelTunnelWithError(NSError(
+                domain: "io.netbird.NetBirdTVNetworkExtension",
+                code: 1001,
+                userInfo: [NSLocalizedDescriptionKey: "Login required."]
+            ))
         }
 
         adapter.start { error in
@@ -95,6 +114,13 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     }
 
     override func stopTunnel(with reason: NEProviderStopReason, completionHandler: @escaping () -> Void) {
+        // If the start was parked waiting for login (e.g. the user cancelled the auth
+        // sheet), release it as cancelled so the system doesn't hang on teardown.
+        failPendingStartIfParked(NSError(
+            domain: "io.netbird.NetBirdTVNetworkExtension",
+            code: 1005,
+            userInfo: [NSLocalizedDescriptionKey: "Login cancelled."]
+        ))
         adapter?.stop()
         if let pathMonitor = self.pathMonitor {
             pathMonitor.cancel()
@@ -103,6 +129,63 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
             completionHandler()
         }
+    }
+
+    // MARK: - Parked start (device auth)
+
+    /// How long a parked startTunnel waits for the device-auth flow before failing.
+    /// Matches the typical device-code lifetime; covers a user walking to a browser.
+    private static let parkedStartTimeout: TimeInterval = 5 * 60
+
+    private func parkStartUntilLogin(completionHandler: @escaping (Error?) -> Void) {
+        pendingStartWatchdog?.cancel()
+        pendingStartCompletion = completionHandler
+
+        let watchdog = DispatchWorkItem { [weak self] in
+            guard let self = self, self.pendingStartCompletion != nil else { return }
+            logger.error("startTunnel: parked start timed out waiting for login")
+            self.failPendingStartIfParked(NSError(
+                domain: "io.netbird.NetBirdTVNetworkExtension",
+                code: 1001,
+                userInfo: [NSLocalizedDescriptionKey: "Login required."]
+            ))
+        }
+        pendingStartWatchdog = watchdog
+        DispatchQueue.global().asyncAfter(deadline: .now() + Self.parkedStartTimeout, execute: watchdog)
+    }
+
+    /// Called when the device-auth login succeeded: the adapter's client now holds the
+    /// post-login config (set by NetBirdAdapter.loginAsync), so the tunnel can start.
+    private func continuePendingStart() {
+        pendingStartWatchdog?.cancel()
+        pendingStartWatchdog = nil
+        guard let pending = pendingStartCompletion else { return }
+        pendingStartCompletion = nil
+
+        guard let adapter = adapter else {
+            pending(NSError(
+                domain: "io.netbird.NetBirdTVNetworkExtension",
+                code: 1003,
+                userInfo: [NSLocalizedDescriptionKey: "Failed to initialize NetBird adapter."]
+            ))
+            return
+        }
+
+        logger.info("startTunnel: login completed, starting engine for parked tunnel")
+        adapter.start { error in
+            if let error = error {
+                logger.error("startTunnel: adapter.start() after login failed: \(error.localizedDescription, privacy: .public)")
+            }
+            pending(error)
+        }
+    }
+
+    private func failPendingStartIfParked(_ error: Error) {
+        pendingStartWatchdog?.cancel()
+        pendingStartWatchdog = nil
+        guard let pending = pendingStartCompletion else { return }
+        pendingStartCompletion = nil
+        pending(error)
     }
 
     override func handleAppMessage(_ messageData: Data, completionHandler: ((Data?) -> Void)?) {
@@ -400,8 +483,9 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         // For the new Auth.Login() with device auth flow, we need to check lastLoginResult instead.
         let sdkLoginComplete = adapter.client.isLoginComplete()
 
-        // Also check loginRequired for comparison (may be stale if Client was created before config)
-        let loginRequired = adapter.needsLogin()
+        // While the start is parked (no config yet) a full needsLogin() would run a
+        // doomed config-load + Login RPC on every poll tick — use the cached check.
+        let loginRequired = pendingStartCompletion != nil ? adapter.needsLoginCached() : adapter.needsLogin()
 
         // Also check if config file exists now (written after successful auth)
         let configPath = Preferences.configFile() ?? ""
@@ -490,20 +574,15 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
                     completionHandler(nil)
                 }
             },
-            onSuccess: {
-                // Login completed - the app will detect this via polling
-                // and start the VPN tunnel via startVPNConnection()
+            onSuccess: { [weak self] in
+                // Login completed - the config is persisted and loaded into the client
+                // by NetBirdAdapter.loginAsync's success handler (runs first, same hop).
                 logger.info("loginTV: Login completed successfully!")
-                logger.info("loginTV: Config should now be saved to App Group container")
 
-                // Debug: Verify config file was written
-                let configPath = Preferences.configFile() ?? ""
-                let statePath = Preferences.stateFile() ?? ""
-                let fileManager = FileManager.default
-                logger.info("loginTV: configFile exists = \(!configPath.isEmpty && fileManager.fileExists(atPath: configPath))")
-                logger.info("loginTV: stateFile exists = \(!statePath.isEmpty && fileManager.fileExists(atPath: statePath))")
+                // If startTunnel was parked waiting for this login, start the engine now.
+                self?.continuePendingStart()
             },
-            onError: { error in
+            onError: { [weak self] error in
                 // Log with privacy: .public to avoid iOS privacy redaction
                 if let nsError = error as NSError? {
                     logger.error("loginTV: Login failed - domain: \(nsError.domain, privacy: .public), code: \(nsError.code, privacy: .public), description: \(nsError.localizedDescription, privacy: .public)")
@@ -523,6 +602,13 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
 
                 if !alreadySentUrl {
                     logger.error("loginTV: Error before URL was sent, returning nil to app")
+                    // Auth can't proceed (server unreachable, device auth unsupported…);
+                    // a parked start would otherwise wait out the full watchdog timeout.
+                    self?.failPendingStartIfParked(NSError(
+                        domain: "io.netbird.NetBirdTVNetworkExtension",
+                        code: 1006,
+                        userInfo: [NSLocalizedDescriptionKey: "Login failed: \(error?.localizedDescription ?? "unknown error")"]
+                    ))
                     completionHandler(nil)
                 } else {
                     logger.warning("loginTV: Error after URL was sent (device code may have expired), app is still polling")
@@ -681,7 +767,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     func setTunnelSettings(tunnelNetworkSettings: NEPacketTunnelNetworkSettings) {
         setTunnelNetworkSettings(tunnelNetworkSettings) { error in
             if let error = error {
-                logger.error("setTunnelSettings: Error assigning routes: \(error.localizedDescription)")
+                logger.error("setTunnelSettings: Error assigning routes: \(error.localizedDescription, privacy: .public)")
                 return
             }
             logger.info("setTunnelSettings: Routes set successfully.")

--- a/NetbirdKit/NetworkExtensionAdapter.swift
+++ b/NetbirdKit/NetworkExtensionAdapter.swift
@@ -930,55 +930,19 @@ public class NetworkExtensionAdapter: ObservableObject {
         }
     }
 
-    /// Check if login is complete by asking the Network Extension directly
-    /// This is more reliable than isLoginRequired() because it queries the same SDK client
-    /// that is actually performing the login
-    func checkLoginComplete(completion: @escaping (Bool) -> Void) {
+    /// Fetch login diagnostics from the Network Extension in a single IPC round-trip.
+    /// This queries the same SDK client that is actually performing the login.
+    /// Callers derive both error and completion state from the same response.
+    func checkLoginDiagnostics(completion: @escaping (LoginDiagnostics?) -> Void) {
         guard let session = self.session else {
-            logger.error("checkLoginComplete: No session available")
-            completion(false)
-            return
-        }
-
-        let messageString = "IsLoginComplete"
-        guard let messageData = messageString.data(using: .utf8) else {
-            print("checkLoginComplete: Failed to encode message")
-            completion(false)
-            return
-        }
-
-        do {
-            try session.sendProviderMessage(messageData) { response in
-                if let response = response {
-                    do {
-                        let diagnostic = try self.decoder.decode(LoginDiagnostics.self, from: response)
-                        print("checkLoginComplete: result=\(diagnostic.isComplete), isExecuting=\(diagnostic.isExecuting), loginRequired=\(diagnostic.loginRequired), configExists=\(diagnostic.configExists), stateExists=\(diagnostic.stateExists), lastResult=\(diagnostic.lastResult), lastError=\(diagnostic.lastError)")
-                        completion(diagnostic.isComplete)
-                    } catch {
-                        print("checkLoginComplete: Failed to decode LoginDiagnostics - \(error)")
-                        completion(false)
-                    }
-                } else {
-                    print("checkLoginComplete: No response from extension")
-                    completion(false)
-                }
-            }
-        } catch {
-            print("checkLoginComplete: Failed to send message - \(error)")
-            completion(false)
-        }
-    }
-
-    /// Check if there's a login error from the extension
-    /// Returns the error message via completion handler, or nil if no error
-    func checkLoginError(completion: @escaping (String?) -> Void) {
-        guard let session = self.session else {
+            logger.error("checkLoginDiagnostics: No session available")
             completion(nil)
             return
         }
 
         let messageString = "IsLoginComplete"
         guard let messageData = messageString.data(using: .utf8) else {
+            print("checkLoginDiagnostics: Failed to encode message")
             completion(nil)
             return
         }
@@ -988,30 +952,19 @@ public class NetworkExtensionAdapter: ObservableObject {
                 if let response = response {
                     do {
                         let diagnostic = try self.decoder.decode(LoginDiagnostics.self, from: response)
-                        // Only report error if lastResult is "error" and there's an actual error message
-                        if diagnostic.lastResult == "error" && !diagnostic.lastError.isEmpty {
-                            // Make the error message more user-friendly
-                            var friendlyError = diagnostic.lastError
-                            if diagnostic.lastError.contains("no peer auth method provided") {
-                                friendlyError = "This server doesn't support device code authentication. Please use a setup key instead."
-                            } else if diagnostic.lastError.contains("expired") || diagnostic.lastError.contains("token") {
-                                friendlyError = "The device code has expired. Please try again."
-                            } else if diagnostic.lastError.contains("denied") || diagnostic.lastError.contains("rejected") {
-                                friendlyError = "Authentication was denied. Please try again."
-                            }
-                            completion(friendlyError)
-                            return
-                        }
-                        completion(nil)
+                        print("checkLoginDiagnostics: result=\(diagnostic.isComplete), isExecuting=\(diagnostic.isExecuting), loginRequired=\(diagnostic.loginRequired), configExists=\(diagnostic.configExists), stateExists=\(diagnostic.stateExists), lastResult=\(diagnostic.lastResult), lastError=\(diagnostic.lastError)")
+                        completion(diagnostic)
                     } catch {
-                        print("checkLoginError: Failed to decode LoginDiagnostics - \(error)")
+                        print("checkLoginDiagnostics: Failed to decode LoginDiagnostics - \(error)")
                         completion(nil)
                     }
                 } else {
+                    print("checkLoginDiagnostics: No response from extension")
                     completion(nil)
                 }
             }
         } catch {
+            print("checkLoginDiagnostics: Failed to send message - \(error)")
             completion(nil)
         }
     }

--- a/NetbirdKit/NetworkExtensionAdapter.swift
+++ b/NetbirdKit/NetworkExtensionAdapter.swift
@@ -49,6 +49,33 @@ class ConfigSSOListener: NSObject, NetBirdSDKSSOListenerProtocol {
     }
 }
 
+#if os(tvOS)
+/// Thread-safe generation token for cancelling the delayed device-auth IPC retry chain.
+private nonisolated final class LoginRetryState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var generation: UInt = 0
+
+    func begin() -> UInt {
+        lock.lock()
+        defer { lock.unlock() }
+        generation &+= 1
+        return generation
+    }
+
+    func isActive(_ candidate: UInt) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return generation == candidate
+    }
+
+    func cancel() {
+        lock.lock()
+        generation &+= 1
+        lock.unlock()
+    }
+}
+#endif
+
 public class NetworkExtensionAdapter: ObservableObject {
 
     private let logger = Logger(subsystem: "io.netbird.app", category: "NetworkExtensionAdapter")
@@ -63,6 +90,7 @@ public class NetworkExtensionAdapter: ObservableObject {
     #if os(tvOS)
     var extensionID = "io.netbird.app.tv.extension"
     var extensionName = "NetBird"
+    private let loginRetryState = LoginRetryState()
     #else
     var extensionID = "io.netbird.app.NetbirdNetworkExtension"
     var extensionName = "NetBird Network Extension"
@@ -177,24 +205,10 @@ public class NetworkExtensionAdapter: ObservableObject {
     private func configureManager() async throws {
         let managers = try await NETunnelProviderManager.loadAllFromPreferences()
 
-        // Remove stale configurations that share our display name but point at a
-        // different provider bundle — e.g. leftovers from an App Store install or a
-        // renamed bundle ID. Deleting an app does NOT remove its VPN configuration,
-        // and matching such a config by name makes startVPNTunnel target a provider
-        // that isn't installed ("The VPN app used by the VPN configuration is not
-        // installed").
-        for stale in managers where stale.localizedDescription == self.extensionName {
-            let providerID = (stale.protocolConfiguration as? NETunnelProviderProtocol)?.providerBundleIdentifier
-            if providerID != self.extensionID {
-                logger.warning("configureManager: removing stale VPN config (provider=\(providerID ?? "nil", privacy: .public))")
-                do {
-                    try await stale.removeFromPreferences()
-                } catch {
-                    logger.error("configureManager: failed to remove stale VPN config: \(error.localizedDescription, privacy: .public)")
-                }
-            }
-        }
-
+        // The provider bundle ID is the stable identity. A matching display name may
+        // belong to another installed flavor, such as App Store and development builds.
+        // Leave foreign configurations untouched, including active connections. Exact
+        // provider matching below prevents one build from binding to another's profile.
         if let manager = managers.first(where: {
             $0.localizedDescription == self.extensionName &&
             ($0.protocolConfiguration as? NETunnelProviderProtocol)?.providerBundleIdentifier == self.extensionID
@@ -600,6 +614,9 @@ public class NetworkExtensionAdapter: ObservableObject {
         #endif
 
         #if os(tvOS)
+        let retryState = loginRetryState
+        let retryGeneration = retryState.begin()
+
         // On tvOS the device-auth flow runs inside the extension (via the "LoginTV"
         // IPC), and IPC only reaches a RUNNING extension. Boot the tunnel first: when
         // login is required, the extension parks its startTunnel instead of failing,
@@ -615,6 +632,11 @@ public class NetworkExtensionAdapter: ObservableObject {
             let maxAttempts = 12
 
             func attempt() {
+                guard retryState.isActive(retryGeneration) else {
+                    continuation.resume(returning: nil)
+                    return
+                }
+
                 attempts += 1
                 // Push the server config each round: early attempts may run before the
                 // extension process is up, and the extension needs the management URL
@@ -630,6 +652,11 @@ public class NetworkExtensionAdapter: ObservableObject {
                 }
 
                 self.login { urlString in
+                    guard retryState.isActive(retryGeneration) else {
+                        continuation.resume(returning: nil)
+                        return
+                    }
+
                     if let urlString = urlString, !urlString.isEmpty {
                         continuation.resume(returning: urlString)
                     } else if attempts < maxAttempts {
@@ -650,6 +677,12 @@ public class NetworkExtensionAdapter: ObservableObject {
             self.login { urlString in
                 continuation.resume(returning: urlString)
             }
+        }
+        #endif
+        #if os(tvOS)
+        guard retryState.isActive(retryGeneration) else {
+            logger.info("performLogin: tvOS login IPC retry loop cancelled")
+            return
         }
         #endif
         guard let url = loginURLString, !url.isEmpty else {
@@ -725,6 +758,9 @@ public class NetworkExtensionAdapter: ObservableObject {
 
     
     func stop() -> Void {
+        #if os(tvOS)
+        loginRetryState.cancel()
+        #endif
         self.vpnManager?.connection.stopVPNTunnel()
     }
 
@@ -956,17 +992,6 @@ public class NetworkExtensionAdapter: ObservableObject {
                 if let response = response {
                     do {
                         let diagnostic = try self.decoder.decode(LoginDiagnostics.self, from: response)
-                        #if os(tvOS)
-                        if diagnostic.isComplete,
-                           let configJSON = diagnostic.configJSON,
-                           !configJSON.isEmpty {
-                            if Preferences.saveConfigToUserDefaults(configJSON) {
-                                self.logger.info("checkLoginDiagnostics: saved post-login config in main app")
-                            } else {
-                                self.logger.error("checkLoginDiagnostics: failed to save post-login config in main app")
-                            }
-                        }
-                        #endif
                         print("checkLoginDiagnostics: result=\(diagnostic.isComplete), isExecuting=\(diagnostic.isExecuting), loginRequired=\(diagnostic.loginRequired), configExists=\(diagnostic.configExists), stateExists=\(diagnostic.stateExists), lastResult=\(diagnostic.lastResult), lastError=\(diagnostic.lastError)")
                         completion(diagnostic)
                     } catch {
@@ -982,6 +1007,24 @@ public class NetworkExtensionAdapter: ObservableObject {
             print("checkLoginDiagnostics: Failed to send message - \(error)")
             completion(nil)
         }
+    }
+
+    /// Persists configuration returned by a completed tvOS device-auth flow.
+    /// Kept separate from checkLoginDiagnostics so polling remains a read-only operation.
+    func persistLoginConfiguration(from diagnostic: LoginDiagnostics) {
+        #if os(tvOS)
+        guard diagnostic.isComplete,
+              let configJSON = diagnostic.configJSON,
+              !configJSON.isEmpty else {
+            return
+        }
+
+        if Preferences.saveConfigToUserDefaults(configJSON) {
+            logger.info("persistLoginConfiguration: saved post-login config in main app")
+        } else {
+            logger.error("persistLoginConfiguration: failed to save post-login config in main app")
+        }
+        #endif
     }
 
     func getRoutes(completion: @escaping (RoutesSelectionDetails) -> Void) {

--- a/NetbirdKit/NetworkExtensionAdapter.swift
+++ b/NetbirdKit/NetworkExtensionAdapter.swift
@@ -571,12 +571,59 @@ public class NetworkExtensionAdapter: ObservableObject {
         }
         #endif
 
-        // Fallback: IPC to the NE extension (tvOS, or if main-app auth setup failed)
+        #if os(tvOS)
+        // On tvOS the device-auth flow runs inside the extension (via the "LoginTV"
+        // IPC), and IPC only reaches a RUNNING extension. Boot the tunnel first: when
+        // login is required, the extension parks its startTunnel instead of failing,
+        // keeping the process alive for the whole auth flow.
+        if self.vpnManager?.connection.status == .disconnected
+            || self.vpnManager?.connection.status == .invalid {
+            logger.info("performLogin: tvOS - starting tunnel to boot extension for device auth")
+            startVPNConnection()
+        }
+
+        let loginURLString: String? = await withCheckedContinuation { continuation in
+            var attempts = 0
+            let maxAttempts = 12
+
+            func attempt() {
+                attempts += 1
+                // Push the server config each round: early attempts may run before the
+                // extension process is up, and the extension needs the management URL
+                // (custom servers) before it can start the device-auth flow.
+                if attempts > 1, let configJSON = Preferences.loadConfigFromUserDefaults(), !configJSON.isEmpty {
+                    self.sendConfigToExtension(configJSON)
+                    if let url = Preferences.loadManagementURL() {
+                        let messageString = "SetManagementURL:\(url)"
+                        if let data = messageString.data(using: .utf8) {
+                            try? self.session?.sendProviderMessage(data) { _ in }
+                        }
+                    }
+                }
+
+                self.login { urlString in
+                    if let urlString = urlString, !urlString.isEmpty {
+                        continuation.resume(returning: urlString)
+                    } else if attempts < maxAttempts {
+                        DispatchQueue.global().asyncAfter(deadline: .now() + 0.8) {
+                            attempt()
+                        }
+                    } else {
+                        continuation.resume(returning: nil)
+                    }
+                }
+            }
+
+            attempt()
+        }
+        #else
+        // Fallback: IPC to the NE extension (if main-app auth setup failed)
         let loginURLString: String? = await withCheckedContinuation { continuation in
             self.login { urlString in
                 continuation.resume(returning: urlString)
             }
         }
+        #endif
         guard let url = loginURLString, !url.isEmpty else {
             logger.error("performLogin: no login URL received from extension, aborting")
             return

--- a/NetbirdKit/NetworkExtensionAdapter.swift
+++ b/NetbirdKit/NetworkExtensionAdapter.swift
@@ -176,7 +176,25 @@ public class NetworkExtensionAdapter: ObservableObject {
 
     private func configureManager() async throws {
         let managers = try await NETunnelProviderManager.loadAllFromPreferences()
-        if let manager = managers.first(where: { $0.localizedDescription == self.extensionName }) {
+
+        // Remove stale configurations that share our display name but point at a
+        // different provider bundle — e.g. leftovers from an App Store install or a
+        // renamed bundle ID. Deleting an app does NOT remove its VPN configuration,
+        // and matching such a config by name makes startVPNTunnel target a provider
+        // that isn't installed ("The VPN app used by the VPN configuration is not
+        // installed").
+        for stale in managers where stale.localizedDescription == self.extensionName {
+            let providerID = (stale.protocolConfiguration as? NETunnelProviderProtocol)?.providerBundleIdentifier
+            if providerID != self.extensionID {
+                logger.warning("configureManager: removing stale VPN config (provider=\(providerID ?? "nil", privacy: .public))")
+                try? await stale.removeFromPreferences()
+            }
+        }
+
+        if let manager = managers.first(where: {
+            $0.localizedDescription == self.extensionName &&
+            ($0.protocolConfiguration as? NETunnelProviderProtocol)?.providerBundleIdentifier == self.extensionID
+        }) {
             self.vpnManager = manager
             // Only write preferences when strictly necessary.
             // Calling saveToPreferences() on an already-configured manager triggers
@@ -205,7 +223,10 @@ public class NetworkExtensionAdapter: ObservableObject {
     public func loadCurrentConnectionState() async -> NEVPNStatus? {
         do {
             let managers = try await NETunnelProviderManager.loadAllFromPreferences()
-            guard let manager = managers.first(where: { $0.localizedDescription == self.extensionName }) else {
+            guard let manager = managers.first(where: {
+                $0.localizedDescription == self.extensionName &&
+                ($0.protocolConfiguration as? NETunnelProviderProtocol)?.providerBundleIdentifier == self.extensionID
+            }) else {
                 logger.info("loadCurrentConnectionState: No existing manager found")
                 return nil
             }
@@ -219,7 +240,10 @@ public class NetworkExtensionAdapter: ObservableObject {
             if status == .disconnected || status == .invalid {
                 try? await Task.sleep(nanoseconds: 200_000_000) // 200 ms
                 let refreshed = try await NETunnelProviderManager.loadAllFromPreferences()
-                if let fresh = refreshed.first(where: { $0.localizedDescription == self.extensionName }) {
+                if let fresh = refreshed.first(where: {
+                    $0.localizedDescription == self.extensionName &&
+                    ($0.protocolConfiguration as? NETunnelProviderProtocol)?.providerBundleIdentifier == self.extensionID
+                }) {
                     status = fresh.connection.status
                     self.vpnManager = fresh
                     self.session = fresh.connection as? NETunnelProviderSession

--- a/NetbirdKit/NetworkExtensionAdapter.swift
+++ b/NetbirdKit/NetworkExtensionAdapter.swift
@@ -187,7 +187,11 @@ public class NetworkExtensionAdapter: ObservableObject {
             let providerID = (stale.protocolConfiguration as? NETunnelProviderProtocol)?.providerBundleIdentifier
             if providerID != self.extensionID {
                 logger.warning("configureManager: removing stale VPN config (provider=\(providerID ?? "nil", privacy: .public))")
-                try? await stale.removeFromPreferences()
+                do {
+                    try await stale.removeFromPreferences()
+                } catch {
+                    logger.error("configureManager: failed to remove stale VPN config: \(error.localizedDescription, privacy: .public)")
+                }
             }
         }
 
@@ -428,7 +432,7 @@ public class NetworkExtensionAdapter: ObservableObject {
         logger.info("isLoginRequired: tvOS - config found, checking with management server...")
 
         // Create a Client and load config from UserDefaults
-        guard let client = NetBirdSDKNewClient("", "", Preferences.cacheDirectory(), "", Device.getName(), Device.getOsVersion(), Device.getOsName(), nil, nil) else {
+        guard let client = NetBirdSDKNewClient("", statePath, Preferences.cacheDirectory(), "", Device.getName(), Device.getOsVersion(), Device.getOsName(), nil, nil) else {
             logger.error("isLoginRequired: tvOS - failed to create SDK client")
             return true
         }
@@ -952,6 +956,17 @@ public class NetworkExtensionAdapter: ObservableObject {
                 if let response = response {
                     do {
                         let diagnostic = try self.decoder.decode(LoginDiagnostics.self, from: response)
+                        #if os(tvOS)
+                        if diagnostic.isComplete,
+                           let configJSON = diagnostic.configJSON,
+                           !configJSON.isEmpty {
+                            if Preferences.saveConfigToUserDefaults(configJSON) {
+                                self.logger.info("checkLoginDiagnostics: saved post-login config in main app")
+                            } else {
+                                self.logger.error("checkLoginDiagnostics: failed to save post-login config in main app")
+                            }
+                        }
+                        #endif
                         print("checkLoginDiagnostics: result=\(diagnostic.isComplete), isExecuting=\(diagnostic.isExecuting), loginRequired=\(diagnostic.loginRequired), configExists=\(diagnostic.configExists), stateExists=\(diagnostic.stateExists), lastResult=\(diagnostic.lastResult), lastError=\(diagnostic.lastError)")
                         completion(diagnostic)
                     } catch {

--- a/NetbirdKit/RoutesSelectionDetails.swift
+++ b/NetbirdKit/RoutesSelectionDetails.swift
@@ -14,6 +14,10 @@ struct LoginDiagnostics: Codable {
     var stateExists: Bool
     var lastResult: String
     var lastError: String
+    /// Post-login config returned by the extension after device authentication.
+    /// The main app and extension have separate UserDefaults containers on tvOS,
+    /// so the app must persist this copy for subsequent login preflight checks.
+    var configJSON: String? = nil
 }
 
 extension LoginDiagnostics {

--- a/NetbirdKit/RoutesSelectionDetails.swift
+++ b/NetbirdKit/RoutesSelectionDetails.swift
@@ -16,6 +16,21 @@ struct LoginDiagnostics: Codable {
     var lastError: String
 }
 
+extension LoginDiagnostics {
+    /// User-facing error message, or nil if login hasn't failed
+    var friendlyError: String? {
+        guard lastResult == "error", !lastError.isEmpty else { return nil }
+        if lastError.contains("no peer auth method provided") {
+            return "This server doesn't support device code authentication. Please use a setup key instead."
+        } else if lastError.contains("expired") || lastError.contains("token") {
+            return "The device code has expired. Please try again."
+        } else if lastError.contains("denied") || lastError.contains("rejected") {
+            return "Authentication was denied. Please try again."
+        }
+        return lastError
+    }
+}
+
 struct DeviceAuthResponse: Codable {
     var url: String
     var userCode: String

--- a/NetbirdNetworkExtension/NetBirdAdapter.swift
+++ b/NetbirdNetworkExtension/NetBirdAdapter.swift
@@ -424,6 +424,21 @@ public class NetBirdAdapter {
                     #if os(tvOS)
                     let correctDeviceName = Device.getName()
                     configJSON = Self.updateDeviceNameInConfig(configJSON, newName: correctDeviceName)
+
+                    // Persist where adapter.init reads it: extension-local
+                    // standard UserDefaults (App Group storage is not shared
+                    // between app and extension on tvOS).
+                    UserDefaults.standard.set(configJSON, forKey: "netbird_config_json_local")
+                    UserDefaults.standard.synchronize()
+
+                    // Load the fresh config into the already-running client so a
+                    // parked startTunnel can proceed with adapter.start().
+                    do {
+                        try self?.client.setConfigFromJSON(configJSON)
+                        adapterLogger.info("loginAsync: tvOS - loaded post-login config into client")
+                    } catch {
+                        adapterLogger.error("loginAsync: tvOS - failed to load post-login config: \(error.localizedDescription)")
+                    }
                     #endif
 
                     _ = Preferences.saveConfigToUserDefaults(configJSON)


### PR DESCRIPTION
## Merge dependency

This PR must land before #192.

PR #192 passes `Preferences.stateFile()` and the related configuration paths to the Go SDK during the tvOS device-auth flow. Without the writable process-local paths introduced here, the SDK attempts to write in the App Group container and can fail with `EPERM` before authentication starts.

Recommended merge order:

1. #191
2. #192

## What this fixes
Device-code connect/login on tvOS was unreliable, and VPN profile lookup could bind the wrong extension.

1. **Parked tunnel** — Login IPC only reaches a running packet tunnel, but `startTunnel` failed as soon as login was required, so auth had no live extension and users had to connect again after login. Cancel could leave a parked extension until the watchdog.
2. **Double IPC poll** — The auth UI sent two identical `IsLoginComplete` IPCs per timer tick; error and completion could disagree between round-trips.
3. **Wrong VPN profile** — Matching managers only by `localizedDescription` could attach to a stale profile from another install or bundle ID.
4. **onChange warnings** — Minor tvOS 17 `onChange` API cleanup in the same login UI surfaces.

## Change
- Park tunnel start during auth, keep the extension alive for `LoginTV`, persist post-login config, tear down on cancel.
- Replace dual poll APIs with one `checkLoginDiagnostics` round-trip.
- Match/clean VPN configs by `providerBundleIdentifier`.
- Update SwiftUI `onChange` to the non-deprecated forms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved tvOS login flow with clearer authentication diagnostics and user-friendly error messages.
  * VPN connections can now resume automatically after completing device authentication.
  * Login configuration is preserved after successful authentication.

* **Bug Fixes**
  * Fixed VPN startup failures when login is required.
  * Improved cancellation and timeout handling during authentication.
  * Prevented unnecessary tunnel restarts and ensured parked connections are cleaned up when authentication fails or is cancelled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->