### PR TITLE
feat(tvos): add exit node selection to the connection screen

### DIFF
--- a/NetBird.xcodeproj/project.pbxproj
+++ b/NetBird.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		443782C52EDF288A00F9FA94 /* TVSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 443782C32EDF288A00F9FA94 /* TVSettingsView.swift */; };
 		443782C62EDF288A00F9FA94 /* TVPeersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 443782C22EDF288A00F9FA94 /* TVPeersView.swift */; };
 		443782C72EDF288A00F9FA94 /* TVNetworksView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 443782C12EDF288A00F9FA94 /* TVNetworksView.swift */; };
+		E1E0F0012F90000100000001 /* TVExitNodeSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1E0F0002F90000100000001 /* TVExitNodeSelector.swift */; };
 		443782C82EDF288A00F9FA94 /* TVMainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 443782C02EDF288A00F9FA94 /* TVMainView.swift */; };
 		443782C92EDF293400F9FA94 /* NetBirdApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50A8911A2A792A15007C48FC /* NetBirdApp.swift */; };
 		443782CA2EDF296500F9FA94 /* MainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50A8911C2A792A15007C48FC /* MainView.swift */; };
@@ -286,6 +287,7 @@
 		443782BD2EDF284A00F9FA94 /* Platform.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Platform.swift; sourceTree = "<group>"; };
 		443782C02EDF288A00F9FA94 /* TVMainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TVMainView.swift; sourceTree = "<group>"; };
 		443782C12EDF288A00F9FA94 /* TVNetworksView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TVNetworksView.swift; sourceTree = "<group>"; };
+		E1E0F0002F90000100000001 /* TVExitNodeSelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TVExitNodeSelector.swift; sourceTree = "<group>"; };
 		443782C22EDF288A00F9FA94 /* TVPeersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TVPeersView.swift; sourceTree = "<group>"; };
 		443782C32EDF288A00F9FA94 /* TVSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TVSettingsView.swift; sourceTree = "<group>"; };
 		4483B26C2F19331A00BD9F66 /* TVColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TVColors.swift; sourceTree = "<group>"; };
@@ -495,6 +497,7 @@
 				44F3E39A2EE2F9FA00C87FEC /* TVAuthView.swift */,
 				443782C02EDF288A00F9FA94 /* TVMainView.swift */,
 				443782C12EDF288A00F9FA94 /* TVNetworksView.swift */,
+				E1E0F0002F90000100000001 /* TVExitNodeSelector.swift */,
 				443782C22EDF288A00F9FA94 /* TVPeersView.swift */,
 				443782C32EDF288A00F9FA94 /* TVSettingsView.swift */,
 				AA1B2C012F4E5A0100D1E2F3 /* TVGradientBackground.swift */,
@@ -1084,6 +1087,7 @@
 				443782C92EDF293400F9FA94 /* NetBirdApp.swift in Sources */,
 				443782C62EDF288A00F9FA94 /* TVPeersView.swift in Sources */,
 				443782C72EDF288A00F9FA94 /* TVNetworksView.swift in Sources */,
+				E1E0F0012F90000100000001 /* TVExitNodeSelector.swift in Sources */,
 				44F3E39B2EE2F9FA00C87FEC /* TVAuthView.swift in Sources */,
 				4483B26D2F19331A00BD9F66 /* TVColors.swift in Sources */,
 				443782C82EDF288A00F9FA94 /* TVMainView.swift in Sources */,

--- a/NetBird/Source/App/Views/TV/TVExitNodeSelector.swift
+++ b/NetBird/Source/App/Views/TV/TVExitNodeSelector.swift
@@ -1,0 +1,200 @@
+//
+//  TVExitNodeSelector.swift
+//  NetBird
+//
+//  Exit node selector shown on the tvOS connection screen.
+//
+
+import SwiftUI
+
+#if os(tvOS)
+
+/// tvOS counterpart of the connection screen's `ExitNodeSelectorCard`. It shares the same
+/// model rules — exit nodes live outside the resources list, only one can be active, and
+/// "None" clears the current one.
+///
+/// Where iOS expands a dropdown in place, this opens the list modally. The connection
+/// screen is a centred layout, so a list growing inline would shove the toggle and the
+/// stats bar out of position, and tvOS has no pointer to dismiss a floating overlay with;
+/// a sheet is the platform's normal way to pick from a set of options.
+///
+/// The card stays in the layout even with nothing to choose from, rendering disabled, so
+/// the screen doesn't reflow as routes come and go.
+struct TVExitNodeSelector: View {
+    @ObservedObject var routeViewModel: RoutesViewModel
+
+    @State private var isPresentingList = false
+    @FocusState private var isFocused: Bool
+
+    private var exitNodes: [RoutesSelectionInfo] { routeViewModel.exitNodes }
+    private var isAvailable: Bool { !exitNodes.isEmpty }
+
+    var body: some View {
+        Button {
+            isPresentingList = true
+        } label: {
+            card
+        }
+        .buttonStyle(TVSettingsButtonStyle())
+        .focused($isFocused)
+        .disabled(!isAvailable)
+        .accessibilityLabel("Exit node")
+        .accessibilityValue(subtitle)
+        .sheet(isPresented: $isPresentingList) {
+            TVExitNodeListSheet(routeViewModel: routeViewModel)
+        }
+        // Losing the tunnel clears every route, which would leave the open sheet listing
+        // nothing but "None".
+        .onChange(of: isAvailable) { available in
+            guard !available, isPresentingList else { return }
+            isPresentingList = false
+        }
+    }
+
+    private var card: some View {
+        HStack(spacing: 18) {
+            Image(systemName: "arrow.triangle.branch")
+                .font(.system(size: 26))
+                .foregroundColor(isFocused ? .black : iconColor)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Exit node")
+                    .font(.system(size: 20, weight: .medium))
+                    .foregroundColor(isFocused ? .black.opacity(0.6) : TVColors.textSecondary)
+
+                Text(subtitle)
+                    .font(.system(size: 26, weight: .semibold))
+                    .foregroundColor(isFocused ? .black : titleColor)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+
+            Spacer(minLength: 16)
+
+            Image(systemName: "chevron.right")
+                .font(.system(size: 20, weight: .semibold))
+                .foregroundColor(isFocused ? .black : TVColors.textSecondary)
+        }
+        .padding(.horizontal, 28)
+        .padding(.vertical, 20)
+        .background(
+            RoundedRectangle(cornerRadius: 20)
+                .fill(isFocused ? Color.white : Color.white.opacity(0.05))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 20)
+                        .stroke(Color.white.opacity(isFocused ? 0 : 0.08), lineWidth: 1)
+                )
+        )
+    }
+
+    private var subtitle: String {
+        guard isAvailable else { return "No exit nodes available" }
+        return routeViewModel.selectedExitNode?.name ?? "None"
+    }
+
+    private var iconColor: Color {
+        isAvailable ? .orange : TVColors.textSecondary
+    }
+
+    private var titleColor: Color {
+        isAvailable ? TVColors.textPrimary : TVColors.textSecondary
+    }
+}
+
+/// Modal list of exit nodes: "None" plus every node in the network map, single selection.
+struct TVExitNodeListSheet: View {
+    @ObservedObject var routeViewModel: RoutesViewModel
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        ZStack {
+            TVGradientBackground()
+
+            VStack(alignment: .leading, spacing: 20) {
+                Text("Exit node")
+                    .font(.system(size: 48, weight: .bold))
+                    .foregroundColor(TVColors.textPrimary)
+
+                Text("Only one exit node can be active at a time.")
+                    .font(.system(size: 26))
+                    .foregroundColor(TVColors.textSecondary)
+                    .padding(.bottom, 10)
+
+                ScrollView {
+                    LazyVStack(spacing: 4) {
+                        TVExitNodeRow(
+                            title: "None",
+                            isSelected: routeViewModel.selectedExitNode == nil
+                        ) {
+                            select(nil)
+                        }
+
+                        ForEach(routeViewModel.exitNodes) { exitNode in
+                            TVExitNodeRow(
+                                title: exitNode.name,
+                                isSelected: exitNode.selected
+                            ) {
+                                select(exitNode)
+                            }
+                        }
+                    }
+                    .padding(10)
+                    .background(
+                        RoundedRectangle(cornerRadius: TVLayout.cornerRadiusMedium)
+                            .fill(Color.white.opacity(0.04))
+                    )
+                }
+            }
+            .padding(.horizontal, TVLayout.contentPadding)
+            .padding(.vertical, 60)
+        }
+    }
+
+    private func select(_ exitNode: RoutesSelectionInfo?) {
+        routeViewModel.setExitNode(exitNode)
+        dismiss()
+    }
+}
+
+/// One entry in the exit node list.
+struct TVExitNodeRow: View {
+    let title: String
+    let isSelected: Bool
+    let action: () -> Void
+
+    @FocusState private var isFocused: Bool
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 20) {
+                Text(title)
+                    .font(.system(size: 26, weight: isSelected ? .semibold : .regular))
+                    .foregroundColor(isFocused ? .black : TVColors.textPrimary)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+
+                Spacer(minLength: 12)
+
+                if isSelected {
+                    Image(systemName: "checkmark")
+                        .font(.system(size: 22, weight: .semibold))
+                        .foregroundColor(isFocused ? .black : .orange)
+                        // Decorative: the selection is carried as a trait instead, so
+                        // VoiceOver reads "<name>, selected" rather than "<name>, checkmark".
+                        .accessibilityHidden(true)
+                }
+            }
+            .padding(.horizontal, 28)
+            .padding(.vertical, 18)
+            .background(
+                RoundedRectangle(cornerRadius: 14)
+                    .fill(isFocused ? Color.white : Color.clear)
+            )
+        }
+        .buttonStyle(TVSettingsButtonStyle())
+        .focused($isFocused)
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+    }
+}
+
+#endif

--- a/NetBird/Source/App/Views/TV/TVMainView.swift
+++ b/NetBird/Source/App/Views/TV/TVMainView.swift
@@ -163,9 +163,7 @@ struct TVConnectionView: View {
                 }
                 .padding(.top, 28)
 
-                // Device info sits below the toggle (mirrors the iOS layout) so the
-                // expanding address dropdown grows into the empty area underneath
-                // instead of pushing the toggle off-centre.
+                // Device info sits below the toggle, mirroring the iOS layout.
                 VStack(spacing: 12) {
                     Text(viewModel.fqdn.isEmpty ? " " : viewModel.fqdn)
                         .font(.system(size: 34, weight: .semibold))
@@ -194,6 +192,10 @@ struct TVConnectionView: View {
                 }
 
                 Spacer()
+
+                TVExitNodeSelector(routeViewModel: viewModel.routeViewModel)
+                    .padding(.horizontal, 120)
+                    .padding(.bottom, 24)
 
                 // Bottom stats bar — glanceable network overview
                 HStack(spacing: 50) {
@@ -240,8 +242,17 @@ struct TVConnectionView: View {
                 .padding(.bottom, 50)
             }
         }
+        .onAppear {
+            // Coming back to this tab doesn't go through applyExtensionStatus, so refresh
+            // the network map here to keep the exit node selector current. Only while
+            // connected: GetRoutes answers with an empty list when there is no tunnel
+            // session and would wipe a list that is still valid.
+            if viewModel.vpnDisplayState == .connected {
+                viewModel.routeViewModel.getRoutes()
+            }
+        }
     }
-    
+
     // Computed Properties
     
     private var statusColor: Color {
@@ -262,14 +273,15 @@ struct TVConnectionView: View {
         return viewModel.peerViewModel.peerInfo.count.description
     }
 
+    // Exit nodes are reported by their own selector, not counted as resources here.
     private var activeNetworksCount: String {
         guard viewModel.extensionStateText == "Connected" else { return "0" }
-        return viewModel.routeViewModel.routeInfo.filter { $0.selected }.count.description
+        return viewModel.routeViewModel.resourceRouteInfo.filter { $0.selected }.count.description
     }
 
     private var totalNetworksCount: String {
         guard viewModel.extensionStateText == "Connected" else { return "0" }
-        return viewModel.routeViewModel.routeInfo.count.description
+        return viewModel.routeViewModel.resourceRouteInfo.count.description
     }
 }
 
@@ -407,15 +419,14 @@ struct TVVPNToggleView: View {
     }
 }
 
-/// Expandable IPv4 / IPv6 readout for the tvOS connection screen.
+/// IPv4 / IPv6 readout for the tvOS connection screen: shows the v4 address inline and
+/// opens the full pair in its own screen.
 ///
-/// The iOS version pairs each address with a copy-to-clipboard button; tvOS has no
-/// pasteboard and nothing to paste into, so the rows are read-only. Keeping them
-/// non-focusable also means the expanded panel cannot trap Siri Remote focus — only
-/// the disclosure row itself participates in focus navigation.
-///
-/// The panel is an overlay rather than part of the stack flow, so expanding it does
-/// not resize the centred block and shift the toggle above it.
+/// This used to expand a panel in place, but that panel hung over whatever sat below it
+/// on a centred layout — the exit node card, and before that the stats bar it was
+/// hand-tuned to just barely clear. A separate screen removes the overlap entirely
+/// instead of trading one collision for another, and matches how the exit node list is
+/// presented on this platform.
 struct TVAddressDropdown: View {
     let ipv4: String
     let ipv6: String
@@ -425,19 +436,16 @@ struct TVAddressDropdown: View {
 
     var body: some View {
         Button {
-            withAnimation(.easeInOut(duration: 0.2)) {
-                isExpanded.toggle()
-            }
+            isExpanded = true
         } label: {
             HStack(spacing: 14) {
                 Text(ipv4.isEmpty ? "—" : ipv4)
                     .font(.system(size: 30, weight: .medium, design: .monospaced))
                     .foregroundColor(isFocused ? .black : TVColors.textSecondary.opacity(0.7))
 
-                Image(systemName: "chevron.down")
+                Image(systemName: "chevron.right")
                     .font(.system(size: 22, weight: .semibold))
                     .foregroundColor(isFocused ? .black.opacity(0.6) : TVColors.textSecondary.opacity(0.7))
-                    .rotationEffect(.degrees(isExpanded ? 180 : 0))
             }
             .padding(.horizontal, 28)
             .padding(.vertical, 14)
@@ -456,8 +464,35 @@ struct TVAddressDropdown: View {
         .buttonStyle(TVSettingsButtonStyle())
         .focused($isFocused)
         .accessibilityLabel("IP addresses")
-        .overlay(alignment: .top) {
-            if isExpanded {
+        .sheet(isPresented: $isExpanded) {
+            TVAddressDetailsView(ipv4: ipv4, ipv6: ipv6)
+        }
+    }
+}
+
+/// Full IPv4 / IPv6 readout.
+///
+/// The iOS version pairs each address with a copy-to-clipboard button; tvOS has no
+/// pasteboard and nothing to paste into, so the rows are read-only and non-focusable —
+/// the screen is dismissed with the remote's Menu button.
+struct TVAddressDetailsView: View {
+    let ipv4: String
+    let ipv6: String
+
+    var body: some View {
+        ZStack {
+            TVGradientBackground()
+
+            VStack(alignment: .leading, spacing: 20) {
+                Text("IP addresses")
+                    .font(.system(size: 48, weight: .bold))
+                    .foregroundColor(TVColors.textPrimary)
+
+                Text("Addresses assigned to this device on the NetBird network.")
+                    .font(.system(size: 26))
+                    .foregroundColor(TVColors.textSecondary)
+                    .padding(.bottom, 10)
+
                 VStack(spacing: 0) {
                     addressRow(label: "IPv4", value: ipv4)
 
@@ -467,9 +502,6 @@ struct TVAddressDropdown: View {
 
                     addressRow(label: "IPv6", value: ipv6)
                 }
-                .frame(width: 760)
-                // Same card treatment as the bottom stats bar, so the panel reads
-                // as part of the tvOS layout rather than a pop-up menu.
                 .background(
                     RoundedRectangle(cornerRadius: TVLayout.cornerRadiusMedium)
                         .fill(Color.white.opacity(0.05))
@@ -478,15 +510,16 @@ struct TVAddressDropdown: View {
                                 .stroke(Color.white.opacity(0.08), lineWidth: 1)
                         )
                 )
-                .offset(y: 74)
-                .transition(.opacity)
+
+                Spacer()
             }
+            .padding(.horizontal, TVLayout.contentPadding)
+            .padding(.vertical, 60)
         }
     }
 
     /// Single-line row: the address is the payload, so it carries the large type
-    /// while the family label stays a quiet caption. Keeping rows to one line also
-    /// keeps the expanded panel clear of the bottom stats bar.
+    /// while the family label stays a quiet caption.
     @ViewBuilder
     private func addressRow(label: String, value: String) -> some View {
         HStack(spacing: 18) {
@@ -504,7 +537,7 @@ struct TVAddressDropdown: View {
                 .truncationMode(.middle)
         }
         .padding(.horizontal, 28)
-        .padding(.vertical, 14)
+        .padding(.vertical, 18)
     }
 }
 

--- a/NetBird/Source/App/Views/TV/TVNetworksView.swift
+++ b/NetBird/Source/App/Views/TV/TVNetworksView.swift
@@ -82,10 +82,13 @@ struct TVNetworkListContent: View {
             .padding(.horizontal, 80)
             .padding(.bottom, 30)
 
+            // Exit nodes are excluded here on purpose: they are mutually exclusive, so they
+            // get their own selector on the connection screen rather than sitting among
+            // the independently toggled resources.
             // Network list
             ScrollView {
                 LazyVStack(spacing: 4) {
-                    ForEach(viewModel.routeViewModel.filteredRoutes, id: \.id) { route in
+                    ForEach(viewModel.routeViewModel.filteredResourceRoutes, id: \.id) { route in
                         TVNetworkCard(
                             route: route,
                             routeViewModel: viewModel.routeViewModel
@@ -107,12 +110,13 @@ struct TVNetworkListContent: View {
     
     // Computed Properties
 
+    // Exit nodes are counted by their own selector, not by this list.
     private var activeCount: Int {
-        viewModel.routeViewModel.routeInfo.filter { $0.selected }.count
+        viewModel.routeViewModel.resourceRouteInfo.filter { $0.selected }.count
     }
 
     private var totalCount: Int {
-        viewModel.routeViewModel.routeInfo.count
+        viewModel.routeViewModel.resourceRouteInfo.count
     }
     
     // Actions


### PR DESCRIPTION
## Description

## Add exit node selection to tvOS

Brings the exit node feature to Apple TV, matching what iOS already does on its connection screen.

### What changed

- **Exit node selector on the connection screen** — a card above the stats bar shows the active exit node (or `None`) and opens the list of available nodes. It stays in the layout when there is nothing to choose from, rendered disabled with *"No exit nodes available"*, so the screen doesn't reflow as routes come and go.
- **Exit nodes removed from the resources list** — they're mutually exclusive, so they no longer sit among the independently toggled resources, and they're excluded from both resource counters (Networks header and the connection screen stats card).
- **Network map refresh on appear** — returning to the connection screen from another tab doesn't go through the status handler, so the selector could show stale nodes. Refreshes only while connected: `GetRoutes` answers empty without a tunnel session and would wipe a list that is still valid.

### Selection model

No view model changes. `exitNodes`, `selectedExitNode`, `setExitNode` and `filteredResourceRoutes` already live in the shared `RoutesViewModel`, so single selection, the mutual-exclusion ordering and the reconcile-after-write behaviour are identical to iOS by construction.

### Deviations from iOS, and why

| Decision | Reason |
| --- | --- |
| Nodes are picked from a separate screen, not an inline dropdown | The connection screen is a centred layout — a list expanding in place pushes the toggle and stats bar out of position. tvOS has no pointer, so a floating panel can't be dismissed by tapping outside it. A modal list is the platform norm and is already used here (`TVQRCodeSheet`). |
| The IPv4/IPv6 readout also moved to its own screen | It expanded a panel that overhung whatever sat below it, with row heights hand-tuned to just barely clear the stats bar. The exit node card landed in exactly that space. Making it a screen removes the overlap instead of re-tuning the clearance and hitting the next collision later. Its chevron changed from down to right to match. |

### Files

| File | Change |
| --- | --- |
| `TVExitNodeSelector.swift` | **new** — selector card, modal list, list row |
| `TVMainView.swift` | selector placement, resource counters, refresh on appear, address readout → own screen |
| `TVNetworksView.swift` | exit nodes hidden from the list and its counters |
| `project.pbxproj` | registers the new file for the **NetBird TV** target |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added exit-node selection to the tvOS connection screen, including the option to clear the selection.
  * Added a dedicated details sheet for viewing IPv4 and IPv6 addresses.
  * Added focus styling and accessibility indicators for selectable exit nodes.

* **Improvements**
  * Network lists and counts now reflect resource routes accurately.
  * Route information refreshes when the connected screen appears.
  * Exit-node selections are dismissed when no longer available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->