### PR TITLE
TVos - vpn on demand 

### DIFF
--- a/NetBird/Source/App/ViewModels/MainViewModel.swift
+++ b/NetBird/Source/App/ViewModels/MainViewModel.swift
@@ -310,9 +310,16 @@ class ViewModel: ObservableObject {
     }
 
     /// Disables On Demand and connects (user chose to override conflicting rules).
+    /// Connects only once the disarm has been written, otherwise a Disconnect rule that is
+    /// still in force tears the new tunnel down again. The connect runs even if the manager
+    /// refused the change — the user asked for a connection, and the rule conflict is
+    /// reported by the alert that led here.
     func connectWithOnDemandDisabled() {
-        setConnectOnDemand(isEnabled: false)
-        performConnect()
+        setConnectOnDemand(isEnabled: false) { [weak self] _ in
+            DispatchQueue.main.async {
+                self?.performConnect()
+            }
+        }
     }
 
     #if os(iOS)
@@ -463,9 +470,20 @@ class ViewModel: ObservableObject {
     }
 
     /// Disables On Demand and disconnects (user chose to prevent auto-reconnect).
+    /// The disconnect waits for the disarm to be persisted: stopping the tunnel while a rule
+    /// is still in force just has the system bring it back, which reads as a failed
+    /// disconnect. If the manager refuses the change, the tunnel is left up rather than
+    /// dropped into an immediate reconnect.
     func closeWithOnDemandDisabled() {
-        setConnectOnDemand(isEnabled: false)
-        performClose()
+        setConnectOnDemand(isEnabled: false) { [weak self] inForce in
+            guard inForce else {
+                AppLogger.shared.log("closeWithOnDemandDisabled: On Demand still armed, keeping the tunnel up")
+                return
+            }
+            DispatchQueue.main.async {
+                self?.performClose()
+            }
+        }
     }
 
     func updateVPNDisplayState(priorExtensionState: NEVPNStatus? = nil) {
@@ -665,22 +683,54 @@ class ViewModel: ObservableObject {
         defaults.removeObject(forKey: "ip")
         defaults.removeObject(forKey: "fqdn")
 
-        // Disable and persist On Demand off to keep UI/storage/manager in sync
-        setConnectOnDemand(isEnabled: false)
-
-        // Clear config JSON (contains server credentials and all settings)
-        Preferences.removeConfigFromUserDefaults()
+        // Disable and persist On Demand off to keep UI/storage/manager in sync, and wipe the
+        // config only once that disarm has actually landed — a rule still in force would have
+        // the system restart the tunnel against the configuration being removed.
+        if connectOnDemand {
+            setConnectOnDemand(isEnabled: false) { [weak self] inForce in
+                if !inForce {
+                    AppLogger.shared.log("clearDetails: On Demand disarm failed, clearing the config anyway")
+                }
+                DispatchQueue.main.async {
+                    self?.wipeStoredConfig()
+                }
+            }
+        } else {
+            wipeStoredConfig()
+        }
 
         // Reset @Published properties to reflect cleared state in UI
         self.rosenpassEnabled = false
         self.rosenpassPermissive = false
         self.presharedKey = ""
         self.presharedKeySecure = false
+    }
+
+    /// Removes the stored configuration — server credentials and all settings.
+    private func wipeStoredConfig() {
+        Preferences.removeConfigFromUserDefaults()
 
         #if os(tvOS)
         // Also clear extension-local config to prevent stale credentials
         networkExtensionAdapter.clearExtensionConfig()
         #endif
+    }
+
+    /// Server change: disarm On Demand, then disconnect and clear local state, in that order.
+    /// Proceeds even when the disarm fails — the user asked to leave this server, and stale
+    /// credentials must not be kept just because the tunnel manager refused a rule change.
+    func resetForServerChange(completion: @escaping () -> Void) {
+        setConnectOnDemand(isEnabled: false) { [weak self] inForce in
+            DispatchQueue.main.async {
+                guard let self else { return }
+                if !inForce {
+                    AppLogger.shared.log("resetForServerChange: On Demand disarm failed, resetting anyway")
+                }
+                self.performClose()
+                self.clearDetails()
+                completion()
+            }
+        }
     }
     
     // MARK: - Configuration Methods (via ConfigurationProvider)
@@ -830,11 +880,35 @@ class ViewModel: ObservableObject {
         #endif
     }
     
-    func setConnectOnDemand(isEnabled: Bool) {
+    /// Stores the user's On Demand choice and asks the tunnel manager to apply it.
+    ///
+    /// The preference is written up front because it is the user's *intent*: when there is
+    /// nothing to arm yet (no manager, or no login), the choice has to survive so
+    /// `applyExtensionStatus` can arm it after the next successful connection. Only a manager
+    /// that actively rejects the change rolls the stored value back, so UI, storage and the
+    /// tunnel manager never disagree about what is in force.
+    ///
+    /// - Parameter completion: called with `true` when the requested state is in force
+    ///   (applied, or nothing needed arming), `false` when the manager refused it. Callers
+    ///   that depend on the change — disconnecting, wiping the config — must wait for it.
+    func setConnectOnDemand(isEnabled: Bool, completion: ((Bool) -> Void)? = nil) {
+        let previous = connectOnDemand
         let userDefaults = UserDefaults(suiteName: GlobalConstants.userPreferencesSuiteName)
         userDefaults?.set(isEnabled, forKey: GlobalConstants.keyConnectOnDemand)
         self.connectOnDemand = isEnabled
-        networkExtensionAdapter.setOnDemandEnabled(isEnabled)
+        networkExtensionAdapter.setOnDemandEnabled(isEnabled) { [weak self] result in
+            switch result {
+            case .applied, .deferred:
+                completion?(true)
+            case .failed(let error):
+                AppLogger.shared.log("On Demand change to \(isEnabled) failed (\(error?.localizedDescription ?? "unknown error")), reverting to \(previous)")
+                DispatchQueue.main.async {
+                    userDefaults?.set(previous, forKey: GlobalConstants.keyConnectOnDemand)
+                    self?.connectOnDemand = previous
+                    completion?(false)
+                }
+            }
+        }
         if isEnabled {
             self.showOnDemandAlert = true
         }

--- a/NetBird/Source/App/ViewModels/MainViewModel.swift
+++ b/NetBird/Source/App/ViewModels/MainViewModel.swift
@@ -418,6 +418,13 @@ class ViewModel: ObservableObject {
             showOnDemandDisconnectAlert = true
             return
         }
+        #else
+        // tvOS runs a single always-connect rule, so an armed On Demand reconnects
+        // immediately on any interface — always warn before a manual disconnect.
+        if connectOnDemand {
+            showOnDemandDisconnectAlert = true
+            return
+        }
         #endif
 
         performClose()
@@ -681,7 +688,15 @@ class ViewModel: ObservableObject {
     func updatePreSharedKey() {
         configProvider.preSharedKey = presharedKey
         if configProvider.commit() {
+            // tvOS: bypass the On Demand disconnect prompt. The user changed a setting that
+            // needs a reconnect, not asked to stay offline — letting On Demand bring the
+            // tunnel back with the new key is the intended outcome (and the prompt would be
+            // hidden behind the pre-shared key cover anyway).
+            #if os(tvOS)
+            self.performClose()
+            #else
             self.close()
+            #endif
             self.presharedKeySecure = true
             self.showPreSharedKeyChangedInfo = true
         } else {
@@ -693,7 +708,11 @@ class ViewModel: ObservableObject {
         presharedKey = ""
         configProvider.preSharedKey = ""
         if configProvider.commit() {
+            #if os(tvOS)
+            self.performClose()
+            #else
             self.close()
+            #endif
             self.presharedKeySecure = false
         } else {
             print("Failed to remove preshared key")

--- a/NetBird/Source/App/Views/TV/TVMainView.swift
+++ b/NetBird/Source/App/Views/TV/TVMainView.swift
@@ -239,6 +239,12 @@ struct TVConnectionView: View {
                 .padding(.horizontal, 120)
                 .padding(.bottom, 50)
             }
+
+            // A manual disconnect while On Demand is armed needs a confirmation:
+            // the system would otherwise bring the tunnel straight back up.
+            if viewModel.showOnDemandDisconnectAlert {
+                TVOnDemandDisconnectAlert(viewModel: viewModel)
+            }
         }
     }
     

--- a/NetBird/Source/App/Views/TV/TVSettingsView.swift
+++ b/NetBird/Source/App/Views/TV/TVSettingsView.swift
@@ -33,6 +33,18 @@ struct TVSettingsView: View {
                 ScrollView {
                     VStack(spacing: 20) {
                         TVSettingsSection(title: "Connection") {
+                            TVSettingsToggleRow(
+                                icon: "bolt.horizontal.circle.fill",
+                                title: "Connect On Demand",
+                                subtitle: "Reconnect automatically after a reboot or network change",
+                                isOn: Binding(
+                                    get: { viewModel.connectOnDemand },
+                                    set: { newValue in
+                                        viewModel.setConnectOnDemand(isEnabled: newValue)
+                                    }
+                                )
+                            )
+
                             TVSettingsRow(
                                 icon: "server.rack",
                                 title: "Change Server",
@@ -442,13 +454,91 @@ struct TVChangeServerAlert: View {
                         style: .filled(Color.red),
                         isFocused: focusedButton == .confirm,
                         action: {
-                            viewModel.close()
+                            // Disable On Demand along with the disconnect: the config is about
+                            // to be wiped, so an armed rule would have the system restart a
+                            // tunnel that can no longer log in.
+                            viewModel.closeWithOnDemandDisabled()
                             viewModel.clearDetails()
                             viewModel.showChangeServerAlert = false
                             viewModel.navigateToServerView = true
                         }
                     )
                     .focused($focusedButton, equals: .confirm)
+                }
+                .focusSection()
+            }
+            .padding(60)
+            .background(
+                RoundedRectangle(cornerRadius: 30)
+                    .fill(TVColors.bgSideDrawer)
+            )
+        }
+        .onAppear {
+            focusedButton = .cancel
+        }
+        .onChange(of: focusedButton) { oldValue, newValue in
+            _ = oldValue  // Suppress unused warning
+            if let newValue = newValue {
+                lastFocusedButton = newValue
+            } else {
+                // Focus escaped - pull it back
+                focusedButton = lastFocusedButton
+            }
+        }
+    }
+}
+
+/// Shown when the user disconnects manually while On Demand is armed. Without this the
+/// tunnel would come straight back up and the disconnect would look like it failed.
+struct TVOnDemandDisconnectAlert: View {
+    @ObservedObject var viewModel: ViewModel
+
+    private enum FocusedButton {
+        case cancel, disconnect
+    }
+
+    @FocusState private var focusedButton: FocusedButton?
+    @State private var lastFocusedButton: FocusedButton = .cancel
+
+    var body: some View {
+        ZStack {
+            Color.black.opacity(0.7)
+                .ignoresSafeArea()
+
+            VStack(spacing: 40) {
+                Image(systemName: "bolt.horizontal.circle.fill")
+                    .font(.system(size: 60))
+                    .foregroundColor(.orange)
+
+                Text("Connect On Demand Is Active")
+                    .font(.system(size: 40, weight: .bold))
+                    .foregroundColor(TVColors.textAlert)
+
+                Text("NetBird will reconnect automatically. Do you want to turn Connect On Demand off and disconnect?")
+                    .font(.system(size: 24))
+                    .foregroundColor(TVColors.textAlert)
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: 600)
+
+                HStack(spacing: 40) {
+                    TVAlertButton(
+                        title: "Cancel",
+                        style: .outlined,
+                        isFocused: focusedButton == .cancel,
+                        action: { viewModel.showOnDemandDisconnectAlert = false }
+                    )
+                    .focused($focusedButton, equals: .cancel)
+
+                    TVAlertButton(
+                        title: "Turn Off & Disconnect",
+                        style: .filled(Color.red),
+                        isFocused: focusedButton == .disconnect,
+                        action: {
+                            viewModel.showOnDemandDisconnectAlert = false
+                            viewModel.closeWithOnDemandDisabled()
+                        }
+                    )
+                    .focused($focusedButton, equals: .disconnect)
                 }
                 .focusSection()
             }
@@ -522,7 +612,9 @@ struct TVRosenpassChangedAlert: View {
                         isFocused: focusedButton == .reconnect,
                         action: {
                             viewModel.showRosenpassChangedAlert = false
-                            viewModel.close()
+                            // performClose(), not close(): this is an explicit reconnect, so the
+                            // On Demand disconnect prompt would only interrupt the sequence.
+                            viewModel.performClose()
                             // Small delay before reconnecting to allow disconnect to complete
                             DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
                                 viewModel.connect()

--- a/NetBird/Source/App/Views/TV/TVSettingsView.swift
+++ b/NetBird/Source/App/Views/TV/TVSettingsView.swift
@@ -454,13 +454,13 @@ struct TVChangeServerAlert: View {
                         style: .filled(Color.red),
                         isFocused: focusedButton == .confirm,
                         action: {
-                            // Disable On Demand along with the disconnect: the config is about
-                            // to be wiped, so an armed rule would have the system restart a
-                            // tunnel that can no longer log in.
-                            viewModel.closeWithOnDemandDisabled()
-                            viewModel.clearDetails()
                             viewModel.showChangeServerAlert = false
-                            viewModel.navigateToServerView = true
+                            // Disarm On Demand before the disconnect and the config wipe: an
+                            // armed rule would have the system restart a tunnel that can no
+                            // longer log in.
+                            viewModel.resetForServerChange {
+                                viewModel.navigateToServerView = true
+                            }
                         }
                     )
                     .focused($focusedButton, equals: .confirm)

--- a/NetbirdKit/NetworkExtensionAdapter.swift
+++ b/NetbirdKit/NetworkExtensionAdapter.swift
@@ -269,9 +269,16 @@ public class NetworkExtensionAdapter: ObservableObject {
             // Stop the system from retry-looping the tunnel while the user works through the
             // device code flow — every unattended start would fail on "login required".
             // applyExtensionStatus re-arms On Demand once the tunnel is up again.
+            // Await the save: the login starts a tunnel of its own, and a rule that is still
+            // in force would race it with an unauthenticated start.
             if isOnDemandEnabled {
                 logger.info("loginIfRequired: disarming On Demand for the duration of the login")
-                setOnDemandEnabled(false)
+                let result = await withCheckedContinuation { (continuation: CheckedContinuation<OnDemandUpdate, Never>) in
+                    setOnDemandEnabled(false) { continuation.resume(returning: $0) }
+                }
+                if case .failed(let error) = result {
+                    logger.error("loginIfRequired: could not disarm On Demand: \(error?.localizedDescription ?? "unknown error")")
+                }
             }
             #endif
 
@@ -664,21 +671,51 @@ public class NetworkExtensionAdapter: ObservableObject {
         self.vpnManager?.connection.stopVPNTunnel()
     }
 
+    /// Outcome of an On Demand update. Callers that persist or display the state must wait
+    /// for this before claiming the change took effect.
+    enum OnDemandUpdate {
+        /// The rules were written to the tunnel manager.
+        case applied
+        /// There was nothing to arm — no manager exists yet, or no configuration to connect
+        /// with. The stored preference stands and `applyExtensionStatus` arms it after the
+        /// next successful connection.
+        case deferred
+        /// The tunnel manager rejected the change; what is in force is still the old state.
+        case failed(Error?)
+    }
+
+    /// Last requested On Demand state, kept because the manager may still be loading when
+    /// the next request arrives. Locked like `isFetchingStatus`: requests come from the main
+    /// queue and from the (non-isolated) async login path.
+    private let onDemandLock = NSLock()
+    private var _requestedOnDemandState: Bool?
+    private var requestedOnDemandState: Bool? {
+        get { onDemandLock.lock(); defer { onDemandLock.unlock() }; return _requestedOnDemandState }
+        set { onDemandLock.lock(); defer { onDemandLock.unlock() }; _requestedOnDemandState = newValue }
+    }
+
     /// Updates the VPN On Demand configuration on the current manager.
     /// When enabled, iOS will automatically reconnect the VPN after network changes or reboot.
     /// Should only be enabled when the user is logged in to avoid reconnect loops.
-    func setOnDemandEnabled(_ enabled: Bool) {
+    func setOnDemandEnabled(_ enabled: Bool, completion: ((OnDemandUpdate) -> Void)? = nil) {
         if enabled && !hasUsableConfigForOnDemand() {
             logger.warning("setOnDemandEnabled: Refusing to enable On Demand — user is not logged in")
+            completion?(.deferred)
             return
         }
+
+        // Record the request before any async work: a state that arrives while the manager
+        // is still loading must win over the one that started that load, or the stale value
+        // gets written after it.
+        requestedOnDemandState = enabled
 
         guard let manager = self.vpnManager else {
             // Nothing is armed without a manager, so disabling is already the effective
             // state. Never configure one just to switch On Demand off — that would create
             // the VPN configuration (and its system prompt) from a background code path.
             guard enabled else {
-                logger.warning("setOnDemandEnabled: No VPN manager available")
+                logger.info("setOnDemandEnabled: No VPN manager — nothing is armed, disable is already in force")
+                completion?(.deferred)
                 return
             }
 
@@ -691,22 +728,29 @@ public class NetworkExtensionAdapter: ObservableObject {
                     try await self.configureManager()
                 } catch {
                     self.logger.error("setOnDemandEnabled: configureManager failed: \(error.localizedDescription)")
+                    completion?(.failed(error))
                     return
                 }
                 guard let manager = self.vpnManager else {
                     self.logger.error("setOnDemandEnabled: manager still unavailable after configureManager")
+                    completion?(.failed(nil))
                     return
                 }
-                self.applyOnDemandState(enabled, to: manager)
+                // Apply the latest request rather than the one this task was started for.
+                let state = self.requestedOnDemandState ?? enabled
+                if state != enabled {
+                    self.logger.info("setOnDemandEnabled: superseded while configuring, applying \(state) instead of \(enabled)")
+                }
+                self.applyOnDemandState(state, to: manager, completion: completion)
             }
             return
         }
 
-        applyOnDemandState(enabled, to: manager)
+        applyOnDemandState(enabled, to: manager, completion: completion)
     }
 
     /// Writes the On Demand state and matching rules to the given manager.
-    private func applyOnDemandState(_ enabled: Bool, to manager: NETunnelProviderManager) {
+    private func applyOnDemandState(_ enabled: Bool, to manager: NETunnelProviderManager, completion: ((OnDemandUpdate) -> Void)? = nil) {
         if enabled {
             // Build rules from saved settings
             let rules = buildOnDemandRules()
@@ -726,8 +770,10 @@ public class NetworkExtensionAdapter: ObservableObject {
         manager.saveToPreferences { error in
             if let error = error {
                 self.logger.error("setOnDemandEnabled: Failed to save preferences: \(error.localizedDescription)")
+                completion?(.failed(error))
             } else {
                 self.logger.info("setOnDemandEnabled: On Demand \(enabled ? "enabled" : "disabled") successfully")
+                completion?(.applied)
             }
         }
     }

--- a/NetbirdKit/NetworkExtensionAdapter.swift
+++ b/NetbirdKit/NetworkExtensionAdapter.swift
@@ -264,6 +264,17 @@ public class NetworkExtensionAdapter: ObservableObject {
 
         if needsLogin {
             logger.info("loginIfRequired: login required, calling performLogin()")
+
+            #if os(tvOS)
+            // Stop the system from retry-looping the tunnel while the user works through the
+            // device code flow — every unattended start would fail on "login required".
+            // applyExtensionStatus re-arms On Demand once the tunnel is up again.
+            if isOnDemandEnabled {
+                logger.info("loginIfRequired: disarming On Demand for the duration of the login")
+                setOnDemandEnabled(false)
+            }
+            #endif
+
             // Note: For tvOS, config initialization happens in the extension's startTunnel
             // before the needsLogin check. The extension has permission to write to App Group.
             await performLogin()
@@ -657,20 +668,45 @@ public class NetworkExtensionAdapter: ObservableObject {
     /// When enabled, iOS will automatically reconnect the VPN after network changes or reboot.
     /// Should only be enabled when the user is logged in to avoid reconnect loops.
     func setOnDemandEnabled(_ enabled: Bool) {
-        guard let manager = self.vpnManager else {
-            logger.warning("setOnDemandEnabled: No VPN manager available")
+        if enabled && !hasUsableConfigForOnDemand() {
+            logger.warning("setOnDemandEnabled: Refusing to enable On Demand — user is not logged in")
             return
         }
 
-        if enabled {
-            let defaults = UserDefaults(suiteName: GlobalConstants.userPreferencesSuiteName)
-            let loginRequired = defaults?.bool(forKey: GlobalConstants.keyLoginRequired) ?? true
-            if loginRequired {
-                logger.warning("setOnDemandEnabled: Refusing to enable On Demand — user is not logged in")
+        guard let manager = self.vpnManager else {
+            // Nothing is armed without a manager, so disabling is already the effective
+            // state. Never configure one just to switch On Demand off — that would create
+            // the VPN configuration (and its system prompt) from a background code path.
+            guard enabled else {
+                logger.warning("setOnDemandEnabled: No VPN manager available")
                 return
             }
+
+            // The manager is created lazily on the first connect. On tvOS the On Demand
+            // toggle lives in Settings and can be flipped before that ever happens, so
+            // load (or create) the manager here instead of dropping the change.
+            logger.info("setOnDemandEnabled: No VPN manager yet — configuring one first")
+            Task { @MainActor in
+                do {
+                    try await self.configureManager()
+                } catch {
+                    self.logger.error("setOnDemandEnabled: configureManager failed: \(error.localizedDescription)")
+                    return
+                }
+                guard let manager = self.vpnManager else {
+                    self.logger.error("setOnDemandEnabled: manager still unavailable after configureManager")
+                    return
+                }
+                self.applyOnDemandState(enabled, to: manager)
+            }
+            return
         }
 
+        applyOnDemandState(enabled, to: manager)
+    }
+
+    /// Writes the On Demand state and matching rules to the given manager.
+    private func applyOnDemandState(_ enabled: Bool, to manager: NETunnelProviderManager) {
         if enabled {
             // Build rules from saved settings
             let rules = buildOnDemandRules()
@@ -694,6 +730,20 @@ public class NetworkExtensionAdapter: ObservableObject {
                 self.logger.info("setOnDemandEnabled: On Demand \(enabled ? "enabled" : "disabled") successfully")
             }
         }
+    }
+
+    /// True when there is a configuration the extension can connect with unattended.
+    /// On Demand must not be armed before that — the system would otherwise keep
+    /// starting a tunnel that immediately fails with "login required".
+    private func hasUsableConfigForOnDemand() -> Bool {
+        #if os(tvOS)
+        // tvOS never writes keyLoginRequired: the app-group defaults are not shared with
+        // the extension there, so the login state is tracked through the stored config.
+        return Preferences.hasConfigInUserDefaults()
+        #else
+        let defaults = UserDefaults(suiteName: GlobalConstants.userPreferencesSuiteName)
+        return !(defaults?.bool(forKey: GlobalConstants.keyLoginRequired) ?? true)
+        #endif
     }
 
     /// Applies granular On Demand rules based on Wi-Fi/Cellular policies and network lists.
@@ -735,6 +785,15 @@ public class NetworkExtensionAdapter: ObservableObject {
 
     /// Converts policy enums into NEOnDemandRule objects.
     private func buildOnDemandRulesFrom(wifiPolicy: WiFiOnDemandPolicy, cellularPolicy: CellularOnDemandPolicy, wifiNetworks: [String]) -> [NEOnDemandRule] {
+        #if os(tvOS)
+        // Apple TV exposes a single "always connect" behaviour: there are no per-network
+        // rules (NEHotspotNetwork is unavailable) and no cellular interface. The match must
+        // be .any rather than .wiFi — an Apple TV on Ethernet never matches a Wi-Fi rule,
+        // and wired setups are exactly the always-on ones this is meant to serve.
+        let rule = NEOnDemandRuleConnect()
+        rule.interfaceTypeMatch = .any
+        return [rule]
+        #else
         var rules: [NEOnDemandRule] = []
 
         // Wi-Fi rules
@@ -772,8 +831,7 @@ public class NetworkExtensionAdapter: ObservableObject {
             break
         }
 
-        // Cellular rules (cellular is not available on tvOS)
-        #if !os(tvOS)
+        // Cellular rules
         switch cellularPolicy {
         case .always:
             let rule = NEOnDemandRuleConnect()
@@ -786,9 +844,9 @@ public class NetworkExtensionAdapter: ObservableObject {
         case .doNothing:
             break
         }
-        #endif
 
         return rules
+        #endif
     }
 
     /// Returns the current On Demand enabled state from the VPN manager.


### PR DESCRIPTION
## Description


On Apple TV the tunnel only comes up when someone opens the app and presses
Connect. After every reboot NetBird stays down, which makes the platform's
main use cases — exit node, routing peer, always-on access to home servers —
impractical. iOS has had VPN On Demand for a while; tvOS was never wired up.

Requested by a community user who confirmed the behaviour works on their fork
across several Apple TVs.

## What changed

The On Demand code already lives in the shared `NetbirdKit` layer, so most of
this is enabling it plus fixing the pieces that could not have worked on tvOS.

**`NetbirdKit/NetworkExtensionAdapter.swift`**
- `buildOnDemandRulesFrom` returns a single `NEOnDemandRuleConnect` with
  `interfaceTypeMatch = .any` on tvOS. The shared rules match `.wiFi`, which an
  Apple TV on Ethernet never satisfies — and wired boxes are precisely the
  always-on installs this feature exists for. Cellular and SSID matching remain
  iOS-only.
- The "is the user logged in" guard checked `keyLoginRequired`. Nothing writes
  that key on tvOS (app group defaults are not shared with the extension), so
  the guard was effectively a no-op there. On tvOS it now checks for a stored
  config, which is what the login flow actually persists.
- `setOnDemandEnabled` loads or creates the tunnel manager when one does not
  exist yet, instead of dropping the change into the log. The manager is only
  created when *enabling*, so disabling from a background path can never
  trigger the system VPN configuration prompt.
- On Demand is disarmed for the duration of a device code login and re-armed by
  `applyExtensionStatus` on the next successful connection, so an expired
  session cannot turn into a restart loop.

**UI (`TVSettingsView`, `TVMainView`)**
- "Connect On Demand" toggle in the Connection section of Settings.
- `TVOnDemandDisconnectAlert` on the connection screen: a manual disconnect with
  an armed rule would otherwise reconnect immediately and look like a failure.
  Confirming turns the setting off and disconnects.

**`MainViewModel`**
- `close()` asks for confirmation on tvOS when On Demand is on.
- Change server now disconnects *and* turns On Demand off — the config is wiped
  right after, so an armed rule would only restart a tunnel that can no longer
  log in.
- The Rosenpass reconnect and pre-shared key flows call `performClose()` so the
  confirmation prompt does not interrupt a sequence the user already committed
  to (and would be hidden behind the pre-shared key cover anyway).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Connect On Demand” setting on tvOS.
  * Added confirmation prompts before manually disconnecting while On Demand is enabled.
* **Bug Fixes**
  * Improved On Demand behavior during login, server changes, and reconnection.
  * Prevented repeated unattended connection attempts when login is required.
  * Added clearer warnings when disconnecting from an always-connected configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->