### PR TITLE
fix: apply route side effects when activation assigns the status directly

### DIFF
--- a/NetBird/Source/App/NetBirdApp.swift
+++ b/NetBird/Source/App/NetBirdApp.swift
@@ -173,6 +173,18 @@ struct NetBirdApp: App {
                 viewModel.disconnectPressed = false
                 viewModel.extensionState = initialStatus
                 viewModel.updateVPNDisplayState()
+
+                // Assigning extensionState directly means the checkExtensionState() below
+                // hits applyExtensionStatus' `extensionState != status` guard and returns
+                // early — taking its route side effects with it. Apply them here instead.
+                //
+                // Launching (or foregrounding) onto an already-connected tunnel would
+                // otherwise leave the exit node selector stuck on "No exit nodes
+                // available" until the user visits the Resources tab, whose own onAppear
+                // does the fetch. Foregrounding onto a tunnel that dropped while the app
+                // was away is the mirror case: the routes are never cleared, so the
+                // selector stays enabled over nodes the core can no longer apply.
+                viewModel.applyRouteSideEffects(for: initialStatus)
             } else {
                 // No matching VPN profile found — still force a widget timeline refresh so
                 // the widget doesn't stay stuck on a transitioning state from a prior

--- a/NetBird/Source/App/NetBirdApp.swift
+++ b/NetBird/Source/App/NetBirdApp.swift
@@ -184,6 +184,12 @@ struct NetBirdApp: App {
                 // does the fetch. Foregrounding onto a tunnel that dropped while the app
                 // was away is the mirror case: the routes are never cleared, so the
                 // selector stays enabled over nodes the core can no longer apply.
+                //
+                // loadCurrentConnectionState can await past this activation's lifetime:
+                // its 200 ms retry sleep uses `try?`, which swallows cancellation. The
+                // assignment above is a cheap local update, but the route sync below is
+                // an IPC round-trip — don't make it for an activation already superseded.
+                guard isAppActive, !Task.isCancelled else { return }
                 viewModel.applyRouteSideEffects(for: initialStatus)
             } else {
                 // No matching VPN profile found — still force a widget timeline refresh so

--- a/NetBird/Source/App/ViewModels/MainViewModel.swift
+++ b/NetBird/Source/App/ViewModels/MainViewModel.swift
@@ -637,11 +637,22 @@ class ViewModel: ObservableObject {
         extensionState = status
         updateVPNDisplayState(priorExtensionState: priorState)
 
+        applyRouteSideEffects(for: status)
+
+        if status == .connected, connectOnDemand {
+            networkExtensionAdapter.setOnDemandEnabled(true)
+        }
+    }
+
+    /// Brings the cached route list in line with `status`.
+    ///
+    /// Separate from `applyExtensionStatus` so that callers which assign `extensionState`
+    /// themselves — and therefore trip its `extensionState != status` guard — can still
+    /// apply this part. Idempotent: re-running it for an unchanged status costs one
+    /// GetRoutes round-trip while connected, and nothing at all while disconnected.
+    func applyRouteSideEffects(for status: NEVPNStatus) {
         if status == .connected {
             routeViewModel.getRoutes()
-            if connectOnDemand {
-                networkExtensionAdapter.setOnDemandEnabled(true)
-            }
         } else if status == .disconnected {
             // Routes only exist while the extension is up. Drop them so the exit node
             // selector on the connection screen falls back to its disabled state instead


### PR DESCRIPTION
## Description

Raised with @braginini on Telegram, who asked for the fix to be sent in for the upcoming release.

The exit node selector added in #170 shows "No exit nodes available" while the tunnel is up, if the app was launched (or foregrounded) onto an already-running tunnel.

### Steps to reproduce

1. Connect the tunnel.
2. Swipe the app away so it is unloaded from memory. The tunnel keeps running in the extension — the VPN indicator stays in the status bar.
3. Reopen the app.

The connection screen reports "Connected", but the exit node card stays disabled with "No exit nodes available". Switching to the Resources tab and back fixes it, because `RouteTabView.onAppear` fetches routes unconditionally.

Reproduced on iPhone 15 / iOS 26.1 with a build of `main` at 5b29c05, and verified fixed with the same build plus this change.

### Cause

`startActivation()` assigns `viewModel.extensionState = initialStatus` directly. The `checkExtensionState()` that follows therefore reaches `applyExtensionStatus` with a status equal to the one already stored, trips its `guard knownStatuses.contains(status), extensionState != status else { return }` and returns early — skipping the route side effects that live inside it.

`iOSConnectionView.onAppear` doesn't cover this: its own `getRoutes()` is gated on `vpnDisplayState == .connected`, and at the time it runs the state has not been applied yet.

The same guard skips the mirror case. Foregrounding onto a tunnel that dropped while the app was away never runs `clearRoutes()`, so the selector stays enabled over nodes the core can no longer apply — and `ExitNodeSelectorCard` is the one consumer of `routeInfo` that isn't gated on connection state, so it is where this surfaces.

### Change

Extracted the route side effects from `applyExtensionStatus` into `applyRouteSideEffects(for:)`, and call it from `startActivation()` with the status it just loaded. `applyExtensionStatus` calls the same method, so behaviour on a genuine status change is unchanged; the On Demand re-arm stays where it was.

This covers tvOS too — `TVExitNodeSelector` reads the same `routeInfo` and had the same symptom.

### Not covered here

On any `GetRoutes` failure the extension encodes an empty list, which is indistinguishable from a genuinely empty network map and overwrites a still-valid cache. That predates this change — `iOSConnectionView.onAppear` and `TVMainView` already call `getRoutes()` the same way — so I left it alone rather than widening the diff. Happy to follow up separately if you'd like it addressed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization of routes and exit-node status when returning to the app with an active or previously disconnected tunnel.
  * Ensured connected-state automatic activation is applied consistently when VPN status changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->