### PR TITLE
Pin gobind alongside gomobile instead of running gomobile init

### DIFF
--- a/.github/workflows/build-upload-tvos.yml
+++ b/.github/workflows/build-upload-tvos.yml
@@ -55,11 +55,6 @@ jobs:
           go-version-file: 'ios-client/netbird-core/go.mod'
           cache-dependency-path: ios-client/netbird-core/go.sum
 
-      - name: Install gomobile-netbird (tvOS fork)
-        run: |
-          GOPROXY=direct go install github.com/netbirdio/gomobile-tvos-fork/cmd/gomobile-netbird@v0.0.0-20260129172842-a56582c0e7c9
-          GOPROXY=direct go install github.com/netbirdio/gomobile-tvos-fork/cmd/gobind-netbird@v0.0.0-20260129172842-a56582c0e7c9
-
       - name: Build NetBirdSDK xcframework
         working-directory: ios-client
         run: ./build-go-lib.sh --tvos

--- a/.github/workflows/build-upload.yml
+++ b/.github/workflows/build-upload.yml
@@ -67,9 +67,6 @@ jobs:
           go-version-file: 'ios-client/netbird-core/go.mod'
           cache-dependency-path: ios-client/netbird-core/go.sum
 
-      - name: Install gomobile
-        run: go install golang.org/x/mobile/cmd/gomobile@v0.0.0-20251113184115-a159579294ab
-
       - name: Build NetBirdSDK xcframework
         working-directory: ios-client
         run: ./build-go-lib.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,8 +36,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ios-client/NetBirdSDK.xcframework
-          # gomobile/xcode segments must match the pinned versions in this job
-          key: netbirdsdk-ios-${{ steps.core-sha.outputs.sha }}-${{ hashFiles('ios-client/build-go-lib.sh') }}-gomobile-20251113184115-xcode-26.1.1
+          # The xcode segment must match the version selected in this job. The
+          # gomobile/gobind pin comes from netbird-core/go.mod, which the core
+          # sha already captures.
+          key: netbirdsdk-ios-${{ steps.core-sha.outputs.sha }}-${{ hashFiles('ios-client/build-go-lib.sh') }}-xcode-26.1.1
 
       - name: Fetch netbird tags
         if: steps.sdk-cache.outputs.cache-hit != 'true'
@@ -50,10 +52,6 @@ jobs:
         with:
           go-version-file: 'ios-client/netbird-core/go.mod'
           cache-dependency-path: ios-client/netbird-core/go.sum
-
-      - name: Install gomobile
-        if: steps.sdk-cache.outputs.cache-hit != 'true'
-        run: go install golang.org/x/mobile/cmd/gomobile@v0.0.0-20251113184115-a159579294ab
 
       - name: Build NetBirdSDK xcframework
         if: steps.sdk-cache.outputs.cache-hit != 'true'
@@ -175,8 +173,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ios-client/NetBirdSDK.xcframework
-          # gomobile/xcode segments must match the pinned versions in this job
-          key: netbirdsdk-tvos-${{ steps.core-sha.outputs.sha }}-${{ hashFiles('ios-client/build-go-lib.sh') }}-gomobile-fork-20260129172842-xcode-26.1.1
+          # The xcode segment must match the version selected in this job. The
+          # tvOS fork pin lives in build-go-lib.sh, which the hashFiles segment
+          # already captures.
+          key: netbirdsdk-tvos-${{ steps.core-sha.outputs.sha }}-${{ hashFiles('ios-client/build-go-lib.sh') }}-xcode-26.1.1
 
       - name: Fetch netbird tags
         if: steps.sdk-cache.outputs.cache-hit != 'true'
@@ -189,12 +189,6 @@ jobs:
         with:
           go-version-file: 'ios-client/netbird-core/go.mod'
           cache-dependency-path: ios-client/netbird-core/go.sum
-
-      - name: Install gomobile-netbird (tvOS fork)
-        if: steps.sdk-cache.outputs.cache-hit != 'true'
-        run: |
-          GOPROXY=direct go install github.com/netbirdio/gomobile-tvos-fork/cmd/gomobile-netbird@v0.0.0-20260129172842-a56582c0e7c9
-          GOPROXY=direct go install github.com/netbirdio/gomobile-tvos-fork/cmd/gobind-netbird@v0.0.0-20260129172842-a56582c0e7c9
 
       - name: Build NetBirdSDK xcframework
         if: steps.sdk-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,8 +36,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ios-client/NetBirdSDK.xcframework
-          # gomobile/xcode segments must match the pinned versions in this job
-          key: netbirdsdk-ios-${{ steps.core-sha.outputs.sha }}-${{ hashFiles('ios-client/build-go-lib.sh') }}-gomobile-20251113184115-xcode-26.1.1
+          # The xcode segment must match the version selected in this job. The
+          # gomobile/gobind pin comes from netbird-core/go.mod, which the core
+          # sha already captures.
+          key: netbirdsdk-ios-${{ steps.core-sha.outputs.sha }}-${{ hashFiles('ios-client/build-go-lib.sh') }}-xcode-26.1.1
 
       - name: Fetch netbird tags
         if: steps.sdk-cache.outputs.cache-hit != 'true'
@@ -50,10 +52,6 @@ jobs:
         with:
           go-version-file: 'ios-client/netbird-core/go.mod'
           cache-dependency-path: ios-client/netbird-core/go.sum
-
-      - name: Install gomobile
-        if: steps.sdk-cache.outputs.cache-hit != 'true'
-        run: go install golang.org/x/mobile/cmd/gomobile@v0.0.0-20251113184115-a159579294ab
 
       - name: Build NetBirdSDK xcframework
         if: steps.sdk-cache.outputs.cache-hit != 'true'

--- a/build-go-lib.sh
+++ b/build-go-lib.sh
@@ -13,6 +13,13 @@
 
 set -euo pipefail
 
+# The tvOS fork is not a dependency of the submodule, so its revision cannot be
+# read from go.mod the way the upstream gomobile pin is; this constant is the
+# single place it is pinned. The CI cache keys follow it through the hash of
+# this script.
+tvos_fork_module="github.com/netbirdio/gomobile-tvos-fork"
+tvos_fork_version="v0.0.0-20260129172842-a56582c0e7c9"
+
 app_path=$(pwd)
 tvos=false
 
@@ -69,6 +76,43 @@ get_version() {
   echo "$new_version"
 }
 
+# The gomobile driver shells out to gobind, and gobind is the tool that
+# actually generates the ObjC bindings and glue. Its own suggestion for a
+# missing gobind is `gomobile init`, which installs it from @latest — that
+# would let the generator float even though the driver is pinned, changing the
+# generated API without a commit here. So both tools are held to the wanted
+# revision: the module version embedded in each binary (go version -m) is
+# compared to the pin, and a missing or diverging tool is reinstalled at the
+# pin.
+#
+# GOBIN is prepended to PATH so the binary this function verified or installed
+# is the one the bind driver (and its PATH lookup of the generator) actually
+# runs, even when another copy sits earlier on the caller's PATH.
+ensure_gomobile_tools() {
+  local module="$1" want="$2"
+  shift 2
+
+  local gobin
+  gobin=$(go env GOBIN)
+  [ -n "$gobin" ] || gobin="$(go env GOPATH)/bin"
+  export PATH="$gobin:$PATH"
+
+  local tool path have
+  for tool in "$@"; do
+    have=""
+    if path=$(command -v "$tool"); then
+      # `|| true`: go version fails on binaries without build info, and set -e
+      # would abort instead of letting the reinstall below repair the tool.
+      have=$(go version -m "$path" 2>/dev/null \
+        | awk -v mod="$module" '$1 == "mod" && $2 == mod {print $3}') || true
+    fi
+    if [ "$have" != "$want" ]; then
+      echo "Installing $tool at the pin $want (found: ${have:-none})"
+      go install "$module/cmd/$tool@$want"
+    fi
+  done
+}
+
 cd netbird-core
 
 version=$(get_version "${1:-}")
@@ -76,8 +120,9 @@ echo "Using version: $version"
 
 if [ "$tvos" = true ]; then
   echo "Building for tvOS (using gomobile-netbird fork)"
-  gomobile-netbird init
-  go get github.com/netbirdio/gomobile-tvos-fork@latest
+  GOPROXY=direct ensure_gomobile_tools "$tvos_fork_module" "$tvos_fork_version" \
+    gomobile-netbird gobind-netbird
+  go get "$tvos_fork_module@$tvos_fork_version"
 
   gomobile-netbird bind \
     -target=ios,iossimulator,tvos,tvossimulator \
@@ -87,7 +132,9 @@ if [ "$tvos" = true ]; then
     "$(pwd)/client/ios/NetBirdSDK"
 else
   echo "Building for iOS"
-  gomobile init
+  ensure_gomobile_tools golang.org/x/mobile \
+    "$(go list -m -f '{{.Version}}' golang.org/x/mobile)" \
+    gomobile gobind
 
   gomobile bind \
     -target=ios,iossimulator \


### PR DESCRIPTION
## Description

gomobile bind shells out to gobind, and gobind is the tool that actually generates the bindings and glue. CI installed only the pinned gomobile and left the build script to call gomobile init, which installs gobind from @latest: the driver was pinned while the generator floated, so the generated API could change without a commit here. The tvOS path floated the same way through `go get gomobile-tvos-fork@latest`.

The build script now verifies both tools against the pin and reinstalls a missing or diverging one. The upstream pair is held to the golang.org/x/mobile revision the submodule's go.mod already carries; the tvOS fork is not a dependency of the submodule, so its revision is pinned once in the script and the go get follows the same pin.

With the script as the single enforcement point, the separate install steps in the workflows are gone, and the hardcoded gomobile version segments leave the xcframework cache keys: the upstream pin is captured by the core sha through go.mod, the fork pin by the hash of the build script.





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build Improvements**
  * Improved iOS and tvOS SDK build reliability by automatically verifying and installing compatible mobile build tools.
  * Standardized tool versions across SDK builds, including a pinned tvOS build tool revision.
  * Updated build caching to reflect the selected platform, Xcode version, and source configuration.
  * Removed redundant tool installation steps from automated build and test workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->