### PR TITLE
fix: do not abandon the login when the browser session ends on backgrounding

### DIFF
--- a/NetBird/Source/App/Views/Components/SafariView.swift
+++ b/NetBird/Source/App/Views/Components/SafariView.swift
@@ -17,11 +17,20 @@ struct SafariView: UIViewControllerRepresentable {
     @Binding var isPresented: Bool
     let url: URL
     /// Called when the web auth session ends (success, user cancel, or error).
+    ///
     /// Note: with the NetBird PKCE loopback flow the completion fires with a nil
     /// callbackURL even on success — the loopback redirect is consumed by the Go HTTP
     /// server, not the auth session — so the caller must determine success from the
     /// SDK's login callback, not from this handler.
-    let didFinish: () -> Void
+    ///
+    /// - Parameter interruptedByBackgrounding: true when the app was sent to the
+    ///   background while the session was open. iOS then ends the session with
+    ///   `canceledLogin`, which is indistinguishable from the user tapping Cancel,
+    ///   even though the login is still very much in progress. This happens on every
+    ///   login that requires leaving the app — switching to an authenticator app to
+    ///   approve a push, for instance. Treating it as a cancellation tears down the
+    ///   loopback server that the IdP redirect is about to arrive at.
+    let didFinish: (_ interruptedByBackgrounding: Bool) -> Void
 
     func makeUIViewController(context: Context) -> UIViewController {
         let vc = UIViewController()
@@ -41,9 +50,17 @@ struct SafariView: UIViewControllerRepresentable {
     class Coordinator: NSObject, ASWebAuthenticationPresentationContextProviding {
         let parent: SafariView
         private var session: ASWebAuthenticationSession?
+        private var backgroundObserver: NSObjectProtocol?
+        private var wentToBackground = false
 
         init(_ parent: SafariView) {
             self.parent = parent
+        }
+
+        deinit {
+            if let backgroundObserver {
+                NotificationCenter.default.removeObserver(backgroundObserver)
+            }
         }
 
         func startSession(from viewController: UIViewController) {
@@ -52,6 +69,16 @@ struct SafariView: UIViewControllerRepresentable {
             // follows it, so "http" works as a callback scheme in practice.
             // A proper long-term fix requires the SDK to expose a custom-scheme
             // redirect URI (e.g. "netbird://") for mobile OAuth flows.
+            // iOS ends the session with .canceledLogin when the app is backgrounded,
+            // so remember whether that happened before the completion fires.
+            backgroundObserver = NotificationCenter.default.addObserver(
+                forName: UIApplication.didEnterBackgroundNotification,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                self?.wentToBackground = true
+            }
+
             let completionHandler: ASWebAuthenticationSession.CompletionHandler = { [weak self] callbackURL, error in
                 guard let self else { return }
 
@@ -61,10 +88,16 @@ struct SafariView: UIViewControllerRepresentable {
                     }
                     if let error = error as? ASWebAuthenticationSessionError,
                        error.code == .canceledLogin {
-                        print("User cancelled login")
+                        print(self.wentToBackground
+                              ? "Auth session ended after the app was backgrounded"
+                              : "User cancelled login")
+                    }
+                    if let backgroundObserver = self.backgroundObserver {
+                        NotificationCenter.default.removeObserver(backgroundObserver)
+                        self.backgroundObserver = nil
                     }
                     self.parent.isPresented = false
-                    self.parent.didFinish()
+                    self.parent.didFinish(self.wentToBackground)
                 }
             }
 

--- a/NetBird/Source/App/Views/Components/SafariView.swift
+++ b/NetBird/Source/App/Views/Components/SafariView.swift
@@ -57,12 +57,18 @@ struct SafariView: UIViewControllerRepresentable {
             self.parent = parent
         }
 
+        /// Drops the backgrounding observer if the coordinator goes away before the
+        /// auth session completes.
         deinit {
             if let backgroundObserver {
                 NotificationCenter.default.removeObserver(backgroundObserver)
             }
         }
 
+        /// Presents the web authentication session for the login URL.
+        ///
+        /// - Parameter viewController: the just-presented controller the session is
+        ///   started from, once it is part of the window hierarchy.
         func startSession(from viewController: UIViewController) {
             // The NetBird SDK uses a PKCE flow with an http://localhost redirect URI.
             // ASWebAuthenticationSession intercepts that navigation before the browser

--- a/NetBird/Source/App/Views/iOS/iOSConnectionView.swift
+++ b/NetBird/Source/App/Views/iOS/iOSConnectionView.swift
@@ -155,12 +155,20 @@ struct iOSConnectionView: View {
                 SafariView(
                     isPresented: $viewModel.networkExtensionAdapter.showBrowser,
                     url: loginURL,
-                    didFinish: {
+                    didFinish: { interruptedByBackgrounding in
                         if viewModel.networkExtensionAdapter.loginSucceeded {
                             print("Finish login")
                             // The SDK just completed the management login, so the extension
                             // can skip its own needs-login check (one Login RPC) when it starts.
                             viewModel.networkExtensionAdapter.startVPNConnection(loginVerified: true)
+                        } else if interruptedByBackgrounding {
+                            // Not a cancellation: iOS ended the session because the app went
+                            // to the background, which is what any login involving another
+                            // app looks like. The flow is still running and its redirect is
+                            // still on its way, so give it time rather than killing it.
+                            viewModel.networkExtensionAdapter.deferLoginCancellation {
+                                viewModel.cancelPendingLogin()
+                            }
                         } else {
                             // User closed the browser without completing login. Do NOT start
                             // the VPN — that would launch the extension, trip its needs-login

--- a/NetbirdKit/NetworkExtensionAdapter.swift
+++ b/NetbirdKit/NetworkExtensionAdapter.swift
@@ -490,6 +490,13 @@ public class NetworkExtensionAdapter: ObservableObject {
         var observer: NSObjectProtocol?
     }
 
+    /// Runs the interactive OAuth login and hands the resulting URL to the browser.
+    ///
+    /// On iOS the flow deliberately runs in the main app rather than in the network
+    /// extension, whose context is cancelled when the tunnel is torn down after a
+    /// login-required failure — that would kill the loopback server before the OAuth
+    /// callback could reach it. Falls back to IPC with the extension on tvOS, or if
+    /// the SDK auth cannot be set up here.
     private func performLogin() async {
         #if os(iOS)
         // Run the OAuth flow in the main-app process using NetBirdSDKAuth.

--- a/NetbirdKit/NetworkExtensionAdapter.swift
+++ b/NetbirdKit/NetworkExtensionAdapter.swift
@@ -88,6 +88,12 @@ public class NetworkExtensionAdapter: ObservableObject {
     /// still allowed to finish. See deferLoginCancellation(onGiveUp:).
     private var awaitingDeferredLogin = false
 
+    /// Identifies the current login attempt. Bumped whenever an attempt starts or is
+    /// abandoned, so that a grace period armed for one attempt cannot act on another:
+    /// a user who retries within the grace period would otherwise have the newer login
+    /// cancelled by the older timer.
+    private var loginAttempt = 0
+
     /// How long an interrupted login may still complete before it is abandoned and
     /// its loopback port released. Comfortably covers a trip to an authenticator
     /// app, and stays well inside the SDK flow's own five-minute deadline.
@@ -521,6 +527,11 @@ public class NetworkExtensionAdapter: ObservableObject {
            let auth = NetBirdSDKNewAuth(configPath, activeManagementURL, nil) {
             self.pendingAuth = auth
             self.loginSucceeded = false
+
+            // A new attempt supersedes any grace period still running for a previous one.
+            loginAttempt &+= 1
+            awaitingDeferredLogin = false
+            let attempt = loginAttempt
             let urlOpener = MainAppLoginURLOpener()
             let errListener = MainAppLoginErrListener()
 
@@ -574,7 +585,7 @@ public class NetworkExtensionAdapter: ObservableObject {
                         // app is backgrounded, which is exactly what happens when the
                         // user leaves to approve an MFA push. Nobody is left to react to
                         // the login, so start the tunnel here instead.
-                        if self.awaitingDeferredLogin {
+                        if self.awaitingDeferredLogin, self.loginAttempt == attempt {
                             self.awaitingDeferredLogin = false
                             self.logger.info("login completed after the browser session had ended, starting the tunnel")
                             self.startVPNConnection(loginVerified: true)
@@ -640,9 +651,11 @@ public class NetworkExtensionAdapter: ObservableObject {
 
         logger.info("deferLoginCancellation: browser session ended while backgrounded, letting the login finish")
         awaitingDeferredLogin = true
+        let attempt = loginAttempt
 
         DispatchQueue.main.asyncAfter(deadline: .now() + Self.deferredLoginGracePeriod) { [weak self] in
-            guard let self, self.awaitingDeferredLogin else { return }
+            // Only act while this is still the attempt the grace period was armed for.
+            guard let self, self.awaitingDeferredLogin, self.loginAttempt == attempt else { return }
             self.awaitingDeferredLogin = false
 
             guard !self.loginSucceeded else { return }
@@ -658,6 +671,7 @@ public class NetworkExtensionAdapter: ObservableObject {
     /// trying to bind the same port until the previous flow expires.
     public func cancelLogin() {
         logger.info("cancelLogin: aborting in-progress login")
+        loginAttempt &+= 1
         awaitingDeferredLogin = false
         pendingAuth?.stop()
         pendingAuth = nil

--- a/NetbirdKit/NetworkExtensionAdapter.swift
+++ b/NetbirdKit/NetworkExtensionAdapter.swift
@@ -83,6 +83,15 @@ public class NetworkExtensionAdapter: ObservableObject {
     /// (the loopback redirect is consumed by the Go HTTP server, not the auth session),
     /// so the SafariView callback alone cannot distinguish success from cancellation.
     public private(set) var loginSucceeded = false
+
+    /// True while a login whose browser session was cut short by backgrounding is
+    /// still allowed to finish. See deferLoginCancellation(onGiveUp:).
+    private var awaitingDeferredLogin = false
+
+    /// How long an interrupted login may still complete before it is abandoned and
+    /// its loopback port released. Comfortably covers a trip to an authenticator
+    /// app, and stays well inside the SDK flow's own five-minute deadline.
+    private static let deferredLoginGracePeriod: TimeInterval = 90
     #endif
     @Published var userCode: String?
 
@@ -557,8 +566,19 @@ public class NetworkExtensionAdapter: ObservableObject {
                     // observes it and starts the VPN instead of treating the browser
                     // dismissal as a cancellation.
                     DispatchQueue.main.async {
-                        self?.loginSucceeded = true
-                        self?.pendingAuth = nil
+                        guard let self else { return }
+                        self.loginSucceeded = true
+                        self.pendingAuth = nil
+
+                        // The browser session may already be gone: iOS ends it when the
+                        // app is backgrounded, which is exactly what happens when the
+                        // user leaves to approve an MFA push. Nobody is left to react to
+                        // the login, so start the tunnel here instead.
+                        if self.awaitingDeferredLogin {
+                            self.awaitingDeferredLogin = false
+                            self.logger.info("login completed after the browser session had ended, starting the tunnel")
+                            self.startVPNConnection(loginVerified: true)
+                        }
                     }
                 }
                 errListener.onSuccessCallback = { urlOpener.onSuccess?() }
@@ -604,6 +624,33 @@ public class NetworkExtensionAdapter: ObservableObject {
     }
 
     #if os(iOS)
+    /// Keeps an interrupted login alive for a grace period instead of aborting it.
+    ///
+    /// iOS ends an ASWebAuthenticationSession with `canceledLogin` whenever the app is
+    /// backgrounded, and that is indistinguishable from the user tapping Cancel. Any
+    /// login that sends the user to another app — approving an MFA push, fetching a
+    /// one-time code — therefore looks like a cancellation. Acting on it tears down
+    /// the loopback server just as the IdP redirect carrying the authorization code is
+    /// about to reach it, and the browser is left reporting that it cannot connect.
+    ///
+    /// So let the flow run on. If the code arrives, onSuccess starts the tunnel; if
+    /// nothing arrives within the grace period, give up and free the port.
+    public func deferLoginCancellation(onGiveUp: @escaping () -> Void) {
+        guard !loginSucceeded else { return }
+
+        logger.info("deferLoginCancellation: browser session ended while backgrounded, letting the login finish")
+        awaitingDeferredLogin = true
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.deferredLoginGracePeriod) { [weak self] in
+            guard let self, self.awaitingDeferredLogin else { return }
+            self.awaitingDeferredLogin = false
+
+            guard !self.loginSucceeded else { return }
+            self.logger.info("deferLoginCancellation: nothing arrived within the grace period, abandoning the login")
+            onGiveUp()
+        }
+    }
+
     /// Aborts an in-progress interactive login (e.g. the user dismissed the OAuth
     /// browser without completing it). Stopping the SDK auth cancels its context,
     /// which unblocks the PKCE WaitToken and shuts down the loopback HTTP server so
@@ -611,6 +658,7 @@ public class NetworkExtensionAdapter: ObservableObject {
     /// trying to bind the same port until the previous flow expires.
     public func cancelLogin() {
         logger.info("cancelLogin: aborting in-progress login")
+        awaitingDeferredLogin = false
         pendingAuth?.stop()
         pendingAuth = nil
         loginSucceeded = false


### PR DESCRIPTION
## Description

Any interactive login that sends the user to another app is treated as a cancellation and torn down. The user comes back to "Safari cannot open the page because it could not connect to the server" on the loopback URL — on a login that had already succeeded on the IdP side.

This hits every login that cannot be completed without leaving the app: approving an MFA push, copying a one-time code from an authenticator, opening a link from a message. On a phone that receives its own MFA push, that is the normal path, not an edge case.

Reproduced on iPhone 15 / iOS 26.1 against a self-hosted deployment with push MFA, on a build of `main`, and verified fixed with the same build plus this change.

### Steps to reproduce

1. Configure an IdP whose login requires leaving the app — an MFA push approved in a separate app is the easiest.
2. Tap Connect and enter credentials in the browser sheet.
3. Switch to the authenticator app, approve the push, and return to NetBird.

The browser sheet shows that it could not connect to `http://localhost:53000`. The login has to be started over, and it fails the same way on most attempts.

### Cause

`ASWebAuthenticationSession` completes with `.canceledLogin` whenever the host app is backgrounded. That is indistinguishable from the user tapping Cancel, and `SafariView`'s completion handler treats both the same way. `iOSConnectionView` then calls `cancelPendingLogin()` → `cancelLogin()` → `pendingAuth?.stop()`, which cancels the SDK's auth context and shuts down the PKCE loopback HTTP server.

The IdP redirect carrying the authorization code arrives moments later at a closed port.

Whether a login survives is a race between that redirect and the teardown. Device log across four attempts — three lost, one won:

```
isLoginRequired: SDK returned true
User cancelled login
Login cancelled by user
isLoginRequired: SDK returned true
User cancelled login
Login cancelled by user
isLoginRequired: SDK returned true
User cancelled login
Finish login              <- the code reached the loopback server just in time
```

May well be behind #184, where the login popup appears daily and tapping Login does nothing.

### Change

`SafariView` observes `UIApplication.didEnterBackgroundNotification` for the lifetime of the session and reports, through `didFinish`, whether the app was backgrounded before the session ended.

A genuine dismissal aborts exactly as before. An interrupted one no longer cancels anything: the flow is left running for a grace period of 90 seconds, comfortably inside the SDK flow's own five-minute deadline. If the code arrives, the SDK's success callback starts the tunnel itself — the browser session that used to do that on dismissal is gone by then. If nothing arrives, the login is abandoned and the loopback port released, as before.

### Not covered here

The grace period is a constant rather than a setting; 90 seconds was picked to cover a trip to an authenticator app without holding the port for long. Happy to make it configurable if you'd prefer.

tvOS is unaffected — `TVAuthView` does not use `ASWebAuthenticationSession`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved iOS sign-in handling when the app moves to the background during browser-based authentication.
  - Login flows interrupted by backgrounding, such as during MFA approval, can now resume instead of being incorrectly canceled.
  - Added a brief grace period for completing interrupted sign-ins.
  - Genuine cancellations continue to close the login flow immediately.
  - Successful authentication now starts the VPN connection as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->