### PR TITLE
fix: stop using an ephemeral browser session for the OAuth login

### DIFF
--- a/NetBird/Source/App/Views/Components/SafariView.swift
+++ b/NetBird/Source/App/Views/Components/SafariView.swift
@@ -83,8 +83,21 @@ struct SafariView: UIViewControllerRepresentable {
                 )
             }
 
-            // Ephemeral = no shared cookies, fresh login every time
-            session.prefersEphemeralWebBrowserSession = true
+            // Deliberately NOT ephemeral. An ephemeral session starts with an empty
+            // cookie jar on every login, and Keycloak's login theme reacts to that by
+            // starting the session poll in authChecker.js — it only skips it when a
+            // KEYCLOAK_SESSION cookie is already present ("if (initialSession) return").
+            // That poll is what races the redirect carrying the authorization code and
+            // bounces the browser to /login-actions/restart, which answers
+            // ALREADY_LOGGED_IN and fails the login with authentication_expired. Safari
+            // on iOS never fires beforeunload (WebKit bug 219102), so Keycloak's own
+            // safeguard against that race does not apply here.
+            //
+            // Persisting cookies keeps the IdP session across logins, so the poll never
+            // starts from the second login onwards. The trade-off is that a logout no
+            // longer clears the IdP session for the next profile, which matters for
+            // multi-profile setups against different accounts.
+            session.prefersEphemeralWebBrowserSession = false
             session.presentationContextProvider = self
             self.session = session
             session.start()

--- a/NetBird/Source/App/Views/Components/SafariView.swift
+++ b/NetBird/Source/App/Views/Components/SafariView.swift
@@ -83,21 +83,25 @@ struct SafariView: UIViewControllerRepresentable {
                 )
             }
 
-            // Deliberately NOT ephemeral. An ephemeral session starts with an empty
-            // cookie jar on every login, and Keycloak's login theme reacts to that by
-            // starting the session poll in authChecker.js — it only skips it when a
-            // KEYCLOAK_SESSION cookie is already present ("if (initialSession) return").
-            // That poll is what races the redirect carrying the authorization code and
-            // bounces the browser to /login-actions/restart, which answers
-            // ALREADY_LOGGED_IN and fails the login with authentication_expired. Safari
-            // on iOS never fires beforeunload (WebKit bug 219102), so Keycloak's own
-            // safeguard against that race does not apply here.
+            // An ephemeral session hands the IdP an empty cookie jar on every login.
+            // Keycloak's login theme reacts to that by starting the session poll in
+            // authChecker.js — it only skips it when a KEYCLOAK_SESSION cookie is
+            // already present ("if (initialSession) return"). That poll races the
+            // redirect carrying the authorization code and bounces the browser to
+            // /login-actions/restart, which answers ALREADY_LOGGED_IN and fails the
+            // login with authentication_expired. Safari on iOS never fires
+            // beforeunload (WebKit bug 219102), so Keycloak's own safeguard against
+            // that race never applies, and every login becomes a race against a
+            // two-second timer.
             //
-            // Persisting cookies keeps the IdP session across logins, so the poll never
-            // starts from the second login onwards. The trade-off is that a logout no
-            // longer clears the IdP session for the next profile, which matters for
-            // multi-profile setups against different accounts.
-            session.prefersEphemeralWebBrowserSession = false
+            // Persisting cookies avoids that, but it also means a logout no longer
+            // clears the IdP session — which is what keeps profiles signed into
+            // different accounts apart. So keep the ephemeral session exactly where it
+            // still buys something: when the server does not already force a fresh
+            // authentication. With prompt=login or max_age=0 the IdP re-authenticates
+            // regardless of any live session, so the empty jar protects nothing and
+            // only costs reliability.
+            session.prefersEphemeralWebBrowserSession = !parent.url.forcesReauthentication
             session.presentationContextProvider = self
             self.session = session
             session.start()
@@ -116,4 +120,22 @@ struct SafariView: UIViewControllerRepresentable {
         }
     }
 }
+
+private extension URL {
+    /// Whether this authorization request asks the IdP to authenticate the user afresh,
+    /// ignoring any existing session.
+    ///
+    /// The SDK adds `prompt=login` or `max_age=0` according to the login flag the
+    /// management server sends (`LoginFlagPromptLogin` by default), so the request URL
+    /// already carries the answer and nothing needs plumbing through the SDK.
+    var forcesReauthentication: Bool {
+        guard let items = URLComponents(url: self, resolvingAgainstBaseURL: false)?.queryItems else {
+            return false
+        }
+        return items.contains { item in
+            (item.name == "prompt" && item.value == "login") || (item.name == "max_age" && item.value == "0")
+        }
+    }
+}
+
 #endif


### PR DESCRIPTION
## Description

Raised with @braginini on Telegram along with #203; opening this one with the design question below still open, so the direction can be settled here rather than over chat.

Against Keycloak, interactive login on iOS fails most of the time with:

```
authentication failed: authentication_expired
```

Users retry Connect until one attempt sticks. Worst measured run: **12 consecutive failures before a login went through**. With this change, 5 out of 5 succeed.

This is iOS-only. Desktop and Android clients against the same Keycloak realm never see it, and the reason turns out to be the ephemeral browser session rather than anything platform-specific in the flow itself.

Reproduced on iPhone 15 / iOS 26.1 against Keycloak 26.5.7 with push MFA, on a build of `main`, and verified fixed with the same build plus this change.

### Steps to reproduce

1. Point a profile at a Keycloak-backed deployment.
2. Tap Connect, complete the login in the browser sheet.
3. Repeat. Most attempts end with `authentication_expired` rather than a connected tunnel.

### Cause

Keycloak's login theme loads `authChecker.js` on every login page. It polls for a session every two seconds and, the moment one appears, navigates to `/login-actions/restart` — cancelling the in-flight redirect that carries the authorization code. Keycloak answers that restart with `ALREADY_LOGGED_IN`, which `OIDCLoginProtocol.translateError` maps to `temporarily_unavailable` / `authentication_expired`, and that is what reaches the loopback server.

Keycloak guards against this with a `beforeunload` handler, and Safari on iOS never fires it. Their own source says so, referencing [WebKit 219102](https://bugs.webkit.org/show_bug.cgi?id=219102):

```js
// Stop polling for a session when a form is submitted to prevent unexpected redirects.
// This is required as Safari does not support the 'beforeunload' event properly.
forms.forEach((form) => form.addEventListener("submit", () => stopSessionPolling()));
```

That secondary guard ([keycloak#35143](https://github.com/keycloak/keycloak/pull/35143), fixing [keycloak#33071](https://github.com/keycloak/keycloak/issues/33071)) attaches listeners to `Array.from(document.forms)` captured at module load, so it misses forms that MFA plugins build dynamically — which is our case.

What makes it an iOS-only problem is the third line of that file:

```js
const initialSession = getSession();   // KEYCLOAK_SESSION cookie
...
export function startSessionPolling(redirectUrl) {
  if (initialSession) return;          // no cookie, no early exit
```

`SafariView` sets `prefersEphemeralWebBrowserSession = true`, so Keycloak receives an empty cookie jar on **every** login. `initialSession` is always null, the poll always starts, and every login becomes a race against a two-second timer. Desktop and Android keep their cookies and take the early exit.

### Change

Keep the ephemeral session wherever it still protects something, and drop it only where it does not.

`prefersEphemeralWebBrowserSession` exists for multi-profile support: `logoutProfile` only deletes the local `config` and `state` files, so with a persistent session a logout no longer clears the IdP session for the next profile — and a profile could end up reusing whichever account is signed in.

That only holds when the server does not already force a fresh authentication. With `prompt=login` or `max_age=0` the IdP re-authenticates regardless of any live session, so the empty cookie jar protects nothing there and only costs reliability.

The authorization URL already carries the answer — the SDK puts those parameters in according to the management server's login flag (`LoginFlagPromptLogin` by default), so nothing needs plumbing through the SDK:

```swift
session.prefersEphemeralWebBrowserSession = !parent.url.forcesReauthentication
```

So deployments that force re-authentication (the default) get reliable logins, and deployments that do not keep the isolation they rely on today.

Verified on the strictest setup available to us: two NetBird servers sharing one Keycloak realm, so both profiles share a cookie jar. Switching profiles still presented the login form and MFA every time.

One user-visible cost where the session is no longer ephemeral: the system consent dialog ("NetBird wants to use <domain> to sign in") appears on each login.

### Alternative we tried and discarded

Retrying the authorization request client-side on `authentication_expired`, as Keycloak's own guidance prescribes: the loopback server answers `302` to a fresh authorization request with `prompt=none`. Implemented in the Go core, tested on device — **it does not work on iOS**. The browser session is closed by the OS at exactly that moment, so the redirect is never followed. It would need the platform to reopen the browser through a callback, and with an ephemeral jar the retry starts from an empty cookie jar anyway, so `prompt=none` returns `login_required` and the user is shown the form again.
