### PR TITLE
Mdm integration

### DIFF
--- a/NetBird.xcodeproj/project.pbxproj
+++ b/NetBird.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		443782C82EDF288A00F9FA94 /* TVMainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 443782C02EDF288A00F9FA94 /* TVMainView.swift */; };
 		443782C92EDF293400F9FA94 /* NetBirdApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50A8911A2A792A15007C48FC /* NetBirdApp.swift */; };
 		443782CA2EDF296500F9FA94 /* MainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50A8911C2A792A15007C48FC /* MainView.swift */; };
+		AA000F012F22000F00000001 /* MDMManagedNotice.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000F002F22000F00000001 /* MDMManagedNotice.swift */; };
 		443782CC2EDF298B00F9FA94 /* PeerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50D402962BD9B89300D4AC5B /* PeerViewModel.swift */; };
 		443782CD2EDF298B00F9FA94 /* MainViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50E608122A7958B100BAF09B /* MainViewModel.swift */; };
 		443782CE2EDF298B00F9FA94 /* RoutesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 509CCD692BE908C000B7C2D8 /* RoutesViewModel.swift */; };
@@ -117,6 +118,7 @@
 		E1D0E0032F80000200000001 /* ExitNodeSelectorCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1D0E0022F80000200000001 /* ExitNodeSelectorCard.swift */; };
 		50A8911B2A792A15007C48FC /* NetBirdApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50A8911A2A792A15007C48FC /* NetBirdApp.swift */; };
 		50A8911D2A792A15007C48FC /* MainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50A8911C2A792A15007C48FC /* MainView.swift */; };
+		AA000F022F22000F00000001 /* MDMManagedNotice.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000F002F22000F00000001 /* MDMManagedNotice.swift */; };
 		50A8911F2A792A16007C48FC /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 50A8911E2A792A16007C48FC /* Assets.xcassets */; };
 		50BB17412C30239400518BCA /* RouteCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50BB17402C30239400518BCA /* RouteCard.swift */; };
 		50C5D30F2BDD96CF003159BE /* RoutesSelectionDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50C5D30E2BDD96CF003159BE /* RoutesSelectionDetails.swift */; };
@@ -153,6 +155,8 @@
 		55D865982F70982100A2EFF8 /* NetBirdWidgetExtensionExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 55D865832F70982000A2EFF8 /* NetBirdWidgetExtensionExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		71DD928A21BE4943BB0FEC1D /* iOSNetworksView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A1CFF65CC44187912007EC /* iOSNetworksView.swift */; };
 		94F739DA3E076313908BA6DF /* GlobalConstantsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E054D83063E440DAD0C52FA /* GlobalConstantsTests.swift */; };
+		AA0011012F22001100000001 /* MDMBridgeIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0011002F22001100000001 /* MDMBridgeIntegrationTests.swift */; };
+		AA0010012F22001000000001 /* MDMRestrictionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0010002F22001000000001 /* MDMRestrictionsTests.swift */; };
 		962925F1DAA24D40B98D395B /* iOSPeersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42873052F9544A89B1408339 /* iOSPeersView.swift */; };
 		978FC4702EEDF167002D0EB8 /* AppLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 978FC46F2EEDF167002D0EB8 /* AppLogger.swift */; };
 		978FC4712EEDF167002D0EB8 /* AppLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 978FC46F2EEDF167002D0EB8 /* AppLogger.swift */; };
@@ -178,9 +182,17 @@
 		AA0001032F22000100000001 /* ProfileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0001002F22000100000001 /* ProfileManager.swift */; };
 		AA0001042F22000100000001 /* ProfileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0001002F22000100000001 /* ProfileManager.swift */; };
 		AA000A012F22000A00000001 /* ProfileLayoutMigration.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000A002F22000A00000001 /* ProfileLayoutMigration.swift */; };
+		AA000D012F22000D00000001 /* MDMPolicyFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000D002F22000D00000001 /* MDMPolicyFetcher.swift */; };
+		AA000E012F22000E00000001 /* MDMRestrictions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000E002F22000E00000001 /* MDMRestrictions.swift */; };
 		AA000A022F22000A00000001 /* ProfileLayoutMigration.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000A002F22000A00000001 /* ProfileLayoutMigration.swift */; };
+		AA000D022F22000D00000001 /* MDMPolicyFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000D002F22000D00000001 /* MDMPolicyFetcher.swift */; };
+		AA000E022F22000E00000001 /* MDMRestrictions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000E002F22000E00000001 /* MDMRestrictions.swift */; };
 		AA000A032F22000A00000001 /* ProfileLayoutMigration.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000A002F22000A00000001 /* ProfileLayoutMigration.swift */; };
+		AA000D032F22000D00000001 /* MDMPolicyFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000D002F22000D00000001 /* MDMPolicyFetcher.swift */; };
+		AA000E032F22000E00000001 /* MDMRestrictions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000E002F22000E00000001 /* MDMRestrictions.swift */; };
 		AA000A042F22000A00000001 /* ProfileLayoutMigration.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000A002F22000A00000001 /* ProfileLayoutMigration.swift */; };
+		AA000D042F22000D00000001 /* MDMPolicyFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000D002F22000D00000001 /* MDMPolicyFetcher.swift */; };
+		AA000E042F22000E00000001 /* MDMRestrictions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000E002F22000E00000001 /* MDMRestrictions.swift */; };
 		AA000B012F22000B00000001 /* ProfileMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000B002F22000B00000001 /* ProfileMigrationTests.swift */; };
 		AA0002052F22000200000001 /* ProfileBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0002012F22000200000001 /* ProfileBadge.swift */; };
 		AA0002062F22000200000001 /* ProfilesListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0002022F22000200000001 /* ProfilesListView.swift */; };
@@ -287,6 +299,8 @@
 /* Begin PBXFileReference section */
 		2F8A4B98A775451786C5DDF8 /* iOSSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOSSettingsView.swift; sourceTree = "<group>"; };
 		3E054D83063E440DAD0C52FA /* GlobalConstantsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GlobalConstantsTests.swift; sourceTree = "<group>"; };
+		AA0011002F22001100000001 /* MDMBridgeIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MDMBridgeIntegrationTests.swift; sourceTree = "<group>"; };
+		AA0010002F22001000000001 /* MDMRestrictionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MDMRestrictionsTests.swift; sourceTree = "<group>"; };
 		42873052F9544A89B1408339 /* iOSPeersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOSPeersView.swift; sourceTree = "<group>"; };
 		441C5AEE2EDF0DAE0055EEFC /* NetBird TV.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "NetBird TV.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		441C5AFD2EDF0DD20055EEFC /* NetBirdTVNetworkExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = NetBirdTVNetworkExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -339,6 +353,7 @@
 		50A891172A792A15007C48FC /* NetBird.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = NetBird.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		50A8911A2A792A15007C48FC /* NetBirdApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetBirdApp.swift; sourceTree = "<group>"; };
 		50A8911C2A792A15007C48FC /* MainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainView.swift; sourceTree = "<group>"; };
+		AA000F002F22000F00000001 /* MDMManagedNotice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MDMManagedNotice.swift; sourceTree = "<group>"; };
 		50A8911E2A792A16007C48FC /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		50BB17402C30239400518BCA /* RouteCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteCard.swift; sourceTree = "<group>"; };
 		50C5D30E2BDD96CF003159BE /* RoutesSelectionDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutesSelectionDetails.swift; sourceTree = "<group>"; };
@@ -375,6 +390,8 @@
 		A1C3D5E82F000002001A2B3C /* CellularOnDemandPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CellularOnDemandPolicy.swift; sourceTree = "<group>"; };
 		AA0001002F22000100000001 /* ProfileManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileManager.swift; sourceTree = "<group>"; };
 		AA000A002F22000A00000001 /* ProfileLayoutMigration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileLayoutMigration.swift; sourceTree = "<group>"; };
+		AA000D002F22000D00000001 /* MDMPolicyFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MDMPolicyFetcher.swift; sourceTree = "<group>"; };
+		AA000E002F22000E00000001 /* MDMRestrictions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MDMRestrictions.swift; sourceTree = "<group>"; };
 		AA000B002F22000B00000001 /* ProfileMigrationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ProfileMigrationTests.swift; sourceTree = "<group>"; };
 		AA0002012F22000200000001 /* ProfileBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileBadge.swift; sourceTree = "<group>"; };
 		AA0002022F22000200000001 /* ProfilesListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfilesListView.swift; sourceTree = "<group>"; };
@@ -628,6 +645,8 @@
 				AA0001002F22000100000001 /* ProfileManager.swift */,
 				AA0009002F22000900000001 /* ProfileConnectionCache.swift */,
 				AA000A002F22000A00000001 /* ProfileLayoutMigration.swift */,
+				AA000D002F22000D00000001 /* MDMPolicyFetcher.swift */,
+				AA000E002F22000E00000001 /* MDMRestrictions.swift */,
 				A1B2C3D42EEDF500001A2B3C /* ConfigurationProvider.swift */,
 				50245A2D2A7BDC470034792B /* NetworkChangeListener.swift */,
 				50CD81612AD0595E00CF830B /* DNSManager.swift */,
@@ -680,6 +699,7 @@
 		50E608092A79557A00BAF09B /* Components */ = {
 			isa = PBXGroup;
 			children = (
+				AA000F002F22000F00000001 /* MDMManagedNotice.swift */,
 				50CD81AF2AD5B94D00CF830B /* PeerCard.swift */,
 				B1A2C3D32F3A000100000001 /* PeerDetailSheet.swift */,
 				508BD8442AF04A990055E415 /* SafariView.swift */,
@@ -721,6 +741,8 @@
 			isa = PBXGroup;
 			children = (
 				3E054D83063E440DAD0C52FA /* GlobalConstantsTests.swift */,
+				AA0011002F22001100000001 /* MDMBridgeIntegrationTests.swift */,
+				AA0010002F22001000000001 /* MDMRestrictionsTests.swift */,
 				8AA7193B3AE82DF185EDEB1B /* AppLoggerTests.swift */,
 				53CB9305A9DC6CAD1895495A /* SharedUserDefaultsTests.swift */,
 				AA000B002F22000B00000001 /* ProfileMigrationTests.swift */,
@@ -1082,6 +1104,8 @@
 				443782D12EDF29A800F9FA94 /* Preferences.swift in Sources */,
 				AA0001012F22000100000001 /* ProfileManager.swift in Sources */,
 				AA000A012F22000A00000001 /* ProfileLayoutMigration.swift in Sources */,
+				AA000D012F22000D00000001 /* MDMPolicyFetcher.swift in Sources */,
+				AA000E012F22000E00000001 /* MDMRestrictions.swift in Sources */,
 				AA0009012F22000900000001 /* ProfileConnectionCache.swift in Sources */,
 				A1B2C3D52EEDF501001A2B3C /* ConfigurationProvider.swift in Sources */,
 				443782D42EDF29A800F9FA94 /* RoutesSelectionDetails.swift in Sources */,
@@ -1090,6 +1114,7 @@
 				443782D72EDF29A800F9FA94 /* NetworkExtensionAdapter.swift in Sources */,
 				443782BF2EDF284A00F9FA94 /* Platform.swift in Sources */,
 				443782CA2EDF296500F9FA94 /* MainView.swift in Sources */,
+				AA000F012F22000F00000001 /* MDMManagedNotice.swift in Sources */,
 				443782CC2EDF298B00F9FA94 /* PeerViewModel.swift in Sources */,
 				443782CD2EDF298B00F9FA94 /* MainViewModel.swift in Sources */,
 				443782CE2EDF298B00F9FA94 /* RoutesViewModel.swift in Sources */,
@@ -1128,6 +1153,8 @@
 				44F3E3922EE2151100C87FEC /* Preferences.swift in Sources */,
 				AA0001022F22000100000001 /* ProfileManager.swift in Sources */,
 				AA000A022F22000A00000001 /* ProfileLayoutMigration.swift in Sources */,
+				AA000D022F22000D00000001 /* MDMPolicyFetcher.swift in Sources */,
+				AA000E022F22000E00000001 /* MDMRestrictions.swift in Sources */,
 				AA0009022F22000900000001 /* ProfileConnectionCache.swift in Sources */,
 				A1B2C3D72EEDF503001A2B3C /* ConfigurationProvider.swift in Sources */,
 				44F3E3932EE2151100C87FEC /* NetworkExtensionAdapter.swift in Sources */,
@@ -1149,6 +1176,8 @@
 				50213A2D2A8D0AA30031D993 /* Preferences.swift in Sources */,
 				AA0001032F22000100000001 /* ProfileManager.swift in Sources */,
 				AA000A032F22000A00000001 /* ProfileLayoutMigration.swift in Sources */,
+				AA000D032F22000D00000001 /* MDMPolicyFetcher.swift in Sources */,
+				AA000E032F22000E00000001 /* MDMRestrictions.swift in Sources */,
 				AA0009032F22000900000001 /* ProfileConnectionCache.swift in Sources */,
 				50CD81A82AD5504B00CF830B /* StatusDetails.swift in Sources */,
 				F1B2920B2EE0BC46001D91B8 /* GlobalConstants.swift in Sources */,
@@ -1172,6 +1201,7 @@
 				50CD84362AD82F9400CF830B /* ServerView.swift in Sources */,
 				50C5D30F2BDD96CF003159BE /* RoutesSelectionDetails.swift in Sources */,
 				50A8911D2A792A15007C48FC /* MainView.swift in Sources */,
+				AA000F022F22000F00000001 /* MDMManagedNotice.swift in Sources */,
 				50CD814F2AD0355000CF830B /* PacketTunnelProviderSettingsManager.swift in Sources */,
 				50C78AEA2A82C858006E898D /* Device.swift in Sources */,
 				509CCD6A2BE908C000B7C2D8 /* RoutesViewModel.swift in Sources */,
@@ -1204,6 +1234,8 @@
 				50216D892ACB18EE009574C9 /* Preferences.swift in Sources */,
 				AA0001042F22000100000001 /* ProfileManager.swift in Sources */,
 				AA000A042F22000A00000001 /* ProfileLayoutMigration.swift in Sources */,
+				AA000D042F22000D00000001 /* MDMPolicyFetcher.swift in Sources */,
+				AA000E042F22000E00000001 /* MDMRestrictions.swift in Sources */,
 				AA0009042F22000900000001 /* ProfileConnectionCache.swift in Sources */,
 				A1B2C3D62EEDF502001A2B3C /* ConfigurationProvider.swift in Sources */,
 				50CD81B02AD5B94D00CF830B /* PeerCard.swift in Sources */,
@@ -1242,6 +1274,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				94F739DA3E076313908BA6DF /* GlobalConstantsTests.swift in Sources */,
+				AA0011012F22001100000001 /* MDMBridgeIntegrationTests.swift in Sources */,
+				AA0010012F22001000000001 /* MDMRestrictionsTests.swift in Sources */,
 				9CC0E000AE3F165CA72FD465 /* AppLoggerTests.swift in Sources */,
 				1C9E4E97130030CE0D6C8F59 /* SharedUserDefaultsTests.swift in Sources */,
 				AA000B012F22000B00000001 /* ProfileMigrationTests.swift in Sources */,

--- a/NetBird/Source/App/NetBirdApp.swift
+++ b/NetBird/Source/App/NetBirdApp.swift
@@ -204,6 +204,7 @@ struct NetBirdApp: App {
             viewModel.checkExtensionState()
             #if os(iOS)
             viewModel.checkLoginRequiredFlag()
+            viewModel.checkMDMPolicyAppliedFlag()
             #endif
             viewModel.startPollingDetails()
         }

--- a/NetBird/Source/App/NetBirdApp.swift
+++ b/NetBird/Source/App/NetBirdApp.swift
@@ -205,6 +205,13 @@ struct NetBirdApp: App {
             #if os(iOS)
             viewModel.checkLoginRequiredFlag()
             viewModel.checkMDMPolicyAppliedFlag()
+            // The OS writes managed configuration from another process, and
+            // UserDefaults.didChangeNotification does not cross that boundary,
+            // so the in-process observer never fires for it. Re-read on every
+            // activation, which is when a policy pushed while the app was away
+            // has to take effect - not least so disableAutoConnect disarms the
+            // On Demand rules.
+            viewModel.refreshMDMRestrictions()
             #endif
             viewModel.startPollingDetails()
         }

--- a/NetBird/Source/App/ViewModels/MainViewModel.swift
+++ b/NetBird/Source/App/ViewModels/MainViewModel.swift
@@ -688,7 +688,10 @@ class ViewModel: ObservableObject {
 
         applyRouteSideEffects(for: status)
 
-        if status == .connected, connectOnDemand {
+        // `connectOnDemand` is the user's saved preference, which the policy
+        // deliberately leaves intact so it can be restored later - so it is
+        // not on its own permission to arm the rules.
+        if status == .connected, connectOnDemand, !autoConnectForbiddenByPolicy {
             networkExtensionAdapter.setOnDemandEnabled(true)
         }
     }
@@ -854,6 +857,16 @@ class ViewModel: ObservableObject {
 
     // Only iOS subscribes to the managed-config change channel; the tvOS
     // screens re-read the snapshot in onAppear instead.
+    /// Whether the policy forbids the daemon from connecting on its own.
+    ///
+    /// Every path that arms the VPN profile's On Demand rules has to consult
+    /// this, not just the user's preference: the rules live in the OS profile
+    /// and outlive any single connection, so one unguarded re-arm restores
+    /// automatic connection for good.
+    private var autoConnectForbiddenByPolicy: Bool {
+        mdmRestrictions.mdm.disableAutoConnect
+    }
+
     /// Arms or disarms the VPN profile's On Demand rules to match the policy.
     ///
     /// `disableAutoConnect` forbids connecting without the user asking, but On
@@ -1013,6 +1026,14 @@ class ViewModel: ObservableObject {
     ///   (applied, or nothing needed arming), `false` when the manager refused it. Callers
     ///   that depend on the change — disconnecting, wiping the config — must wait for it.
     func setConnectOnDemand(isEnabled: Bool, completion: ((Bool) -> Void)? = nil) {
+        // Backstop behind the locked control: the rules must not be armed
+        // while the policy forbids automatic connection, whatever route got
+        // here.
+        if isEnabled, autoConnectForbiddenByPolicy {
+            AppLogger.shared.log("MDM: refusing to arm On Demand while disableAutoConnect is enforced")
+            completion?(false)
+            return
+        }
         let previous = connectOnDemand
         let userDefaults = UserDefaults(suiteName: GlobalConstants.userPreferencesSuiteName)
         userDefaults?.set(isEnabled, forKey: GlobalConstants.keyConnectOnDemand)

--- a/NetBird/Source/App/ViewModels/MainViewModel.swift
+++ b/NetBird/Source/App/ViewModels/MainViewModel.swift
@@ -143,6 +143,14 @@ class ViewModel: ObservableObject {
     @Published var onDemandWiFiNetworks: [String] = []
     @Published var knownSSIDs: [String] = []
     @Published var showRosenpassChangedAlert = false
+    /// MDM enforcement snapshot rendered by the Go layer. `.empty` means no
+    /// policy is in force, which is also the state on any read failure - a
+    /// broken policy must not lock the user out of their own settings.
+    @Published var mdmRestrictions: MDMRestrictions = .empty
+    @Published var showSettingsRejectedAlert = false
+    @Published var showMDMPolicyAppliedToast = false
+    /// Reason shown by the settings-rejected alert.
+    var settingsRejectedMessage = ""
     @Published var networkUnavailable = false
     @Published var isInternetConnected = true
 
@@ -181,6 +189,8 @@ class ViewModel: ObservableObject {
     private let monitorQueue = DispatchQueue(label: "io.netbird.networkMonitor")
     #if os(iOS)
     private var vpnStatusObserver: NSObjectProtocol?
+    private var mdmConfigObserver: NSObjectProtocol?
+    private var mdmRefreshWorkItem: DispatchWorkItem?
     #endif
     
     @Published var peerViewModel: PeerViewModel
@@ -233,6 +243,20 @@ class ViewModel: ObservableObject {
             queue: .main
         ) { [weak self] _ in
             self?.handleVPNStatusChangeForNotification()
+        }
+
+        // The OS delivers MDM managed-configuration pushes through the shared
+        // UserDefaults change channel, which also fires on every unrelated
+        // preference write. The main app has no restart decision to make - it
+        // only re-reads the snapshot - so a short debounce is enough here. The
+        // engine-restart decision lives in the extension, where Go's
+        // hasMDMPolicyChanged() does the real diffing.
+        mdmConfigObserver = NotificationCenter.default.addObserver(
+            forName: UserDefaults.didChangeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.scheduleMDMRestrictionsRefresh()
         }
         #endif
 
@@ -747,8 +771,8 @@ class ViewModel: ObservableObject {
     // MARK: - Configuration Methods (via ConfigurationProvider)
 
     func updatePreSharedKey() {
-        configProvider.preSharedKey = presharedKey
-        if configProvider.commit() {
+        configProvider.setPreSharedKey(presharedKey)
+        if commitSettings() {
             // tvOS: bypass the On Demand disconnect prompt. The user changed a setting that
             // needs a reconnect, not asked to stay offline — letting On Demand bring the
             // tunnel back with the new key is the intended outcome (and the prompt would be
@@ -767,8 +791,8 @@ class ViewModel: ObservableObject {
 
     func removePreSharedKey() {
         presharedKey = ""
-        configProvider.preSharedKey = ""
-        if configProvider.commit() {
+        configProvider.setPreSharedKey("")
+        if commitSettings() {
             #if os(tvOS)
             self.performClose()
             #else
@@ -780,8 +804,60 @@ class ViewModel: ObservableObject {
         }
     }
 
+    /// Commits staged settings and turns an MDM rejection into an explanation.
+    ///
+    /// Preferences.commit() refuses a staged value that diverges from a
+    /// managed key. That is a backstop, not the primary UX - the control
+    /// should already have been locked - so reaching it means this process
+    /// held a stale view of the policy, and the snapshot is re-read.
+    @discardableResult
+    private func commitSettings() -> Bool {
+        if configProvider.commit() {
+            return true
+        }
+        let reason = configProvider.lastCommitError ?? ""
+        refreshMDMRestrictions()
+        if reason.localizedCaseInsensitiveContains("managed by MDM") {
+            settingsRejectedMessage = "This setting is managed by your organization and cannot be changed."
+        } else {
+            settingsRejectedMessage = reason.isEmpty
+                ? "The setting could not be saved."
+                : reason
+        }
+        showSettingsRejectedAlert = true
+        return false
+    }
+
+    /// Re-reads the MDM enforcement snapshot. Cheap: getRestrictionsJSON()
+    /// consults only the policy loader and never touches the config file.
+    /// Call it from onAppear of any screen that hides or locks controls.
+    func refreshMDMRestrictions() {
+        let snapshot = MDMRestrictions.current()
+        // Equatable guards against republishing an identical snapshot and
+        // redrawing every settings screen on unrelated UserDefaults writes.
+        if snapshot != mdmRestrictions {
+            mdmRestrictions = snapshot
+        }
+    }
+
+    // Only iOS subscribes to the managed-config change channel; the tvOS
+    // screens re-read the snapshot in onAppear instead.
+    #if os(iOS)
+    private func scheduleMDMRestrictionsRefresh() {
+        mdmRefreshWorkItem?.cancel()
+        let item = DispatchWorkItem { [weak self] in
+            self?.refreshMDMRestrictions()
+        }
+        mdmRefreshWorkItem = item
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5, execute: item)
+    }
+    #endif
+
     func loadPreSharedKey() {
-        self.presharedKey = configProvider.preSharedKey
+        // The key itself is no longer readable across the bridge - the screen
+        // shows only whether one is configured, and the staging field starts
+        // empty so a save always submits a value the user just typed.
+        self.presharedKey = ""
         self.presharedKeySecure = configProvider.hasPreSharedKey
     }
 
@@ -791,7 +867,7 @@ class ViewModel: ObservableObject {
 
         // Persist to storage (on tvOS this writes directly to config JSON)
         configProvider.rosenpassEnabled = enabled
-        if !configProvider.commit() {
+        if !commitSettings() {
             print("Failed to update rosenpass settings")
         }
 
@@ -826,7 +902,7 @@ class ViewModel: ObservableObject {
 
         // Persist to storage (on tvOS this writes directly to config JSON)
         configProvider.rosenpassPermissive = permissive
-        if !configProvider.commit() {
+        if !commitSettings() {
             print("Failed to update rosenpass permissive settings")
         }
     }
@@ -861,7 +937,7 @@ class ViewModel: ObservableObject {
         let previous = self.disableIPv6
         self.disableIPv6 = disabled
         configProvider.disableIPv6 = disabled
-        if !configProvider.commit() {
+        if !commitSettings() {
             print("Failed to update IPv6 settings")
             self.disableIPv6 = previous
             configProvider.disableIPv6 = previous
@@ -1107,6 +1183,27 @@ class ViewModel: ObservableObject {
     #endif
 
     /// Checks shared app-group container for login required flag set by the network extension.
+    /// Picks up the policy-applied flag the extension sets when an MDM change
+    /// forced an engine restart, and tells the user their configuration was
+    /// updated. The snapshot is re-read at the same time: the restart means
+    /// the policy this process last saw is stale.
+    func checkMDMPolicyAppliedFlag() {
+        #if os(iOS)
+        let userDefaults = UserDefaults(suiteName: GlobalConstants.userPreferencesSuiteName)
+        guard userDefaults?.bool(forKey: GlobalConstants.keyMDMPolicyApplied) == true else { return }
+
+        userDefaults?.set(false, forKey: GlobalConstants.keyMDMPolicyApplied)
+        userDefaults?.synchronize()
+
+        AppLogger.shared.log("MDM: policy-applied flag detected from extension")
+        refreshMDMRestrictions()
+        showMDMPolicyAppliedToast = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + 4) { [weak self] in
+            self?.showMDMPolicyAppliedToast = false
+        }
+        #endif
+    }
+
     /// Shows the authentication UI. Notification was already delivered via NEVPNStatusDidChange observer.
     /// iOS only — tvOS uses IPC via `checkLoginError` in TVAuthView.
     func checkLoginRequiredFlag() {

--- a/NetBird/Source/App/ViewModels/MainViewModel.swift
+++ b/NetBird/Source/App/ViewModels/MainViewModel.swift
@@ -192,6 +192,9 @@ class ViewModel: ObservableObject {
     private var mdmConfigObserver: NSObjectProtocol?
     private var mdmRefreshWorkItem: DispatchWorkItem?
     #endif
+    /// Outside the iOS-only block above: both platforms poll for a policy the
+    /// OS may have pushed from another process.
+    private var lastMDMPolicyCheck = Date.distantPast
     
     @Published var peerViewModel: PeerViewModel
     @Published var routeViewModel: RoutesViewModel
@@ -617,6 +620,7 @@ class ViewModel: ObservableObject {
             self.checkExtensionState()
             self.checkNetworkUnavailableFlag()
             self.checkLoginRequiredFlag()
+            self.refreshMDMRestrictionsIfStale()
 
             let currentState = self.extensionState
 
@@ -849,6 +853,7 @@ class ViewModel: ObservableObject {
     /// consults only the policy loader and never touches the config file.
     /// Call it from onAppear of any screen that hides or locks controls.
     func refreshMDMRestrictions() {
+        lastMDMPolicyCheck = Date()
         let snapshot = MDMRestrictions.current()
         // Equatable guards against republishing an identical snapshot and
         // redrawing every settings screen on unrelated UserDefaults writes.
@@ -871,6 +876,20 @@ class ViewModel: ObservableObject {
 
     // Only iOS subscribes to the managed-config change channel; the tvOS
     // screens re-read the snapshot in onAppear instead.
+    /// Bounds how long an externally pushed policy can go unnoticed while the
+    /// app stays in the foreground.
+    ///
+    /// The OS writes managed configuration from another process, so the
+    /// in-process change notification never fires for it, and KVO cannot stand
+    /// in because the key's dots would be read as a key path. Activation
+    /// covers a policy that arrived while the app was away; this covers one
+    /// that arrives while it is open. Throttled well below the three-second
+    /// tick it rides on - the read crosses into Go.
+    private func refreshMDMRestrictionsIfStale() {
+        guard Date().timeIntervalSince(lastMDMPolicyCheck) >= 30 else { return }
+        refreshMDMRestrictions()
+    }
+
     /// Whether the policy forbids the daemon from connecting on its own.
     ///
     /// Every path that arms the VPN profile's On Demand rules has to consult

--- a/NetBird/Source/App/ViewModels/MainViewModel.swift
+++ b/NetBird/Source/App/ViewModels/MainViewModel.swift
@@ -443,6 +443,16 @@ class ViewModel: ObservableObject {
     #endif
     
     func close() -> Void {
+        // The policy holds the rules disarmed, so nothing will reconnect and
+        // there is nothing to warn about. Prompting here would also route the
+        // user into closeWithOnDemandDisabled(), which writes the saved
+        // preference to false - the one value the policy is deliberately
+        // preserving so it can be restored when the restriction lifts.
+        guard !autoConnectForbiddenByPolicy else {
+            performClose()
+            return
+        }
+
         #if os(iOS)
         // Warn user that On Demand will reconnect if rules match
         if connectOnDemand && onDemandRulesAllowConnect() {

--- a/NetBird/Source/App/ViewModels/MainViewModel.swift
+++ b/NetBird/Source/App/ViewModels/MainViewModel.swift
@@ -245,12 +245,16 @@ class ViewModel: ObservableObject {
             self?.handleVPNStatusChangeForNotification()
         }
 
-        // The OS delivers MDM managed-configuration pushes through the shared
-        // UserDefaults change channel, which also fires on every unrelated
-        // preference write. The main app has no restart decision to make - it
-        // only re-reads the snapshot - so a short debounce is enough here. The
-        // engine-restart decision lives in the extension, where Go's
-        // hasMDMPolicyChanged() does the real diffing.
+        // Catches policy writes this process makes itself. It will NOT fire
+        // for the OS writing managed configuration from another process -
+        // UserDefaults.didChangeNotification is process-local, and KVO cannot
+        // help either because the key contains dots and would be read as a
+        // key path. An externally pushed policy is therefore picked up on the
+        // next activation (see startActivation) or when a screen appears.
+        //
+        // The channel is shared with every other preference write, so the
+        // refresh is debounced. The main app has no restart decision to make;
+        // that lives in the extension, where hasMDMPolicyChanged() diffs.
         mdmConfigObserver = NotificationCenter.default.addObserver(
             forName: UserDefaults.didChangeNotification,
             object: nil,

--- a/NetBird/Source/App/ViewModels/MainViewModel.swift
+++ b/NetBird/Source/App/ViewModels/MainViewModel.swift
@@ -776,6 +776,14 @@ class ViewModel: ObservableObject {
     /// Proceeds even when the disarm fails — the user asked to leave this server, and stale
     /// credentials must not be kept just because the tunnel manager refused a rule change.
     func resetForServerChange(completion: @escaping () -> Void) {
+        refreshMDMRestrictions()
+        guard !mdmRestrictions.mdm.managesManagementURL,
+              !mdmRestrictions.features.disableUpdateSettings else {
+            AppLogger.shared.log("MDM: refusing to reset for a server change while the server is managed")
+            settingsRejectedMessage = "The server for this device is set by your organization."
+            showSettingsRejectedAlert = true
+            return
+        }
         setConnectOnDemand(isEnabled: false) { [weak self] inForce in
             DispatchQueue.main.async {
                 guard let self else { return }
@@ -1188,6 +1196,18 @@ class ViewModel: ObservableObject {
 
     /// Handles server change completion by stopping the engine and resetting all connection state.
     func handleServerChanged() {
+        // The confirmation alert stays presented across a policy change, so
+        // re-read before acting: clearDetails() below erases the stored
+        // configuration, which must not happen once the server is enforced.
+        refreshMDMRestrictions()
+        guard !mdmRestrictions.mdm.managesManagementURL,
+              !mdmRestrictions.features.disableUpdateSettings else {
+            AppLogger.shared.log("MDM: refusing a server change while the management URL is managed")
+            settingsRejectedMessage = "The server for this device is set by your organization."
+            showSettingsRejectedAlert = true
+            return
+        }
+
         AppLogger.shared.log("Server changed - stopping engine and resetting state")
 
         // Stop polling to prevent transitional states from updating UI

--- a/NetBird/Source/App/ViewModels/MainViewModel.swift
+++ b/NetBird/Source/App/ViewModels/MainViewModel.swift
@@ -835,13 +835,47 @@ class ViewModel: ObservableObject {
         let snapshot = MDMRestrictions.current()
         // Equatable guards against republishing an identical snapshot and
         // redrawing every settings screen on unrelated UserDefaults writes.
-        if snapshot != mdmRestrictions {
-            mdmRestrictions = snapshot
+        guard snapshot != mdmRestrictions else { return }
+        let autoConnectWasManaged = mdmRestrictions.mdm.disableAutoConnect
+        mdmRestrictions = snapshot
+
+        if snapshot.mdm.disableAutoConnect != autoConnectWasManaged {
+            applyAutoConnectPolicy(snapshot.mdm.disableAutoConnect)
         }
+
+        // The lock flags alone are not enough: a policy that starts enforcing
+        // Rosenpass or a pre-shared key while a settings screen is open would
+        // leave the now-locked control showing the user's old value. The
+        // getters return the enforced value once a key is managed, so re-read
+        // them here rather than waiting for the next onAppear.
+        loadRosenpassSettings()
+        presharedKeySecure = configProvider.hasPreSharedKey
     }
 
     // Only iOS subscribes to the managed-config change channel; the tvOS
     // screens re-read the snapshot in onAppear instead.
+    /// Arms or disarms the VPN profile's On Demand rules to match the policy.
+    ///
+    /// `disableAutoConnect` forbids connecting without the user asking, but On
+    /// Demand lives in the OS VPN profile, not in the engine - locking the
+    /// toggle changes nothing for a device whose rules are already armed, and
+    /// it would keep reconnecting. The user's saved preference is left alone
+    /// so it can be restored if the policy is lifted.
+    private func applyAutoConnectPolicy(_ managed: Bool) {
+        if managed {
+            guard networkExtensionAdapter.isOnDemandEnabled else { return }
+            AppLogger.shared.log("MDM: disableAutoConnect enforced — disarming On Demand rules")
+            networkExtensionAdapter.setOnDemandEnabled(false)
+            return
+        }
+
+        let userDefaults = UserDefaults(suiteName: GlobalConstants.userPreferencesSuiteName)
+        let saved = userDefaults?.bool(forKey: GlobalConstants.keyConnectOnDemand) ?? false
+        guard saved, !networkExtensionAdapter.isOnDemandEnabled else { return }
+        AppLogger.shared.log("MDM: disableAutoConnect lifted — restoring the user's On Demand setting")
+        networkExtensionAdapter.setOnDemandEnabled(true)
+    }
+
     #if os(iOS)
     private func scheduleMDMRestrictionsRefresh() {
         mdmRefreshWorkItem?.cancel()

--- a/NetBird/Source/App/ViewModels/MainViewModel.swift
+++ b/NetBird/Source/App/ViewModels/MainViewModel.swift
@@ -791,7 +791,22 @@ class ViewModel: ObservableObject {
     
     // MARK: - Configuration Methods (via ConfigurationProvider)
 
+    /// Whether the policy owns the pre-shared key, by managing it directly or
+    /// by forbidding settings edits at all.
+    private var preSharedKeyForbiddenByPolicy: Bool {
+        mdmRestrictions.mdm.preSharedKey || mdmRestrictions.features.disableUpdateSettings
+    }
+
     func updatePreSharedKey() {
+        // The only backstop on tvOS: commit() there writes straight to the
+        // config JSON and always reports success, so a policy that arrives
+        // while a key-entry alert is open would otherwise be overwritten.
+        guard !preSharedKeyForbiddenByPolicy else {
+            AppLogger.shared.log("MDM: refusing to change the pre-shared key while it is managed")
+            settingsRejectedMessage = "This setting is managed by your organization and cannot be changed."
+            showSettingsRejectedAlert = true
+            return
+        }
         configProvider.setPreSharedKey(presharedKey)
         if commitSettings() {
             // tvOS: bypass the On Demand disconnect prompt. The user changed a setting that
@@ -811,6 +826,12 @@ class ViewModel: ObservableObject {
     }
 
     func removePreSharedKey() {
+        guard !preSharedKeyForbiddenByPolicy else {
+            AppLogger.shared.log("MDM: refusing to remove the pre-shared key while it is managed")
+            settingsRejectedMessage = "This setting is managed by your organization and cannot be changed."
+            showSettingsRejectedAlert = true
+            return
+        }
         presharedKey = ""
         configProvider.setPreSharedKey("")
         if commitSettings() {

--- a/NetBird/Source/App/ViewModels/ServerViewModel.swift
+++ b/NetBird/Source/App/ViewModels/ServerViewModel.swift
@@ -121,7 +121,7 @@ class ServerViewModel : ObservableObject {
         let configPath = self.configurationFilePath
         let detachedTask = Task.detached(priority: .background) { () -> (NetBirdSDKAuth?, String?) in
             var error: NSError?
-            let authenticator = NetBirdSDKNewAuth(configPath, managementServerUrl, &error)
+            let authenticator = NetBirdSDKNewAuth(configPath, managementServerUrl, MDMPolicyFetcher(), &error)
 
             if let error = error {
                 print(error.domain, error.code, error.description)

--- a/NetBird/Source/App/Views/AdvancedView.swift
+++ b/NetBird/Source/App/Views/AdvancedView.swift
@@ -10,12 +10,41 @@ import SwiftUI
 struct AdvancedView: View {
     @EnvironmentObject var viewModel: ViewModel
 
+    /// `disableUpdateSettings` gates editing across the whole screen: the
+    /// values stay readable, every control that would write is locked.
+    private var editingDisabled: Bool {
+        viewModel.mdmRestrictions.features.disableUpdateSettings
+    }
+
+    /// The policy carries a pre-shared key, so the local one is irrelevant -
+    /// the field is replaced by a locked "Configured" row.
+    private var pskManaged: Bool {
+        viewModel.mdmRestrictions.mdm.preSharedKey
+    }
+
+    private var rosenpassLocked: Bool {
+        viewModel.mdmRestrictions.mdm.rosenpassEnabled || editingDisabled
+    }
+
+    private var rosenpassPermissiveLocked: Bool {
+        viewModel.mdmRestrictions.mdm.rosenpassPermissive || editingDisabled
+    }
+
     var body: some View {
         Form {
             Section {
-                if viewModel.presharedKeySecure {
-                    SecureField("Pre-shared key", text: $viewModel.presharedKey)
-                        .disabled(true)
+                if pskManaged || viewModel.presharedKeySecure {
+                    // The stored key is not readable through the bridge, so
+                    // show that one is set rather than an empty secure field.
+                    HStack {
+                        Text("Pre-shared key")
+                        Spacer()
+                        Text("Configured")
+                            .foregroundColor(Color("TextSecondary"))
+                        if pskManaged {
+                            MDMManagedBadge()
+                        }
+                    }
                 } else {
                     TextField("Pre-shared key", text: $viewModel.presharedKey)
                         .disableAutocorrection(true)
@@ -23,30 +52,40 @@ struct AdvancedView: View {
                         .onChange(of: viewModel.presharedKey) { value in
                             checkForValidPresharedKey(text: value)
                         }
+                        .mdmLocked(editingDisabled)
                 }
 
-                if viewModel.showInvalidPresharedKeyAlert {
+                if viewModel.showInvalidPresharedKeyAlert && !pskManaged {
                     Text("Invalid key")
                         .foregroundColor(.red)
                         .font(.footnote)
                 }
 
-                Button(viewModel.presharedKeySecure ? "Remove" : "Save") {
-                    if !viewModel.showInvalidPresharedKeyAlert {
-                        if viewModel.presharedKeySecure {
-                            viewModel.removePreSharedKey()
-                        } else {
-                            viewModel.updatePreSharedKey()
+                // With a policy-supplied key there is nothing to save or
+                // remove - the engine uses the managed value either way.
+                if !pskManaged {
+                    Button(viewModel.presharedKeySecure ? "Remove" : "Save") {
+                        if !viewModel.showInvalidPresharedKeyAlert {
+                            if viewModel.presharedKeySecure {
+                                viewModel.removePreSharedKey()
+                            } else {
+                                viewModel.updatePreSharedKey()
+                            }
                         }
                     }
+                    .mdmLocked(editingDisabled)
                 }
             } header: {
                 Text("Pre-shared Key")
             } footer: {
-                Text("You will only communicate with peers that use the same key.")
+                if pskManaged || editingDisabled {
+                    MDMManagedFooter()
+                } else {
+                    Text("You will only communicate with peers that use the same key.")
+                }
             }
 
-            Section(header: Text("Rosenpass")) {
+            Section {
                 Toggle("Enable Rosenpass", isOn: $viewModel.rosenpassEnabled)
                     .toggleStyle(SwitchToggleStyle(tint: .accentColor))
                     .onChange(of: viewModel.rosenpassEnabled) { value in
@@ -55,6 +94,7 @@ struct AdvancedView: View {
                         }
                         viewModel.setRosenpassEnabled(enabled: value)
                     }
+                    .mdmLocked(rosenpassLocked)
 
                 Toggle("Permissive mode", isOn: $viewModel.rosenpassPermissive)
                     .toggleStyle(SwitchToggleStyle(tint: .accentColor))
@@ -64,23 +104,39 @@ struct AdvancedView: View {
                         }
                         viewModel.setRosenpassPermissive(permissive: value)
                     }
+                    .mdmLocked(rosenpassPermissiveLocked)
+            } header: {
+                Text("Rosenpass")
+            } footer: {
+                if rosenpassLocked || rosenpassPermissiveLocked {
+                    MDMManagedFooter()
+                }
             }
 
-            Section(header: Text("Network & Security")) {
+            Section {
                 Toggle("Force relay connection", isOn: $viewModel.forceRelayConnection)
                     .toggleStyle(SwitchToggleStyle(tint: .accentColor))
                     .onChange(of: viewModel.forceRelayConnection) { value in
                         viewModel.setForcedRelayConnection(isEnabled: value)
                     }
+                    .mdmLocked(editingDisabled)
 
                 Toggle("Disable IPv6", isOn: $viewModel.disableIPv6)
                     .toggleStyle(SwitchToggleStyle(tint: .accentColor))
                     .onChange(of: viewModel.disableIPv6) { value in
                         viewModel.setDisableIPv6(disabled: value)
                     }
+                    .mdmLocked(editingDisabled)
+            } header: {
+                Text("Network & Security")
+            } footer: {
+                if editingDisabled {
+                    MDMManagedFooter()
+                }
             }
         }
         .onAppear {
+            viewModel.refreshMDMRestrictions()
             viewModel.loadRosenpassSettings()
             viewModel.loadPreSharedKey()
             viewModel.loadIPv6Settings()

--- a/NetBird/Source/App/Views/Components/MDMManagedNotice.swift
+++ b/NetBird/Source/App/Views/Components/MDMManagedNotice.swift
@@ -1,0 +1,51 @@
+//
+//  MDMManagedNotice.swift
+//  NetBird
+//
+//  Shared presentation for controls an MDM policy has taken over.
+//
+//  Convention across the app:
+//    - a managed *setting* stays visible and is locked, so the user can see
+//      the enforced value and understand why it will not budge;
+//    - a gated *feature* (features.* in the restrictions snapshot) is hidden
+//      outright, because there is nothing meaningful to show.
+//  A control that silently vanishes reads as a bug; one that is visibly
+//  locked explains itself.
+//
+
+import SwiftUI
+
+/// Footer line marking a locked control. The wording matches the desktop
+/// client so a user who runs both gets the same explanation.
+struct MDMManagedFooter: View {
+    var body: some View {
+        HStack(spacing: 4) {
+            Image(systemName: "lock.fill")
+            Text("Managed by your organization")
+        }
+        .foregroundColor(Color("TextSecondary"))
+    }
+}
+
+/// Trailing badge for a locked row inside a list.
+struct MDMManagedBadge: View {
+    var body: some View {
+        Image(systemName: "lock.fill")
+            .font(.caption)
+            .foregroundColor(Color("TextSecondary"))
+            .accessibilityLabel("Managed by your organization")
+    }
+}
+
+extension View {
+    /// Locks a control the policy manages: still readable, no longer editable.
+    @ViewBuilder
+    func mdmLocked(_ locked: Bool) -> some View {
+        if locked {
+            self.disabled(true)
+                .opacity(0.55)
+        } else {
+            self
+        }
+    }
+}

--- a/NetBird/Source/App/Views/MainView.swift
+++ b/NetBird/Source/App/Views/MainView.swift
@@ -34,6 +34,7 @@ enum MainAlertType: String, Identifiable {
     case authenticationRequired
     case onDemandConflict
     case onDemandDisconnect
+    case settingsRejected
 
     var id: String { rawValue }
 }
@@ -66,6 +67,11 @@ struct iOSMainView: View {
             if !hasCompletedOnboarding {
                 FirstLaunchView(
                     hasCompletedOnboarding: $hasCompletedOnboarding,
+                    // With a management URL enforced by policy the server
+                    // choice is not the user's to make, so the onboarding
+                    // drops the "change server" step rather than offering a
+                    // route that would be rejected.
+                    serverPickerAvailable: !viewModel.mdmRestrictions.mdm.managesManagementURL,
                     onChangeServer: {
                         DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
                             activeAlert = .changeServer
@@ -75,6 +81,9 @@ struct iOSMainView: View {
             } else {
                 mainContent
             }
+        }
+        .onAppear {
+            viewModel.refreshMDMRestrictions()
         }
         .alert(item: $activeAlert) { alertType in
             switch alertType {
@@ -130,6 +139,12 @@ struct iOSMainView: View {
                         selectedTab = 3 // Switch to Settings tab
                     }
                 )
+            case .settingsRejected:
+                return Alert(
+                    title: Text("Setting not applied"),
+                    message: Text(viewModel.settingsRejectedMessage),
+                    dismissButton: .default(Text("OK"))
+                )
             case .onDemandDisconnect:
                 return Alert(
                     title: Text("VPN On Demand Active"),
@@ -166,14 +181,16 @@ struct iOSMainView: View {
                 }
                 .tag(1)
 
-                NavigationView {
-                    iOSNetworksView()
+                if !viewModel.mdmRestrictions.features.disableNetworks {
+                    NavigationView {
+                        iOSNetworksView()
+                    }
+                    .navigationViewStyle(StackNavigationViewStyle())
+                    .tabItem {
+                        Label("Resources", systemImage: "globe")
+                    }
+                    .tag(2)
                 }
-                .navigationViewStyle(StackNavigationViewStyle())
-                .tabItem {
-                    Label("Resources", systemImage: "globe")
-                }
-                .tag(2)
 
                 NavigationView {
                     iOSSettingsView()
@@ -206,6 +223,9 @@ struct iOSMainView: View {
             }
             .onChange(of: viewModel.showOnDemandDisconnectAlert) { show in
                 if show { activeAlert = .onDemandDisconnect; viewModel.showOnDemandDisconnectAlert = false }
+            }
+            .onChange(of: viewModel.showSettingsRejectedAlert) { show in
+                if show { activeAlert = .settingsRejected; viewModel.showSettingsRejectedAlert = false }
             }
 
             // Toast alerts
@@ -242,6 +262,24 @@ struct iOSMainView: View {
                     .cornerRadius(8)
                     .transition(AnyTransition.opacity.combined(with: .move(edge: .top)))
                     .animation(.default, value: viewModel.showIpCopiedAlert)
+                    .zIndex(1)
+                }
+
+                if viewModel.showMDMPolicyAppliedToast {
+                    HStack(spacing: 8) {
+                        Image(systemName: "lock.fill")
+                            .foregroundColor(.white)
+                        Text("NetBird configuration was updated by your IT policy.")
+                            .foregroundColor(.white)
+                            .font(.subheadline)
+                            .multilineTextAlignment(.leading)
+                    }
+                    .padding(10)
+                    .background(Color.black.opacity(0.7))
+                    .cornerRadius(8)
+                    .padding(.horizontal, 24)
+                    .transition(AnyTransition.opacity.combined(with: .move(edge: .top)))
+                    .animation(.default, value: viewModel.showMDMPolicyAppliedToast)
                     .zIndex(1)
                 }
                 Spacer().frame(height: 80)

--- a/NetBird/Source/App/Views/MainView.swift
+++ b/NetBird/Source/App/Views/MainView.swift
@@ -224,6 +224,14 @@ struct iOSMainView: View {
             .onChange(of: viewModel.showOnDemandDisconnectAlert) { show in
                 if show { activeAlert = .onDemandDisconnect; viewModel.showOnDemandDisconnectAlert = false }
             }
+            .onChange(of: viewModel.mdmRestrictions.features.disableNetworks) { hidden in
+                // Removing the tab tagged 2 while it is selected leaves the
+                // TabView with a selection no tab matches, and the screen goes
+                // blank. Move off it first.
+                if hidden && selectedTab == 2 {
+                    selectedTab = 0
+                }
+            }
             .onChange(of: viewModel.showSettingsRejectedAlert) { show in
                 if show { activeAlert = .settingsRejected; viewModel.showSettingsRejectedAlert = false }
             }

--- a/NetBird/Source/App/Views/MainView.swift
+++ b/NetBird/Source/App/Views/MainView.swift
@@ -71,7 +71,10 @@ struct iOSMainView: View {
                     // choice is not the user's to make, so the onboarding
                     // drops the "change server" step rather than offering a
                     // route that would be rejected.
-                    serverPickerAvailable: !viewModel.mdmRestrictions.mdm.managesManagementURL,
+                    // Also pointless under disableUpdateSettings: the link
+                    // leads to a form the policy has already locked.
+                    serverPickerAvailable: !viewModel.mdmRestrictions.mdm.managesManagementURL
+                        && !viewModel.mdmRestrictions.features.disableUpdateSettings,
                     onChangeServer: {
                         DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
                             activeAlert = .changeServer

--- a/NetBird/Source/App/Views/RouteTabView.swift
+++ b/NetBird/Source/App/Views/RouteTabView.swift
@@ -18,7 +18,12 @@ struct RouteTabView: View {
             Color("BgMenu")
             VStack {
                 Spacer(minLength: 0)
-                if viewModel.vpnDisplayState == .connected && viewModel.routeViewModel.routeInfo.count > 0 {
+                if viewModel.mdmRestrictions.mdm.disableClientRoutes {
+                    // The engine installs no client routes under this policy,
+                    // so selecting them would change nothing. Say so instead
+                    // of showing an empty list that looks like a failure.
+                    RoutesDisabledByPolicyView()
+                } else if viewModel.vpnDisplayState == .connected && viewModel.routeViewModel.routeInfo.count > 0 {
                     VStack {
                         RouteSelectionHeader(routeViewModel: viewModel.routeViewModel)
                         RouteListView(viewModel: viewModel, routeViewModel: viewModel.routeViewModel, peerViewModel: viewModel.peerViewModel)
@@ -31,8 +36,24 @@ struct RouteTabView: View {
             }
         }
         .onAppear {
+            self.viewModel.refreshMDMRestrictions()
             self.viewModel.routeViewModel.getRoutes()
         }
+    }
+}
+
+struct RoutesDisabledByPolicyView: View {
+    var body: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "lock.fill")
+                .font(.largeTitle)
+                .foregroundColor(Color("TextSecondary"))
+            Text("Network routes are managed by your organization")
+                .font(.system(size: 18 * Layout.fontScale))
+                .foregroundColor(Color("TextPrimary"))
+                .multilineTextAlignment(.center)
+        }
+        .padding(.horizontal, Screen.width * 0.1)
     }
 }
 

--- a/NetBird/Source/App/Views/ServerView.swift
+++ b/NetBird/Source/App/Views/ServerView.swift
@@ -29,8 +29,15 @@ struct ServerView: View {
                 // offer a change the daemon would reject.
                 managedServerNotice
             } else {
-                serverForm
-                    .mdmLocked(viewModel.mdmRestrictions.features.disableUpdateSettings)
+                VStack(spacing: 0) {
+                    serverForm
+                        .mdmLocked(viewModel.mdmRestrictions.features.disableUpdateSettings)
+                    if viewModel.mdmRestrictions.features.disableUpdateSettings {
+                        MDMManagedFooter()
+                            .font(.footnote)
+                            .padding(.bottom, 12)
+                    }
+                }
             }
         }
         .navigationTitle("Change Server")

--- a/NetBird/Source/App/Views/ServerView.swift
+++ b/NetBird/Source/App/Views/ServerView.swift
@@ -22,6 +22,44 @@ struct ServerView: View {
     @Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
 
     var body: some View {
+        Group {
+            if viewModel.mdmRestrictions.mdm.managesManagementURL {
+                // Reachable only through a stale navigation path - the entry
+                // point is hidden under this policy. Fail closed rather than
+                // offer a change the daemon would reject.
+                managedServerNotice
+            } else {
+                serverForm
+                    .mdmLocked(viewModel.mdmRestrictions.features.disableUpdateSettings)
+            }
+        }
+        .navigationTitle("Change Server")
+        .navigationBarTitleDisplayMode(.inline)
+        .onAppear {
+            viewModel.refreshMDMRestrictions()
+        }
+    }
+
+    private var managedServerNotice: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "lock.fill")
+                .font(.largeTitle)
+                .foregroundColor(Color("TextSecondary"))
+            Text("The server for this device is set by your organization.")
+                .multilineTextAlignment(.center)
+                .foregroundColor(Color("TextPrimary"))
+            Text(viewModel.mdmRestrictions.mdm.managementURL)
+                .font(.footnote)
+                .foregroundColor(Color("TextSecondary"))
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
+        }
+        .padding(32)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color("BgMenu"))
+    }
+
+    private var serverForm: some View {
         Form {
             Section(
                 header: Text("Server"),
@@ -127,8 +165,6 @@ struct ServerView: View {
                 .disabled(isButtonDisabled)
             }
         }
-        .navigationTitle("Change Server")
-        .navigationBarTitleDisplayMode(.inline)
         .onChange(of: serverViewModel.viewErrors.ssoNotSupportedError) { error in
             if error != nil {
                 showSetupKeyField = true

--- a/NetBird/Source/App/Views/TV/TVMainView.swift
+++ b/NetBird/Source/App/Views/TV/TVMainView.swift
@@ -54,6 +54,13 @@ struct TVMainView: View {
                 }
                 .tag(3)
         }
+        .onChange(of: viewModel.mdmRestrictions.features.disableNetworks) { _, hidden in
+            // Leaving the selection on a tab that no longer exists shows a
+            // blank screen; the iOS side does the same.
+            if hidden && selectedTab == 2 {
+                selectedTab = 0
+            }
+        }
         .overlay(alignment: .topLeading) {
             Image("netbird-logo-menu")
                 .resizable()

--- a/NetBird/Source/App/Views/TV/TVMainView.swift
+++ b/NetBird/Source/App/Views/TV/TVMainView.swift
@@ -40,11 +40,13 @@ struct TVMainView: View {
                 }
                 .tag(1)
 
-            TVNetworksView()
-                .tabItem {
-                    Label("Resources", systemImage: "globe")
-                }
-                .tag(2)
+            if !viewModel.mdmRestrictions.features.disableNetworks {
+                TVNetworksView()
+                    .tabItem {
+                        Label("Resources", systemImage: "globe")
+                    }
+                    .tag(2)
+            }
 
             TVSettingsView()
                 .tabItem {

--- a/NetBird/Source/App/Views/TV/TVSettingsView.swift
+++ b/NetBird/Source/App/Views/TV/TVSettingsView.swift
@@ -153,9 +153,10 @@ struct TVSettingsView: View {
                             TVSettingsRow(
                                 icon: "key.fill",
                                 title: "Pre-Shared Key",
-                                subtitle: pskManaged
-                                    ? "Managed by your organization"
-                                    : (viewModel.presharedKeySecure ? "Configured" : "Not configured"),
+                                subtitle: subtitle(
+                                    viewModel.presharedKeySecure ? "Configured" : "Not configured",
+                                    managed: pskManaged || editingDisabled
+                                ),
                                 action: (pskManaged || editingDisabled)
                                     ? nil
                                     : { showPreSharedKeyAlert = true }

--- a/NetBird/Source/App/Views/TV/TVSettingsView.swift
+++ b/NetBird/Source/App/Views/TV/TVSettingsView.swift
@@ -18,6 +18,21 @@ import NetBirdSDK
 struct TVSettingsView: View {
     @EnvironmentObject var viewModel: ViewModel
     @State private var showPreSharedKeyAlert = false
+
+    // tvOS rows use their own `isDisabled` flag rather than SwiftUI's
+    // .disabled(), which breaks focus navigation here (see TVSettingsToggleRow).
+    private var editingDisabled: Bool {
+        viewModel.mdmRestrictions.features.disableUpdateSettings
+    }
+    private var pskManaged: Bool {
+        viewModel.mdmRestrictions.mdm.preSharedKey
+    }
+    private var rosenpassLocked: Bool {
+        viewModel.mdmRestrictions.mdm.rosenpassEnabled || editingDisabled
+    }
+    private var rosenpassPermissiveLocked: Bool {
+        viewModel.mdmRestrictions.mdm.rosenpassPermissive || editingDisabled
+    }
     @State private var showDocsQRCode = false
 
     var body: some View {
@@ -43,17 +58,21 @@ struct TVSettingsView: View {
                                     set: { newValue in
                                         viewModel.setConnectOnDemand(isEnabled: newValue)
                                     }
-                                )
+                                ),
+                                isDisabled: viewModel.mdmRestrictions.mdm.disableAutoConnect || editingDisabled
                             )
 
-                            TVSettingsRow(
-                                icon: "server.rack",
-                                title: "Change Server",
-                                subtitle: "Switch to a different NetBird server",
-                                action: { viewModel.showChangeServerAlert = true }
-                            )
+                            if !viewModel.mdmRestrictions.mdm.managesManagementURL {
+                                TVSettingsRow(
+                                    icon: "server.rack",
+                                    title: "Change Server",
+                                    subtitle: "Switch to a different NetBird server",
+                                    action: { viewModel.showChangeServerAlert = true }
+                                )
+                            }
                         }
 
+                        if !viewModel.mdmRestrictions.mdm.disableAdvancedView {
                         TVSettingsSection(title: "Advanced") {
                             TVSettingsToggleRow(
                                 icon: "ant.fill",
@@ -75,7 +94,8 @@ struct TVSettingsView: View {
                                         }
                                         viewModel.setRosenpassEnabled(enabled: newValue)
                                     }
-                                )
+                                ),
+                                isDisabled: rosenpassLocked
                             )
 
                             TVSettingsToggleRow(
@@ -88,8 +108,9 @@ struct TVSettingsView: View {
                                         viewModel.setRosenpassPermissive(permissive: newValue)
                                     }
                                 ),
-                                isDisabled: !viewModel.rosenpassEnabled
+                                isDisabled: !viewModel.rosenpassEnabled || rosenpassPermissiveLocked
                             )
+                        }
                         }
 
                         TVSettingsSection(title: "Network") {
@@ -102,7 +123,8 @@ struct TVSettingsView: View {
                                     set: { newValue in
                                         viewModel.setDisableIPv6(disabled: newValue)
                                     }
-                                )
+                                ),
+                                isDisabled: editingDisabled
                             )
 
                             TVSettingsToggleRow(
@@ -114,7 +136,8 @@ struct TVSettingsView: View {
                                     set: { newValue in
                                         viewModel.setForcedRelayConnection(isEnabled: newValue)
                                     }
-                                )
+                                ),
+                                isDisabled: editingDisabled
                             )
                         }
 
@@ -122,8 +145,12 @@ struct TVSettingsView: View {
                             TVSettingsRow(
                                 icon: "key.fill",
                                 title: "Pre-Shared Key",
-                                subtitle: viewModel.presharedKeySecure ? "Configured" : "Not configured",
-                                action: { showPreSharedKeyAlert = true }
+                                subtitle: pskManaged
+                                    ? "Managed by your organization"
+                                    : (viewModel.presharedKeySecure ? "Configured" : "Not configured"),
+                                action: (pskManaged || editingDisabled)
+                                    ? nil
+                                    : { showPreSharedKeyAlert = true }
                             )
                         }
 
@@ -161,6 +188,7 @@ struct TVSettingsView: View {
 
         }
         .onAppear {
+            viewModel.refreshMDMRestrictions()
             // Load settings from storage to sync UI with actual values
             viewModel.loadRosenpassSettings()
             viewModel.loadPreSharedKey()

--- a/NetBird/Source/App/Views/TV/TVSettingsView.swift
+++ b/NetBird/Source/App/Views/TV/TVSettingsView.swift
@@ -33,6 +33,12 @@ struct TVSettingsView: View {
     private var rosenpassPermissiveLocked: Bool {
         viewModel.mdmRestrictions.mdm.rosenpassPermissive || editingDisabled
     }
+
+    /// tvOS rows carry their explanation in the subtitle - there is no footer
+    /// to put it in, and a row that is merely dimmed gives the user no reason.
+    private func subtitle(_ text: String, managed: Bool) -> String {
+        managed ? "Managed by your organization" : text
+    }
     @State private var showDocsQRCode = false
 
     var body: some View {
@@ -52,7 +58,8 @@ struct TVSettingsView: View {
                             TVSettingsToggleRow(
                                 icon: "bolt.horizontal.circle.fill",
                                 title: "Connect On Demand",
-                                subtitle: "Reconnect automatically after a reboot or network change",
+                                subtitle: subtitle("Reconnect automatically after a reboot or network change",
+                                                   managed: viewModel.mdmRestrictions.mdm.disableAutoConnect || editingDisabled),
                                 isOn: Binding(
                                     get: { viewModel.connectOnDemand },
                                     set: { newValue in
@@ -84,7 +91,7 @@ struct TVSettingsView: View {
                             TVSettingsToggleRow(
                                 icon: "shield.lefthalf.filled",
                                 title: "Rosenpass",
-                                subtitle: "Post-quantum secure encryption",
+                                subtitle: subtitle("Post-quantum secure encryption", managed: rosenpassLocked),
                                 isOn: Binding(
                                     get: { viewModel.rosenpassEnabled },
                                     set: { newValue in
@@ -101,7 +108,8 @@ struct TVSettingsView: View {
                             TVSettingsToggleRow(
                                 icon: "shield.checkerboard",
                                 title: "Rosenpass Permissive",
-                                subtitle: "Allow connections with non-Rosenpass peers",
+                                subtitle: subtitle("Allow connections with non-Rosenpass peers",
+                                                   managed: rosenpassPermissiveLocked),
                                 isOn: Binding(
                                     get: { viewModel.rosenpassPermissive },
                                     set: { newValue in
@@ -117,7 +125,7 @@ struct TVSettingsView: View {
                             TVSettingsToggleRow(
                                 icon: "network",
                                 title: "Disable IPv6",
-                                subtitle: "Disable IPv6 overlay addressing on the tunnel",
+                                subtitle: subtitle("Disable IPv6 overlay addressing on the tunnel", managed: editingDisabled),
                                 isOn: Binding(
                                     get: { viewModel.disableIPv6 },
                                     set: { newValue in
@@ -130,7 +138,7 @@ struct TVSettingsView: View {
                             TVSettingsToggleRow(
                                 icon: "arrow.triangle.branch",
                                 title: "Force Relay",
-                                subtitle: "Force all connections through relay servers",
+                                subtitle: subtitle("Force all connections through relay servers", managed: editingDisabled),
                                 isOn: Binding(
                                     get: { viewModel.forceRelayConnection },
                                     set: { newValue in

--- a/NetBird/Source/App/Views/TV/TVSettingsView.swift
+++ b/NetBird/Source/App/Views/TV/TVSettingsView.swift
@@ -79,7 +79,7 @@ struct TVSettingsView: View {
                             }
                         }
 
-                        if !viewModel.mdmRestrictions.mdm.disableAdvancedView {
+                        if !viewModel.mdmRestrictions.mdm.hidesAdvancedView {
                         TVSettingsSection(title: "Advanced") {
                             TVSettingsToggleRow(
                                 icon: "ant.fill",

--- a/NetBird/Source/App/Views/iOS/AddProfileSheet.swift
+++ b/NetBird/Source/App/Views/iOS/AddProfileSheet.swift
@@ -9,6 +9,10 @@ import SwiftUI
 
 struct AddProfileSheet: View {
     @Environment(\.dismiss) private var dismiss
+    /// Shared rather than a one-off read: a policy that arrives while this
+    /// sheet is open must not leave the form showing - or submitting - a
+    /// management URL the policy has since replaced.
+    @EnvironmentObject var viewModel: ViewModel
     @StateObject private var addVM = AddProfileViewModel()
 
     @State private var profileName = ""
@@ -16,10 +20,6 @@ struct AddProfileSheet: View {
     @State private var setupKey = ""
     @State private var showSetupKeyField = false
     @State private var showNameValidationAlert = false
-    /// Read locally rather than through the environment: sheets are presented
-    /// outside the parent's view tree and this screen must not depend on the
-    /// environment object reaching it.
-    @State private var restrictions: MDMRestrictions = .empty
 
     var onCreated: (() -> Void)?
 
@@ -52,9 +52,9 @@ struct AddProfileSheet: View {
 
                 // Server URL - an MDM-enforced URL is shown, not asked for.
                 Section {
-                    if restrictions.mdm.managesManagementURL {
+                    if viewModel.mdmRestrictions.mdm.managesManagementURL {
                     HStack {
-                        Text(restrictions.mdm.managementURL)
+                        Text(viewModel.mdmRestrictions.mdm.managementURL)
                             .foregroundColor(Color("TextSecondary"))
                             .lineLimit(1)
                             .minimumScaleFactor(0.7)
@@ -82,7 +82,7 @@ struct AddProfileSheet: View {
                 } header: {
                     Text("Server")
                 } footer: {
-                    if restrictions.mdm.managesManagementURL {
+                    if viewModel.mdmRestrictions.mdm.managesManagementURL {
                         MDMManagedFooter()
                     }
                 }
@@ -117,7 +117,7 @@ struct AddProfileSheet: View {
                 }
 
                 // Use NetBird server shortcut
-                if !restrictions.mdm.managesManagementURL {
+                if !viewModel.mdmRestrictions.mdm.managesManagementURL {
                 Section {
                     Button {
                         managementServerUrl = defaultManagementServerUrl
@@ -137,7 +137,7 @@ struct AddProfileSheet: View {
                 }
             }
             .onAppear {
-                restrictions = MDMRestrictions.current()
+                viewModel.refreshMDMRestrictions()
             }
             .listStyle(.insetGrouped)
             .navigationTitle("New Profile")
@@ -164,8 +164,8 @@ struct AddProfileSheet: View {
                                 // Go overrides this anyway; submitting the
                                 // enforced value keeps a stale local one from
                                 // reaching the reachability check at all.
-                                serverUrl: restrictions.mdm.managesManagementURL
-                                    ? restrictions.mdm.managementURL
+                                serverUrl: viewModel.mdmRestrictions.mdm.managesManagementURL
+                                    ? viewModel.mdmRestrictions.mdm.managementURL
                                     : managementServerUrl,
                                 setupKey: setupKey
                             )
@@ -197,6 +197,7 @@ struct AddProfileSheet: View {
 
 #Preview {
     AddProfileSheet()
+        .environmentObject(ViewModel())
 }
 
 #endif

--- a/NetBird/Source/App/Views/iOS/AddProfileSheet.swift
+++ b/NetBird/Source/App/Views/iOS/AddProfileSheet.swift
@@ -16,6 +16,10 @@ struct AddProfileSheet: View {
     @State private var setupKey = ""
     @State private var showSetupKeyField = false
     @State private var showNameValidationAlert = false
+    /// Read locally rather than through the environment: sheets are presented
+    /// outside the parent's view tree and this screen must not depend on the
+    /// environment object reaching it.
+    @State private var restrictions: MDMRestrictions = .empty
 
     var onCreated: (() -> Void)?
 
@@ -46,8 +50,18 @@ struct AddProfileSheet: View {
                     }
                 }
 
-                // Server URL
-                Section(header: Text("Server")) {
+                // Server URL - an MDM-enforced URL is shown, not asked for.
+                Section {
+                    if restrictions.mdm.managesManagementURL {
+                    HStack {
+                        Text(restrictions.mdm.managementURL)
+                            .foregroundColor(Color("TextSecondary"))
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.7)
+                        Spacer()
+                        MDMManagedBadge()
+                    }
+                    } else {
                     TextField("https://api.netbird.io", text: $managementServerUrl)
                         .autocorrectionDisabled()
                         .textInputAutocapitalization(.never)
@@ -58,11 +72,18 @@ struct AddProfileSheet: View {
                             addVM.generalError = nil
                             addVM.ssoNotSupportedError = nil
                         }
+                    }
                     if let error = addVM.urlError {
                         Text(error).foregroundColor(.red).font(.footnote)
                     }
                     if let error = addVM.generalError {
                         Text(error).foregroundColor(.red).font(.footnote)
+                    }
+                } header: {
+                    Text("Server")
+                } footer: {
+                    if restrictions.mdm.managesManagementURL {
+                        MDMManagedFooter()
                     }
                 }
 
@@ -96,6 +117,7 @@ struct AddProfileSheet: View {
                 }
 
                 // Use NetBird server shortcut
+                if !restrictions.mdm.managesManagementURL {
                 Section {
                     Button {
                         managementServerUrl = defaultManagementServerUrl
@@ -112,6 +134,10 @@ struct AddProfileSheet: View {
                     }
                     .disabled(addVM.isLoading)
                 }
+                }
+            }
+            .onAppear {
+                restrictions = MDMRestrictions.current()
             }
             .listStyle(.insetGrouped)
             .navigationTitle("New Profile")
@@ -135,7 +161,12 @@ struct AddProfileSheet: View {
                             }
                             addVM.create(
                                 name: profileName,
-                                serverUrl: managementServerUrl,
+                                // Go overrides this anyway; submitting the
+                                // enforced value keeps a stale local one from
+                                // reaching the reachability check at all.
+                                serverUrl: restrictions.mdm.managesManagementURL
+                                    ? restrictions.mdm.managementURL
+                                    : managementServerUrl,
                                 setupKey: setupKey
                             )
                         }

--- a/NetBird/Source/App/Views/iOS/FirstLaunchView.swift
+++ b/NetBird/Source/App/Views/iOS/FirstLaunchView.swift
@@ -11,6 +11,9 @@ import SwiftUI
 
 struct FirstLaunchView: View {
     @Binding var hasCompletedOnboarding: Bool
+    /// False when an MDM policy enforces the management URL - the server
+    /// step is then dropped from the onboarding copy entirely.
+    var serverPickerAvailable: Bool = true
     var onChangeServer: () -> Void
 
     var body: some View {
@@ -40,7 +43,18 @@ struct FirstLaunchView: View {
         }
     }
 
+    @ViewBuilder
     private var onboardingText: some View {
+        if serverPickerAvailable {
+            serverPickerText
+        } else {
+            Text("Your organization has configured the server this device connects to.")
+                .font(.system(size: 17))
+                .foregroundColor(Color("TextPrimary"))
+        }
+    }
+
+    private var serverPickerText: some View {
         let attributed: AttributedString = {
             let fullText = "By default you will connect to NetBird's cloud servers. Visit the Change server menu to use another server."
             var result = AttributedString(fullText)

--- a/NetBird/Source/App/Views/iOS/ProfilesListView.swift
+++ b/NetBird/Source/App/Views/iOS/ProfilesListView.swift
@@ -26,101 +26,29 @@ struct ProfilesListView: View {
         profiles.filter { !$0.isActive }
     }
 
+    /// The Go profile manager rejects switch/add/rename/remove under this
+    /// gate, so the UI mirrors it: the entries that would fail are removed
+    /// rather than left to error out. Logout is not gated and stays.
+    private var profilesManaged: Bool {
+        viewModel.mdmRestrictions.features.disableProfiles
+    }
+
     var body: some View {
         List {
-            if let active = activeProfile {
-                Section("Active") {
-                    HStack {
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text(active.name)
-                                .font(.body.bold())
-                                .foregroundColor(Color("TextPrimary"))
-                            if let url = ProfileManager.shared.managementURL(forID: active.id) {
-                                Text(url)
-                                    .font(.footnote)
-                                    .foregroundColor(Color("TextSecondary"))
-                            }
-                        }
-                        Spacer()
-                        Text("Active")
-                            .font(.caption2.bold())
-                            .foregroundColor(.white)
-                            .padding(.horizontal, 8)
-                            .padding(.vertical, 4)
-                            .background(Color.green)
-                            .clipShape(Capsule())
-                    }
-                }
-            }
-
-            Section("All Profiles") {
-                if inactiveProfiles.isEmpty {
-                    VStack(spacing: 8) {
-                        Image(systemName: "person.2.slash")
-                            .font(.title2)
-                            .foregroundColor(Color("TextSecondary"))
-                        Text("No Additional Profiles")
-                            .font(.subheadline.bold())
-                            .foregroundColor(Color("TextPrimary"))
-                        Text("Tap + to add a new profile")
-                            .font(.footnote)
-                            .foregroundColor(Color("TextSecondary"))
-                    }
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 16)
-                } else {
-                    ForEach(inactiveProfiles) { profile in
-                        Button {
-                            selectedProfile = profile
-                            showSwitchAlert = true
-                        } label: {
-                            VStack(alignment: .leading, spacing: 4) {
-                                Text(profile.name)
-                                    .font(.body)
-                                    .foregroundColor(Color("TextPrimary"))
-                                if let url = ProfileManager.shared.managementURL(forID: profile.id) {
-                                    Text(url)
-                                        .font(.footnote)
-                                        .foregroundColor(Color("TextSecondary"))
-                                }
-                            }
-                        }
-                        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-                            if !profile.isDefault {
-                                Button(role: .destructive) {
-                                    selectedProfile = profile
-                                    showRemoveAlert = true
-                                } label: {
-                                    Label("Remove", systemImage: "trash")
-                                }
-                            }
-
-                            Button {
-                                selectedProfile = profile
-                                showLogoutAlert = true
-                            } label: {
-                                Label("Logout", systemImage: "rectangle.portrait.and.arrow.right")
-                            }
-                            .tint(.gray)
-                        }
-                    }
-                }
-            }
+            activeSection
+            managedNoticeSection
+            allProfilesSection
         }
         .listStyle(.insetGrouped)
         .navigationTitle("Profiles")
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
-                Button {
-                    showAddSheet = true
-                } label: {
-                    Image(systemName: "plus")
-                        .foregroundColor(.accentColor)
-                }
+                addProfileButton
             }
         }
         .onAppear {
+            viewModel.refreshMDMRestrictions()
             loadProfiles()
         }
         .sheet(isPresented: $showAddSheet) {
@@ -156,6 +84,137 @@ struct ProfilesListView: View {
             Button("OK") {}
         } message: {
             Text(errorMessage)
+        }
+    }
+
+    /// Kept out of the toolbar builder: a conditional inside
+    /// ToolbarContentBuilder is markedly more expensive to type-check than
+    /// the same conditional in a plain ViewBuilder.
+    @ViewBuilder
+    private var addProfileButton: some View {
+        if !profilesManaged {
+            Button {
+                showAddSheet = true
+            } label: {
+                Image(systemName: "plus")
+                    .foregroundColor(.accentColor)
+            }
+        }
+    }
+
+    // MARK: - Sections
+    //
+    // Split out of `body` deliberately: as one expression the List exceeded
+    // what the SwiftUI type-checker will resolve in reasonable time.
+
+    @ViewBuilder
+    private var activeSection: some View {
+        if let active = activeProfile {
+            Section("Active") {
+                HStack {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(active.name)
+                            .font(.body.bold())
+                            .foregroundColor(Color("TextPrimary"))
+                        if let url = ProfileManager.shared.managementURL(forID: active.id) {
+                            Text(url)
+                                .font(.footnote)
+                                .foregroundColor(Color("TextSecondary"))
+                        }
+                    }
+                    Spacer()
+                    Text("Active")
+                        .font(.caption2.bold())
+                        .foregroundColor(.white)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(Color.green)
+                        .clipShape(Capsule())
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var managedNoticeSection: some View {
+        if profilesManaged {
+            Section {
+                MDMManagedFooter()
+                    .font(.footnote)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var allProfilesSection: some View {
+        Section("All Profiles") {
+            if inactiveProfiles.isEmpty {
+                emptyProfilesPlaceholder
+            } else {
+                ForEach(inactiveProfiles) { profile in
+                    inactiveProfileRow(profile)
+                }
+            }
+        }
+    }
+
+    private var emptyProfilesPlaceholder: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "person.2.slash")
+                .font(.title2)
+                .foregroundColor(Color("TextSecondary"))
+            Text("No Additional Profiles")
+                .font(.subheadline.bold())
+                .foregroundColor(Color("TextPrimary"))
+            Text(profilesManaged ? "Profile management is disabled" : "Tap + to add a new profile")
+                .font(.footnote)
+                .foregroundColor(Color("TextSecondary"))
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 16)
+    }
+
+    // MARK: - Rows
+
+    /// Extracted from the List body: inline, the combination of the button,
+    /// the lock modifier and the swipe actions pushed the enclosing
+    /// expression past what the SwiftUI type-checker will resolve.
+    @ViewBuilder
+    private func inactiveProfileRow(_ profile: Profile) -> some View {
+        Button {
+            guard !profilesManaged else { return }
+            selectedProfile = profile
+            showSwitchAlert = true
+        } label: {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(profile.name)
+                    .font(.body)
+                    .foregroundColor(Color("TextPrimary"))
+                if let url = ProfileManager.shared.managementURL(forID: profile.id) {
+                    Text(url)
+                        .font(.footnote)
+                        .foregroundColor(Color("TextSecondary"))
+                }
+            }
+        }
+        .mdmLocked(profilesManaged)
+        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+            if !profile.isDefault && !profilesManaged {
+                Button(role: .destructive) {
+                    selectedProfile = profile
+                    showRemoveAlert = true
+                } label: {
+                    Label("Remove", systemImage: "trash")
+                }
+            }
+
+            Button {
+                selectedProfile = profile
+                showLogoutAlert = true
+            } label: {
+                Label("Logout", systemImage: "rectangle.portrait.and.arrow.right")
+            }
+            .tint(.gray)
         }
     }
 

--- a/NetBird/Source/App/Views/iOS/ProfilesListView.swift
+++ b/NetBird/Source/App/Views/iOS/ProfilesListView.swift
@@ -258,6 +258,16 @@ struct ProfilesListView: View {
     }
 
     private func switchToProfile(_ profile: Profile) {
+        // Re-read first: a policy that arrived while the confirmation alert was
+        // open would otherwise disconnect the user here and only then have the
+        // switch rejected by the Go manager.
+        viewModel.refreshMDMRestrictions()
+        guard !profilesManaged else {
+            errorMessage = "Profile management is disabled by your organization."
+            showErrorAlert = true
+            return
+        }
+
         viewModel.performClose()
 
         do {

--- a/NetBird/Source/App/Views/iOS/ProfilesListView.swift
+++ b/NetBird/Source/App/Views/iOS/ProfilesListView.swift
@@ -36,7 +36,8 @@ struct ProfilesListView: View {
 
     /// The Go profile manager rejects switch/add/rename/remove under this
     /// gate, so the UI mirrors it: the entries that would fail are removed
-    /// rather than left to error out. Logout is not gated and stays.
+    /// rather than left to error out. Logout is gated too for every profile
+    /// but the active one, and only inactive profiles carry the action here.
     private var profilesManaged: Bool {
         viewModel.mdmRestrictions.features.disableProfiles
     }
@@ -194,22 +195,24 @@ struct ProfilesListView: View {
         }
         .mdmLocked(profilesManaged)
         .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-            if !profile.isDefault && !profilesManaged {
-                Button(role: .destructive) {
-                    selectedProfile = profile
-                    showRemoveAlert = true
-                } label: {
-                    Label("Remove", systemImage: "trash")
+            if !profilesManaged {
+                if !profile.isDefault {
+                    Button(role: .destructive) {
+                        selectedProfile = profile
+                        showRemoveAlert = true
+                    } label: {
+                        Label("Remove", systemImage: "trash")
+                    }
                 }
-            }
 
-            Button {
-                selectedProfile = profile
-                showLogoutAlert = true
-            } label: {
-                Label("Logout", systemImage: "rectangle.portrait.and.arrow.right")
+                Button {
+                    selectedProfile = profile
+                    showLogoutAlert = true
+                } label: {
+                    Label("Logout", systemImage: "rectangle.portrait.and.arrow.right")
+                }
+                .tint(.gray)
             }
-            .tint(.gray)
         }
     }
 

--- a/NetBird/Source/App/Views/iOS/VPNOnDemandView.swift
+++ b/NetBird/Source/App/Views/iOS/VPNOnDemandView.swift
@@ -19,6 +19,14 @@ struct VPNOnDemandView: View {
     private let wifiOptions = WiFiOnDemandPolicy.allCases
     private let cellularOptions = CellularOnDemandPolicy.allCases
 
+    /// `disableAutoConnect` forbids the daemon from connecting on its own, so
+    /// the whole On Demand screen becomes read-only; `disableUpdateSettings`
+    /// has the same effect for a different reason.
+    private var onDemandLocked: Bool {
+        viewModel.mdmRestrictions.mdm.disableAutoConnect
+            || viewModel.mdmRestrictions.features.disableUpdateSettings
+    }
+
     var body: some View {
         Form {
             Section {
@@ -31,6 +39,12 @@ struct VPNOnDemandView: View {
                     .onChange(of: viewModel.connectOnDemand) { value in
                         viewModel.setConnectOnDemand(isEnabled: value)
                     }
+                    .mdmLocked(onDemandLocked)
+
+                if onDemandLocked {
+                    MDMManagedFooter()
+                        .font(.footnote)
+                }
             }
 
             if viewModel.connectOnDemand {
@@ -65,6 +79,7 @@ struct VPNOnDemandView: View {
                 } footer: {
                     Text(connectionDescription)
                 }
+                .mdmLocked(onDemandLocked)
                 .onChange(of: viewModel.onDemandWiFiPolicy) { _ in
                     viewModel.saveOnDemandSettings()
                 }
@@ -76,18 +91,21 @@ struct VPNOnDemandView: View {
                     networkListSection(
                         header: "Connect Only On These Wi-Fi Networks"
                     )
+                    .mdmLocked(onDemandLocked)
                 }
 
                 if viewModel.onDemandWiFiPolicy == .exceptOn {
                     networkListSection(
                         header: "Except On These Wi-Fi Networks"
                     )
+                    .mdmLocked(onDemandLocked)
                 }
             }
         }
         .navigationTitle("VPN On Demand")
         .navigationBarTitleDisplayMode(.inline)
         .onAppear {
+            viewModel.refreshMDMRestrictions()
             fetchCurrentSSID()
         }
     }

--- a/NetBird/Source/App/Views/iOS/iOSConnectionView.swift
+++ b/NetBird/Source/App/Views/iOS/iOSConnectionView.swift
@@ -118,8 +118,14 @@ struct iOSConnectionView: View {
                                 .transition(.opacity.combined(with: .move(edge: .bottom)))
                         }
 
-                        ExitNodeSelectorCard(routeViewModel: viewModel.routeViewModel)
-                            .padding(.horizontal, 16)
+                        // With client routes disabled by policy the engine
+                        // installs none, so the selector would be a control
+                        // that cannot do anything - drop it rather than show
+                        // it dead.
+                        if !viewModel.mdmRestrictions.mdm.disableClientRoutes {
+                            ExitNodeSelectorCard(routeViewModel: viewModel.routeViewModel)
+                                .padding(.horizontal, 16)
+                        }
                     }
                     .padding(.bottom, 16)
                     .animation(.easeInOut(duration: 0.3), value: viewModel.isInternetConnected)

--- a/NetBird/Source/App/Views/iOS/iOSSettingsView.swift
+++ b/NetBird/Source/App/Views/iOS/iOSSettingsView.swift
@@ -15,6 +15,9 @@ struct iOSSettingsView: View {
 
     var body: some View {
         List {
+            // Feature gates hide the whole section: with profile management
+            // disabled there is nothing left in it to show.
+            if !viewModel.mdmRestrictions.features.disableProfiles {
             Section {
                 NavigationLink {
                     ProfilesListView()
@@ -32,7 +35,11 @@ struct iOSSettingsView: View {
                     }
                 }
             }
+            }
 
+            // A managed management URL removes the point of the server
+            // picker: the engine targets the enforced URL regardless.
+            if !viewModel.mdmRestrictions.mdm.managesManagementURL {
             Section(header: Text("Connection")) {
                     Button {
                         viewModel.showChangeServerAlert = true
@@ -45,6 +52,7 @@ struct iOSSettingsView: View {
                                 .foregroundColor(Color("TextPrimary"))
                         }
                     }
+                }
                 }
 
                 Section(header: Text("Settings")) {
@@ -60,15 +68,17 @@ struct iOSSettingsView: View {
                         }
                     }
 
-                    NavigationLink {
-                        AdvancedView()
-                    } label: {
-                        HStack {
-                            Image(systemName: "gearshape.2")
-                                .foregroundColor(.accentColor)
-                                .frame(width: 24)
-                            Text("Advanced")
-                                .foregroundColor(Color("TextPrimary"))
+                    if !viewModel.mdmRestrictions.mdm.disableAdvancedView {
+                        NavigationLink {
+                            AdvancedView()
+                        } label: {
+                            HStack {
+                                Image(systemName: "gearshape.2")
+                                    .foregroundColor(.accentColor)
+                                    .frame(width: 24)
+                                Text("Advanced")
+                                    .foregroundColor(Color("TextPrimary"))
+                            }
                         }
                     }
 
@@ -125,6 +135,9 @@ struct iOSSettingsView: View {
                     }
                 }
             }
+        .onAppear {
+            viewModel.refreshMDMRestrictions()
+        }
         .listStyle(InsetGroupedListStyle())
         .navigationTitle("Settings")
         .navigationBarTitleDisplayMode(.inline)

--- a/NetBird/Source/App/Views/iOS/iOSSettingsView.swift
+++ b/NetBird/Source/App/Views/iOS/iOSSettingsView.swift
@@ -68,7 +68,7 @@ struct iOSSettingsView: View {
                         }
                     }
 
-                    if !viewModel.mdmRestrictions.mdm.disableAdvancedView {
+                    if !viewModel.mdmRestrictions.mdm.hidesAdvancedView {
                         NavigationLink {
                             AdvancedView()
                         } label: {

--- a/NetBirdTVNetworkExtension/PacketTunnelProvider.swift
+++ b/NetBirdTVNetworkExtension/PacketTunnelProvider.swift
@@ -311,7 +311,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         logger.info("initializeConfig: No config file found, initializing with management URL: \(managementURL, privacy: .public)")
 
         // Create Auth object with the management URL
-        guard let auth = NetBirdSDKNewAuth(configPath, managementURL, nil) else {
+        guard let auth = NetBirdSDKNewAuth(configPath, managementURL, MDMPolicyFetcher(), nil) else {
             logger.error("initializeConfig: Failed to create Auth object")
             let data = "false".data(using: .utf8)
             completionHandler(data)

--- a/NetBirdTests/MDMBridgeIntegrationTests.swift
+++ b/NetBirdTests/MDMBridgeIntegrationTests.swift
@@ -1,0 +1,108 @@
+//
+//  MDMBridgeIntegrationTests.swift
+//  NetBirdTests
+//
+//  End-to-end check of the MDM bridge without an MDM server: writes the
+//  managed-configuration dictionary the OS would push, then reads the
+//  enforcement snapshot back through the Go layer.
+//
+//  Covers Swift fetcher -> Go policy loader -> BuildRestrictions -> Swift
+//  decode. The only link it cannot cover is the OS actually delivering the
+//  dictionary, which needs a device enrolled in a real MDM.
+//
+
+import XCTest
+@testable import NetBird
+
+final class MDMBridgeIntegrationTests: XCTestCase {
+
+    private let key = MDMPolicyFetcher.managedConfigKey
+    private var saved: [String: Any]?
+
+    /// True when the scheme passes a policy as a launch argument. The
+    /// argument domain outranks every other domain and cannot be cleared at
+    /// runtime, so these tests cannot establish a known starting state and
+    /// must skip rather than report a false result.
+    private var policyForcedByLaunchArgument: Bool {
+        UserDefaults.standard
+            .volatileDomain(forName: UserDefaults.argumentDomain)[key] != nil
+    }
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        try XCTSkipIf(
+            policyForcedByLaunchArgument,
+            "A policy is pinned by the scheme's launch arguments "
+            + "(-\(MDMPolicyFetcher.managedConfigKey)). Uncheck it in "
+            + "Edit Scheme > Run > Arguments to run these tests."
+        )
+        saved = UserDefaults.standard.dictionary(forKey: key)
+    }
+
+    override func tearDown() {
+        if let saved = saved {
+            UserDefaults.standard.set(saved, forKey: key)
+        } else {
+            UserDefaults.standard.removeObject(forKey: key)
+        }
+        super.tearDown()
+    }
+
+    private func push(_ policy: [String: Any]) {
+        UserDefaults.standard.set(policy, forKey: key)
+        UserDefaults.standard.synchronize()
+    }
+
+    /// The fetcher must hand the Go layer exactly what the OS store holds.
+    func testFetcherSerializesManagedConfiguration() {
+        push(["disableProfiles": true, "managementURL": "https://mgmt.example:443"])
+        let json = MDMPolicyFetcher().fetchJSON()
+        XCTAssertTrue(json.contains("disableProfiles"), "fetcher returned: \(json)")
+        XCTAssertTrue(json.contains("mgmt.example"), "fetcher returned: \(json)")
+    }
+
+    /// No managed configuration means an empty string, which the Go layer
+    /// reads as "no policy" - the unmanaged install must behave as before.
+    func testNoManagedConfigurationYieldsEmptyPolicy() {
+        UserDefaults.standard.removeObject(forKey: key)
+        XCTAssertEqual(MDMPolicyFetcher().fetchJSON(), "")
+        XCTAssertEqual(MDMRestrictions.current(), .empty)
+    }
+
+    /// The whole round trip: a pushed policy must come back as rendered
+    /// enforcement state.
+    func testPushedPolicyReachesRestrictions() {
+        push([
+            "managementURL": "https://mgmt.example:443",
+            "preSharedKey": "dGVzdC1rZXktdmFsdWUtZm9yLXVuaXQtdGVzdHMtMDE=",
+            "rosenpassEnabled": true,
+            "disableClientRoutes": true,
+            "disableAutoConnect": true,
+            "disableProfiles": true,
+            "disableNetworks": true,
+            "disableUpdateSettings": true,
+        ])
+
+        let r = MDMRestrictions.current()
+        XCTAssertTrue(r.mdm.managesManagementURL, "managementURL was: '\(r.mdm.managementURL)'")
+        XCTAssertTrue(r.mdm.managementURL.contains("mgmt.example"))
+        XCTAssertTrue(r.mdm.preSharedKey)
+        XCTAssertTrue(r.mdm.rosenpassEnabled)
+        XCTAssertTrue(r.mdm.disableClientRoutes)
+        XCTAssertTrue(r.mdm.disableAutoConnect)
+        XCTAssertTrue(r.features.disableProfiles)
+        XCTAssertTrue(r.features.disableNetworks)
+        XCTAssertTrue(r.features.disableUpdateSettings)
+    }
+
+    /// Keys absent from the policy must stay unmanaged, so a partial policy
+    /// locks only what it names.
+    func testPartialPolicyLocksOnlyNamedKeys() {
+        push(["disableNetworks": true])
+        let r = MDMRestrictions.current()
+        XCTAssertTrue(r.features.disableNetworks)
+        XCTAssertFalse(r.features.disableProfiles)
+        XCTAssertFalse(r.mdm.preSharedKey)
+        XCTAssertFalse(r.mdm.managesManagementURL)
+    }
+}

--- a/NetBirdTests/MDMRestrictionsTests.swift
+++ b/NetBirdTests/MDMRestrictionsTests.swift
@@ -1,0 +1,109 @@
+//
+//  MDMRestrictionsTests.swift
+//  NetBirdTests
+//
+//  Covers the decode side of the MDM enforcement snapshot: the Swift mirror
+//  must survive a Go layer that adds, drops or nulls a key, and must always
+//  degrade to "nothing managed" rather than locking the user out.
+//
+
+import XCTest
+@testable import NetBird
+
+final class MDMRestrictionsTests: XCTestCase {
+
+    /// The full snapshot shape, as documented for getRestrictionsJSON().
+    private let fullSnapshot = """
+    {
+      "mdm": {
+        "managementURL": "https://mgmt.corp.example:443",
+        "preSharedKey": true,
+        "wireguardPort": false,
+        "rosenpassEnabled": true,
+        "rosenpassPermissive": false,
+        "disableClientRoutes": false,
+        "disableServerRoutes": false,
+        "allowServerSSH": null,
+        "disableAutoConnect": true,
+        "disableAutostart": false,
+        "blockInbound": false,
+        "disableMetricsCollection": false,
+        "splitTunnelMode": false,
+        "splitTunnelApps": false,
+        "disableAdvancedView": false
+      },
+      "features": {
+        "disableProfiles": true,
+        "disableNetworks": false,
+        "disableUpdateSettings": false
+      }
+    }
+    """
+
+    func testDecodesFullSnapshot() {
+        let r = MDMRestrictions.decode(fullSnapshot)
+        XCTAssertEqual(r.mdm.managementURL, "https://mgmt.corp.example:443")
+        XCTAssertTrue(r.mdm.managesManagementURL)
+        XCTAssertTrue(r.mdm.preSharedKey)
+        XCTAssertTrue(r.mdm.rosenpassEnabled)
+        XCTAssertFalse(r.mdm.rosenpassPermissive)
+        XCTAssertTrue(r.mdm.disableAutoConnect)
+        XCTAssertFalse(r.mdm.disableAdvancedView)
+        XCTAssertTrue(r.features.disableProfiles)
+        XCTAssertFalse(r.features.disableNetworks)
+        XCTAssertFalse(r.features.disableUpdateSettings)
+    }
+
+    /// `allowServerSSH` is tri-state: absent and explicit null both mean
+    /// "not managed", and must not collapse into `false`.
+    func testAllowServerSSHTriState() {
+        XCTAssertNil(MDMRestrictions.decode(fullSnapshot).mdm.allowServerSSH)
+        XCTAssertNil(MDMRestrictions.decode(#"{"mdm":{}}"#).mdm.allowServerSSH)
+        XCTAssertEqual(MDMRestrictions.decode(#"{"mdm":{"allowServerSSH":true}}"#).mdm.allowServerSSH, true)
+        XCTAssertEqual(MDMRestrictions.decode(#"{"mdm":{"allowServerSSH":false}}"#).mdm.allowServerSSH, false)
+    }
+
+    /// An empty policy must leave every control usable.
+    func testEmptyPolicyManagesNothing() {
+        let r = MDMRestrictions.decode(#"{"mdm":{"managementURL":""},"features":{}}"#)
+        XCTAssertEqual(r, .empty)
+        XCTAssertFalse(r.mdm.managesManagementURL)
+    }
+
+    func testEmptyStringDecodesToEmpty() {
+        XCTAssertEqual(MDMRestrictions.decode(""), .empty)
+    }
+
+    /// A malformed snapshot must not lock the settings screens; it degrades
+    /// to "nothing managed".
+    func testMalformedSnapshotDegradesToEmpty() {
+        XCTAssertEqual(MDMRestrictions.decode("not json"), .empty)
+        XCTAssertEqual(MDMRestrictions.decode("{"), .empty)
+    }
+
+    /// Keys the Swift side does not know about must be ignored rather than
+    /// failing the whole decode - the Go layer may ship new ones first.
+    func testUnknownKeysAreIgnored() {
+        let json = #"{"mdm":{"preSharedKey":true,"someFutureKey":"x"},"features":{"disableNetworks":true,"anotherOne":1}}"#
+        let r = MDMRestrictions.decode(json)
+        XCTAssertTrue(r.mdm.preSharedKey)
+        XCTAssertTrue(r.features.disableNetworks)
+    }
+
+    /// Missing keys fall back to "not managed", so a Go layer that drops a
+    /// key does not start reporting it as locked.
+    func testMissingKeysDefaultToUnmanaged() {
+        let r = MDMRestrictions.decode(#"{"mdm":{"preSharedKey":true}}"#)
+        XCTAssertTrue(r.mdm.preSharedKey)
+        XCTAssertFalse(r.mdm.rosenpassEnabled)
+        XCTAssertFalse(r.mdm.disableClientRoutes)
+        XCTAssertEqual(r.mdm.managementURL, "")
+        XCTAssertFalse(r.features.disableProfiles)
+    }
+
+    /// Only a non-empty managementURL means the URL is enforced.
+    func testManagesManagementURLRequiresNonEmptyValue() {
+        XCTAssertFalse(MDMRestrictions.decode(#"{"mdm":{"managementURL":""}}"#).mdm.managesManagementURL)
+        XCTAssertTrue(MDMRestrictions.decode(#"{"mdm":{"managementURL":"https://x"}}"#).mdm.managesManagementURL)
+    }
+}

--- a/NetBirdTests/MDMRestrictionsTests.swift
+++ b/NetBirdTests/MDMRestrictionsTests.swift
@@ -48,7 +48,8 @@ final class MDMRestrictionsTests: XCTestCase {
         XCTAssertTrue(r.mdm.rosenpassEnabled)
         XCTAssertFalse(r.mdm.rosenpassPermissive)
         XCTAssertTrue(r.mdm.disableAutoConnect)
-        XCTAssertFalse(r.mdm.disableAdvancedView)
+        XCTAssertEqual(r.mdm.disableAdvancedView, false)
+        XCTAssertFalse(r.mdm.hidesAdvancedView)
         XCTAssertTrue(r.features.disableProfiles)
         XCTAssertFalse(r.features.disableNetworks)
         XCTAssertFalse(r.features.disableUpdateSettings)
@@ -61,6 +62,20 @@ final class MDMRestrictionsTests: XCTestCase {
         XCTAssertNil(MDMRestrictions.decode(#"{"mdm":{}}"#).mdm.allowServerSSH)
         XCTAssertEqual(MDMRestrictions.decode(#"{"mdm":{"allowServerSSH":true}}"#).mdm.allowServerSSH, true)
         XCTAssertEqual(MDMRestrictions.decode(#"{"mdm":{"allowServerSSH":false}}"#).mdm.allowServerSSH, false)
+    }
+
+    /// `disableAdvancedView` is tri-state like `allowServerSSH`: only an
+    /// explicit true hides the section, so an unmanaged or explicitly-allowed
+    /// key must leave it in place.
+    func testDisableAdvancedViewTriState() {
+        XCTAssertNil(MDMRestrictions.decode(#"{"mdm":{}}"#).mdm.disableAdvancedView)
+        XCTAssertFalse(MDMRestrictions.decode(#"{"mdm":{}}"#).mdm.hidesAdvancedView)
+
+        XCTAssertEqual(MDMRestrictions.decode(#"{"mdm":{"disableAdvancedView":null}}"#).mdm.disableAdvancedView, nil)
+        XCTAssertFalse(MDMRestrictions.decode(#"{"mdm":{"disableAdvancedView":null}}"#).mdm.hidesAdvancedView)
+
+        XCTAssertFalse(MDMRestrictions.decode(#"{"mdm":{"disableAdvancedView":false}}"#).mdm.hidesAdvancedView)
+        XCTAssertTrue(MDMRestrictions.decode(#"{"mdm":{"disableAdvancedView":true}}"#).mdm.hidesAdvancedView)
     }
 
     /// An empty policy must leave every control usable.

--- a/NetbirdKit/ConfigurationProvider.swift
+++ b/NetbirdKit/ConfigurationProvider.swift
@@ -30,10 +30,13 @@ protocol ConfigurationProvider {
 
     // MARK: - Pre-Shared Key
 
-    /// The current pre-shared key (empty string if not set)
-    var preSharedKey: String { get set }
+    /// Stages a new pre-shared key; an empty string clears it. Write-only by
+    /// design: the Go layer no longer hands the key back across the bridge, so
+    /// there is no matching getter.
+    func setPreSharedKey(_ key: String)
 
-    /// Whether a pre-shared key is configured
+    /// Whether a pre-shared key is configured - staged, persisted, or enforced
+    /// by MDM policy.
     var hasPreSharedKey: Bool { get }
 
     // MARK: - Lifecycle
@@ -42,6 +45,12 @@ protocol ConfigurationProvider {
     /// Returns true on success, false on failure
     @discardableResult
     func commit() -> Bool
+
+    /// Message from the most recent failed commit, or nil after a success.
+    /// The Go layer rejects a staged value that diverges from an MDM-managed
+    /// key, and the caller needs the reason to tell that apart from an I/O
+    /// failure.
+    var lastCommitError: String? { get }
 
     /// Reloads settings from persistent storage
     func reload()
@@ -54,6 +63,7 @@ protocol ConfigurationProvider {
 final class iOSConfigurationProvider: ConfigurationProvider {
 
     private var preferences: NetBirdSDKPreferences
+    private(set) var lastCommitError: String?
 
     init() {
         self.preferences = Preferences.newPreferences()
@@ -110,17 +120,18 @@ final class iOSConfigurationProvider: ConfigurationProvider {
 
     // MARK: - Pre-Shared Key
 
-    var preSharedKey: String {
-        get {
-            return preferences.getPreSharedKey(nil)
-        }
-        set {
-            preferences.setPreSharedKey(newValue)
-        }
+    func setPreSharedKey(_ key: String) {
+        preferences.setPreSharedKey(key)
     }
 
     var hasPreSharedKey: Bool {
-        return !preSharedKey.isEmpty
+        var result = ObjCBool(false)
+        do {
+            try preferences.hasPreSharedKey(&result)
+        } catch {
+            print("ConfigurationProvider: Failed to read hasPreSharedKey - \(error)")
+        }
+        return result.boolValue
     }
 
     // MARK: - Lifecycle
@@ -129,8 +140,10 @@ final class iOSConfigurationProvider: ConfigurationProvider {
     func commit() -> Bool {
         do {
             try preferences.commit()
+            lastCommitError = nil
             return true
         } catch {
+            lastCommitError = error.localizedDescription
             print("ConfigurationProvider: Failed to commit - \(error)")
             return false
         }
@@ -181,13 +194,12 @@ final class tvOSConfigurationProvider: ConfigurationProvider {
 
     // MARK: - Pre-Shared Key
 
-    var preSharedKey: String {
-        get { extractJSONString(field: "PreSharedKey") ?? "" }
-        set { updateJSONField(field: "PreSharedKey", value: newValue) }
+    func setPreSharedKey(_ key: String) {
+        updateJSONField(field: "PreSharedKey", value: key)
     }
 
     var hasPreSharedKey: Bool {
-        return !preSharedKey.isEmpty
+        return !(extractJSONString(field: "PreSharedKey") ?? "").isEmpty
     }
 
     // MARK: - Lifecycle
@@ -197,6 +209,8 @@ final class tvOSConfigurationProvider: ConfigurationProvider {
         // Settings are written directly to config JSON, no separate commit needed
         return true
     }
+
+    var lastCommitError: String? { nil }
 
     func reload() {
         // Config JSON is always read fresh from UserDefaults

--- a/NetbirdKit/ConfigurationProvider.swift
+++ b/NetbirdKit/ConfigurationProvider.swift
@@ -199,6 +199,12 @@ final class tvOSConfigurationProvider: ConfigurationProvider {
     }
 
     var hasPreSharedKey: Bool {
+        // A policy-supplied key never reaches the local config JSON, so
+        // reading only that would report "Not configured" for a device the
+        // policy has in fact given a key.
+        if MDMRestrictions.current().mdm.preSharedKey {
+            return true
+        }
         return !(extractJSONString(field: "PreSharedKey") ?? "").isEmpty
     }
 

--- a/NetbirdKit/GlobalConstants.swift
+++ b/NetbirdKit/GlobalConstants.swift
@@ -41,6 +41,12 @@ struct GlobalConstants {
     static let stateFileName = "state.json"
     static let serverURLFileName = "netbird_server_url"
 
+    /// Set by the extension when an MDM policy change triggered an engine
+    /// restart; the main app clears it and tells the user the configuration
+    /// was updated by their IT policy.
+    static let keyMDMPolicyApplied = "netbird.mdm.policyApplied"
+
     // Local notification identifiers
     static let notificationLoginRequired = "netbird.login.required"
+    static let notificationMDMPolicyApplied = "netbird.mdm.policyApplied"
 }

--- a/NetbirdKit/MDMPolicyFetcher.swift
+++ b/NetbirdKit/MDMPolicyFetcher.swift
@@ -1,0 +1,81 @@
+//
+//  MDMPolicyFetcher.swift
+//  NetbirdKit
+//
+//  Reads the current iOS managed-configuration snapshot
+//  (UserDefaults key "com.apple.configuration.managed", pushed by MDM
+//  controllers via an Apple Configuration Profile of type
+//  com.apple.app.configuration.managed) and exposes it to the Go layer
+//  as a JSON-encoded string.
+//
+//  Registered exactly once per process via
+//  NetBirdSDKSetMobilePolicyFetcher; the Go side invokes fetchJSON()
+//  on every LoadPolicy call so the response is always fresh — no
+//  Swift-side caching.
+//
+//  Return-value contract (matches the Go-side jsonFetcherAdapter):
+//    - "" (empty)   : no MDM source present / no managed keys
+//    - "{}"         : managed config explicitly empty
+//    - "{...}"      : JSON object with key/value pairs
+//    - malformed    : logged, treated as empty
+//
+
+import Foundation
+import NetBirdSDK
+
+@objc public final class MDMPolicyFetcher: NSObject, NetBirdSDKPolicyFetcherProtocol {
+    /// The well-known iOS UserDefaults key under which an MDM-pushed
+    /// Configuration Profile lands the managed-config dictionary.
+    public static let managedConfigKey = "com.apple.configuration.managed"
+
+    public func fetchJSON() -> String {
+        guard let dict = UserDefaults.standard.dictionary(forKey: Self.managedConfigKey),
+              !dict.isEmpty else {
+            return ""
+        }
+        // JSONSerialization rejects non-JSON values (e.g. Date, URL,
+        // custom NSObject); MDM payloads on iOS may contain Data or
+        // Date that Apple Configurator inserts on signed profiles. The
+        // sanitizer below coerces those into JSON-friendly shapes so
+        // a single bad value cannot break the whole snapshot.
+        let sanitized = Self.sanitizeForJSON(dict)
+        guard JSONSerialization.isValidJSONObject(sanitized),
+              let data = try? JSONSerialization.data(withJSONObject: sanitized, options: []),
+              let json = String(data: data, encoding: .utf8) else {
+            AppLogger.shared.log("MDMPolicyFetcher: failed to JSON-encode managed configuration; returning empty")
+            return ""
+        }
+        return json
+    }
+
+    /// Recursively coerces a Foundation-typed managed-config value into
+    /// something JSONSerialization will accept. The Go side ultimately
+    /// expects map[string]any with bool / string / number / array /
+    /// nested-map values — anything else is dropped or stringified.
+    private static func sanitizeForJSON(_ value: Any) -> Any {
+        switch value {
+        case let dict as [String: Any]:
+            var out: [String: Any] = [:]
+            for (k, v) in dict {
+                out[k] = sanitizeForJSON(v)
+            }
+            return out
+        case let arr as [Any]:
+            return arr.map { sanitizeForJSON($0) }
+        case let data as Data:
+            return data.base64EncodedString()
+        case let date as Date:
+            return ISO8601DateFormatter().string(from: date)
+        case let url as URL:
+            return url.absoluteString
+        case is NSNumber, is String, is Bool, is Int, is Double, is Float:
+            return value
+        case is NSNull:
+            return NSNull()
+        default:
+            // Last resort: stringify so the Go side at least sees the
+            // key as managed (not silently swallowed).
+            return "\(value)"
+        }
+    }
+}

--- a/NetbirdKit/MDMRestrictions.swift
+++ b/NetbirdKit/MDMRestrictions.swift
@@ -1,0 +1,165 @@
+//
+//  MDMRestrictions.swift
+//  NetbirdKit
+//
+//  Swift mirror of the Go-side UI enforcement snapshot returned by
+//  getRestrictionsJSON() — the same JSON shape the desktop frontend
+//  consumes. Every MDM decision is made in Go; this type only carries
+//  the rendered answer so views can hide or lock a control.
+//
+//  Semantics:
+//    - mdm.managementURL  : the enforced value ("" = not managed)
+//    - other mdm.* flags  : true = the key is managed, lock the control
+//    - mdm.allowServerSSH : tri-state, nil = not managed
+//    - features.*         : the enforced value of that gate
+//
+
+import Foundation
+import NetBirdSDK
+
+struct MDMRestrictions: Equatable {
+
+    struct Fields: Equatable {
+        var managementURL: String = ""
+        var preSharedKey: Bool = false
+        var wireguardPort: Bool = false
+        var rosenpassEnabled: Bool = false
+        var rosenpassPermissive: Bool = false
+        var disableClientRoutes: Bool = false
+        var disableServerRoutes: Bool = false
+        var allowServerSSH: Bool?
+        var disableAutoConnect: Bool = false
+        var disableAutostart: Bool = false
+        var blockInbound: Bool = false
+        var disableMetricsCollection: Bool = false
+        var splitTunnelMode: Bool = false
+        var splitTunnelApps: Bool = false
+        var disableAdvancedView: Bool = false
+
+        /// True when a management URL is enforced by policy.
+        var managesManagementURL: Bool { !managementURL.isEmpty }
+    }
+
+    struct Features: Equatable {
+        var disableProfiles: Bool = false
+        var disableNetworks: Bool = false
+        var disableUpdateSettings: Bool = false
+    }
+
+    var mdm = Fields()
+    var features = Features()
+
+    /// The no-policy snapshot: nothing managed, nothing gated. Also the
+    /// fallback whenever the bridge cannot be read, so a failure leaves
+    /// the app fully usable instead of locking the user out.
+    static let empty = MDMRestrictions()
+}
+
+// MARK: - Decoding
+
+// The initializers below use decodeIfPresent throughout rather than the
+// synthesized Decodable conformance: the synthesized one requires every
+// key to be present and would reject a snapshot from a Go layer that has
+// added or dropped a key. Missing keys fall back to "not managed".
+extension MDMRestrictions: Decodable {
+    enum CodingKeys: String, CodingKey {
+        case mdm, features
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        mdm = try c.decodeIfPresent(Fields.self, forKey: .mdm) ?? Fields()
+        features = try c.decodeIfPresent(Features.self, forKey: .features) ?? Features()
+    }
+}
+
+extension MDMRestrictions.Fields: Decodable {
+    enum CodingKeys: String, CodingKey {
+        case managementURL, preSharedKey, wireguardPort, rosenpassEnabled,
+             rosenpassPermissive, disableClientRoutes, disableServerRoutes,
+             allowServerSSH, disableAutoConnect, disableAutostart, blockInbound,
+             disableMetricsCollection, splitTunnelMode, splitTunnelApps,
+             disableAdvancedView
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        func flag(_ key: CodingKeys) throws -> Bool {
+            try c.decodeIfPresent(Bool.self, forKey: key) ?? false
+        }
+        managementURL = try c.decodeIfPresent(String.self, forKey: .managementURL) ?? ""
+        preSharedKey = try flag(.preSharedKey)
+        wireguardPort = try flag(.wireguardPort)
+        rosenpassEnabled = try flag(.rosenpassEnabled)
+        rosenpassPermissive = try flag(.rosenpassPermissive)
+        disableClientRoutes = try flag(.disableClientRoutes)
+        disableServerRoutes = try flag(.disableServerRoutes)
+        // Tri-state: absent and JSON null both mean "not managed".
+        allowServerSSH = try c.decodeIfPresent(Bool.self, forKey: .allowServerSSH)
+        disableAutoConnect = try flag(.disableAutoConnect)
+        disableAutostart = try flag(.disableAutostart)
+        blockInbound = try flag(.blockInbound)
+        disableMetricsCollection = try flag(.disableMetricsCollection)
+        splitTunnelMode = try flag(.splitTunnelMode)
+        splitTunnelApps = try flag(.splitTunnelApps)
+        disableAdvancedView = try flag(.disableAdvancedView)
+    }
+}
+
+extension MDMRestrictions.Features: Decodable {
+    enum CodingKeys: String, CodingKey {
+        case disableProfiles, disableNetworks, disableUpdateSettings
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        disableProfiles = try c.decodeIfPresent(Bool.self, forKey: .disableProfiles) ?? false
+        disableNetworks = try c.decodeIfPresent(Bool.self, forKey: .disableNetworks) ?? false
+        disableUpdateSettings = try c.decodeIfPresent(Bool.self, forKey: .disableUpdateSettings) ?? false
+    }
+}
+
+// MARK: - Reading the snapshot
+
+extension MDMRestrictions {
+
+    /// Parses a snapshot produced by getRestrictionsJSON(). Never throws:
+    /// an unreadable snapshot degrades to `.empty` so a malformed policy
+    /// cannot brick the settings screens.
+    static func decode(_ json: String) -> MDMRestrictions {
+        guard !json.isEmpty, let data = json.data(using: .utf8) else {
+            return .empty
+        }
+        do {
+            return try JSONDecoder().decode(MDMRestrictions.self, from: data)
+        } catch {
+            AppLogger.shared.log("MDMRestrictions: failed to decode snapshot - \(error)")
+            return .empty
+        }
+    }
+
+    /// Reads the current snapshot through the Go bridge.
+    ///
+    /// A dedicated Preferences instance is used rather than the app's
+    /// shared one because getRestrictionsJSON() consults only the policy
+    /// loader — it never reads or writes the config file — so this is
+    /// side-effect free and works on tvOS too, where the app process has
+    /// no file-backed Preferences of its own.
+    static func current() -> MDMRestrictions {
+        guard let configPath = Preferences.configFile(),
+              let statePath = Preferences.stateFile(),
+              let preferences = NetBirdSDKNewPreferences(configPath, statePath) else {
+            return .empty
+        }
+        preferences.setMDMPolicyFetcher(MDMPolicyFetcher())
+        // gomobile maps (string, error) with a non-null string to an
+        // NSErrorPointer out-parameter, not to a throwing call.
+        var error: NSError?
+        let json = preferences.getRestrictionsJSON(&error)
+        if let error = error {
+            AppLogger.shared.log("MDMRestrictions: failed to read snapshot - \(error)")
+            return .empty
+        }
+        return decode(json)
+    }
+}

--- a/NetbirdKit/MDMRestrictions.swift
+++ b/NetbirdKit/MDMRestrictions.swift
@@ -34,10 +34,17 @@ struct MDMRestrictions: Equatable {
         var disableMetricsCollection: Bool = false
         var splitTunnelMode: Bool = false
         var splitTunnelApps: Bool = false
-        var disableAdvancedView: Bool = false
+        /// Tri-state, like `allowServerSSH`: nil means the key is not managed,
+        /// and an explicit false means the section is allowed - only true
+        /// hides it.
+        var disableAdvancedView: Bool?
 
         /// True when a management URL is enforced by policy.
         var managesManagementURL: Bool { !managementURL.isEmpty }
+
+        /// Whether the advanced section must be hidden. Folds the tri-state so
+        /// callers do not each have to decide what nil means.
+        var hidesAdvancedView: Bool { disableAdvancedView == true }
     }
 
     struct Features: Equatable {
@@ -102,7 +109,8 @@ extension MDMRestrictions.Fields: Decodable {
         disableMetricsCollection = try flag(.disableMetricsCollection)
         splitTunnelMode = try flag(.splitTunnelMode)
         splitTunnelApps = try flag(.splitTunnelApps)
-        disableAdvancedView = try flag(.disableAdvancedView)
+        // Tri-state: absent and JSON null both mean "not managed".
+        disableAdvancedView = try c.decodeIfPresent(Bool.self, forKey: .disableAdvancedView)
     }
 }
 

--- a/NetbirdKit/NetworkExtensionAdapter.swift
+++ b/NetbirdKit/NetworkExtensionAdapter.swift
@@ -508,7 +508,7 @@ public class NetworkExtensionAdapter: ObservableObject {
         let activeManagementURL = resolvedURL ?? ""
         logger.info("performLogin: using management URL '\(activeManagementURL, privacy: .public)' for profile '\(activeProfileID, privacy: .public)'")
         if let configPath = Preferences.configFile(), !configPath.isEmpty,
-           let auth = NetBirdSDKNewAuth(configPath, activeManagementURL, nil) {
+           let auth = NetBirdSDKNewAuth(configPath, activeManagementURL, MDMPolicyFetcher(), nil) {
             self.pendingAuth = auth
             self.loginSucceeded = false
             let urlOpener = MainAppLoginURLOpener()

--- a/NetbirdKit/Preferences.swift
+++ b/NetbirdKit/Preferences.swift
@@ -37,6 +37,11 @@ class Preferences {
         guard let preferences = NetBirdSDKNewPreferences(configPath, statePath) else {
             preconditionFailure("Failed to create NetBirdSDKPreferences")
         }
+        // Register unconditionally: with no MDM profile installed the fetcher
+        // returns "", the policy is empty and every getter behaves exactly as
+        // before. Without this the settings screens read an empty policy and
+        // silently ignore MDM, and commit() cannot reject a managed key.
+        preferences.setMDMPolicyFetcher(MDMPolicyFetcher())
         return preferences
     }
     #else

--- a/NetbirdKit/ProfileManager.swift
+++ b/NetbirdKit/ProfileManager.swift
@@ -61,6 +61,10 @@ class ProfileManager {
         guard let manager = NetBirdSDKNewProfileManager(configDir) else {
             preconditionFailure("Failed to create NetBirdSDKProfileManager at \(configDir)")
         }
+        // The Go manager rejects switch/add/rename/remove when the policy sets
+        // disableProfiles, so a missed UI check still fails closed — but only
+        // once the fetcher is registered here.
+        manager.setMDMPolicyFetcher(MDMPolicyFetcher())
         self.go = manager
         ProfileManager.excludeProfileStorageFromBackup(configDir: configDir)
     }

--- a/NetbirdNetworkExtension/NetBirdAdapter.swift
+++ b/NetbirdNetworkExtension/NetBirdAdapter.swift
@@ -532,7 +532,7 @@ public class NetBirdAdapter {
             return
         }
         #endif
-        if let auth = NetBirdSDKNewAuth(configPath, managementURL, nil) {
+        if let auth = NetBirdSDKNewAuth(configPath, managementURL, MDMPolicyFetcher(), nil) {
             authRef = auth
 
             // Always pass the device name so the peer registers under the user's

--- a/NetbirdNetworkExtension/NetBirdAdapter.swift
+++ b/NetbirdNetworkExtension/NetBirdAdapter.swift
@@ -286,6 +286,7 @@ public class NetBirdAdapter {
             return nil
         }
         self.client = client
+        registerMDMPolicyFetcher()
 
         // Load config from extension-local storage (set via IPC from main app)
         // Note: Shared App Group UserDefaults does NOT work on tvOS between app and extension
@@ -316,6 +317,7 @@ public class NetBirdAdapter {
             return nil
         }
         self.client = client
+        registerMDMPolicyFetcher()
         self.initializedConfigPath = resolvedConfigPath
         #endif
     }
@@ -627,6 +629,18 @@ public class NetBirdAdapter {
     }
 
     /// Update the device name in a config JSON string
+    /// Registers the policy fetcher on the Client at creation - the only
+    /// object whose Run() enforces the policy.
+    ///
+    /// Doing it here rather than in a caller covers every process and every
+    /// recreation: a profile switch builds a fresh Client, and the tvOS
+    /// extension had no registration site at all, so its engine ran
+    /// unmanaged. It also creates the change detector hasMDMPolicyChanged()
+    /// relies on.
+    private func registerMDMPolicyFetcher() {
+        client.setMDMPolicyFetcher(MDMPolicyFetcher())
+    }
+
     static func updateDeviceNameInConfig(_ configJSON: String, newName: String) -> String {
         // Escape special characters for JSON string
         let escapedName = newName

--- a/NetbirdNetworkExtension/PacketTunnelProvider.swift
+++ b/NetbirdNetworkExtension/PacketTunnelProvider.swift
@@ -97,9 +97,28 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     /// that is going away.
     private var mdmRetryWorkItem: DispatchWorkItem?
 
-    /// Set once stopTunnel begins, so anything still queued on monitorQueue
-    /// can tell that starting the client is no longer wanted.
-    private var isTearingDown = false
+    /// Set once stopTunnel begins, so anything still in flight can tell that
+    /// starting the client is no longer wanted.
+    ///
+    /// Lock-guarded rather than confined to monitorQueue: adapter.stop() can
+    /// run an existing stop handler synchronously, and the restart pipeline's
+    /// completions arrive on a global queue, so both the write and the reads
+    /// happen off that queue. Queueing the write would let a reader see the
+    /// stale value and start the engine into a teardown.
+    private let tearDownLock = NSLock()
+    private var _isTearingDown = false
+    private var isTearingDown: Bool {
+        get {
+            tearDownLock.lock()
+            defer { tearDownLock.unlock() }
+            return _isTearingDown
+        }
+        set {
+            tearDownLock.lock()
+            _isTearingDown = newValue
+            tearDownLock.unlock()
+        }
+    }
 
     override func startTunnel(options: [String : NSObject]?, completionHandler: @escaping (Error?) -> Void) {
         if let options = options, let logLevel = options["logLevel"] as? String {
@@ -134,9 +153,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             self?.startMonitoringNetworkChanges()
         }
 
-        monitorQueue.async { [weak self] in
-            self?.isTearingDown = false
-        }
+        isTearingDown = false
         startObservingMDMConfigChanges()
 
         guard let adapter = adapter else {
@@ -210,8 +227,11 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     }
 
     override func stopTunnel(with reason: NEProviderStopReason, completionHandler: @escaping () -> Void) {
+        // Synchronously, and before adapter.stop(): that call can invoke an
+        // existing stop handler inline, which would otherwise read the old
+        // value and restart into the teardown.
+        isTearingDown = true
         monitorQueue.async { [weak self] in
-            self?.isTearingDown = true
             self?.networkChangeWorkItem?.cancel()
             self?.networkChangeWorkItem = nil
             self?.mdmRetryWorkItem?.cancel()
@@ -768,6 +788,14 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     /// Called from start/stop completion so the widget reflects the real tunnel state
     /// without waiting for the widget's own polling cycle.
     private func updateWidgetStatus(_ status: String) {
+        // adapter.start completions land on a global queue, so one can arrive
+        // after stopTunnel has already written "disconnected". Guarding here
+        // rather than at each call site covers startTunnel and every restart
+        // path at once.
+        if status == "connected", isTearingDown {
+            AppLogger.shared.log("updateWidgetStatus: ignoring \"connected\" during teardown")
+            return
+        }
         let defaults = UserDefaults(suiteName: GlobalConstants.userPreferencesSuiteName)
         defaults?.set(status, forKey: GlobalConstants.keyWidgetVPNStatus)
         AppLogger.shared.log("updateWidgetStatus: \(status)")

--- a/NetbirdNetworkExtension/PacketTunnelProvider.swift
+++ b/NetbirdNetworkExtension/PacketTunnelProvider.swift
@@ -457,6 +457,20 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
                 return
             }
 
+            // stopTunnel may have begun while this pipeline sat in its stop
+            // phase. The scheduling-time guard cannot see that, and cancelling
+            // the retry work item cannot stop work already past it — so check
+            // again here, immediately before bringing the engine back up.
+            if self?.isTearingDown == true {
+                AppLogger.shared.log("restartClient: tunnel is tearing down — abandoning restart")
+                self?.monitorQueue.async {
+                    self?.adapter?.isRestarting = false
+                    self?.isRestartInProgress = false
+                }
+                timeoutWorkItem.cancel()
+                return
+            }
+
             AppLogger.shared.log("restartClient: starting client")
             self?.adapter?.start { [weak self] error in
                 // Cancel timeout whether start succeeds or not
@@ -489,7 +503,11 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
                     self?.updateWidgetStatus("disconnected")
                 } else {
                     AppLogger.shared.log("restartClient: start completed successfully")
-                    onRestarted?()
+                    // A restart that finished into a teardown has not put any
+                    // policy into force, so it must not report that it did.
+                    if self?.isTearingDown != true {
+                        onRestarted?()
+                    }
                     self?.updateWidgetStatus("connected")
                 }
             }

--- a/NetbirdNetworkExtension/PacketTunnelProvider.swift
+++ b/NetbirdNetworkExtension/PacketTunnelProvider.swift
@@ -120,6 +120,40 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         }
     }
 
+    /// Bumped by every startTunnel, so work begun for one tunnel lifecycle can
+    /// tell that it is finishing into another.
+    ///
+    /// The teardown latch alone is not enough: adapter.stop() cannot cancel a
+    /// stop callback that is already executing, and a following startTunnel
+    /// clears the latch — so a callback from the previous lifecycle would pass
+    /// the check and start the engine, or report a policy applied, for the new
+    /// one. The generation makes that callback identifiable as stale.
+    private var _tunnelGeneration = 0
+
+    /// Opens a new lifecycle: clears the latch and invalidates every callback
+    /// still in flight from the previous one.
+    private func beginTunnelGeneration() -> Int {
+        tearDownLock.lock()
+        defer { tearDownLock.unlock() }
+        _isTearingDown = false
+        _tunnelGeneration += 1
+        return _tunnelGeneration
+    }
+
+    private var tunnelGeneration: Int {
+        tearDownLock.lock()
+        defer { tearDownLock.unlock() }
+        return _tunnelGeneration
+    }
+
+    /// True only while `generation` is still the live lifecycle and no
+    /// teardown has begun.
+    private func isCurrentGeneration(_ generation: Int) -> Bool {
+        tearDownLock.lock()
+        defer { tearDownLock.unlock() }
+        return !_isTearingDown && _tunnelGeneration == generation
+    }
+
     override func startTunnel(options: [String : NSObject]?, completionHandler: @escaping (Error?) -> Void) {
         if let options = options, let logLevel = options["logLevel"] as? String {
             initializeLogging(loglevel: logLevel)
@@ -153,7 +187,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             self?.startMonitoringNetworkChanges()
         }
 
-        isTearingDown = false
+        _ = beginTunnelGeneration()
         startObservingMDMConfigChanges()
 
         guard let adapter = adapter else {
@@ -443,6 +477,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             return
         }
         AppLogger.shared.log("restartClient: starting restart sequence")
+        let generation = tunnelGeneration
         isRestartInProgress = true
         adapter.isRestarting = true
 
@@ -481,9 +516,9 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             // phase. The scheduling-time guard cannot see that, and cancelling
             // the retry work item cannot stop work already past it — so check
             // again here, immediately before bringing the engine back up.
-            if self?.isTearingDown == true {
-                AppLogger.shared.log("restartClient: tunnel is tearing down — abandoning restart")
-                self?.monitorQueue.async {
+            if let self = self, !self.isCurrentGeneration(generation) {
+                AppLogger.shared.log("restartClient: tunnel lifecycle moved on — abandoning restart")
+                self.monitorQueue.async { [weak self] in
                     self?.adapter?.isRestarting = false
                     self?.isRestartInProgress = false
                 }
@@ -525,7 +560,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
                     AppLogger.shared.log("restartClient: start completed successfully")
                     // A restart that finished into a teardown has not put any
                     // policy into force, so it must not report that it did.
-                    if self?.isTearingDown != true {
+                    if self?.isCurrentGeneration(generation) == true {
                         onRestarted?()
                     }
                     self?.updateWidgetStatus("connected")

--- a/NetbirdNetworkExtension/PacketTunnelProvider.swift
+++ b/NetbirdNetworkExtension/PacketTunnelProvider.swift
@@ -84,12 +84,6 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     /// Config.apply → applyMDMPolicy on the next Run.
     private var mdmConfigObserver: NSObjectProtocol?
 
-    /// Last-observed snapshot of the managed-config dictionary. Used to
-    /// dedup UserDefaults.didChangeNotification, which fires on ANY
-    /// UserDefaults change — without dedup, every preference write
-    /// would trigger a spurious engine restart.
-    private var lastManagedConfigSnapshot: NSDictionary?
-
     /// Flag preventing concurrent MDM restarts. The restartClient()
     /// path already has its own isRestartInProgress guard; this is
     /// purely to avoid re-entering mdmConfigChanged while a previous
@@ -486,6 +480,31 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         }
     }
 
+    /// Signals that a policy change was applied, using the same two-path
+    /// delivery as the login-required signal: a flag in the shared app-group
+    /// container that the main app picks up when it becomes active, plus a
+    /// best-effort local notification for the case where it does not.
+    private func signalMDMPolicyApplied() {
+        let userDefaults = UserDefaults(suiteName: GlobalConstants.userPreferencesSuiteName)
+        userDefaults?.set(true, forKey: GlobalConstants.keyMDMPolicyApplied)
+        userDefaults?.synchronize()
+
+        let content = UNMutableNotificationContent()
+        content.title = "MDM policy applied"
+        content.body = "NetBird configuration was updated by your IT policy."
+        content.sound = .default
+        let request = UNNotificationRequest(
+            identifier: GlobalConstants.notificationMDMPolicyApplied,
+            content: content,
+            trigger: nil
+        )
+        UNUserNotificationCenter.current().add(request) { error in
+            if let error = error {
+                AppLogger.shared.log("MDM: policy-applied notification not delivered from extension: \(error)")
+            }
+        }
+    }
+
     /// Signals login required by persisting a flag to the shared app-group container.
     /// The main app reads this flag when it becomes active and handles notification scheduling.
     /// Direct notification from extension is best-effort only since NEPacketTunnelProvider
@@ -745,17 +764,10 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     /// the OS-pushed MDM managed-config dictionary
     /// (UserDefaults["com.apple.configuration.managed"]) trigger an
     /// engine restart. iOS does NOT fire a dedicated MDM notification
-    /// — the entire UserDefaults change channel is shared — so the
-    /// handler reads the current managed-config snapshot and compares
-    /// it against the last-observed one before restarting; otherwise
-    /// every unrelated UserDefaults write would cause a spurious
-    /// restart.
+    /// — the entire UserDefaults change channel is shared, so this
+    /// fires on every unrelated preference write too. Deciding whether
+    /// the policy actually changed is Go's job; see the handler.
     private func startObservingMDMConfigChanges() {
-        // Seed the snapshot so the first post-startup change is what
-        // triggers a restart, not the initial appearance.
-        lastManagedConfigSnapshot = UserDefaults.standard
-            .dictionary(forKey: MDMPolicyFetcher.managedConfigKey) as NSDictionary?
-
         if mdmConfigObserver != nil {
             return
         }
@@ -775,23 +787,19 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             mdmConfigObserver = nil
             AppLogger.shared.log("MDM: unsubscribed from managed-configuration changes")
         }
-        lastManagedConfigSnapshot = nil
         isMDMRestartScheduled = false
     }
 
-    /// Called from the UserDefaults notification. Diff vs the last
-    /// snapshot; only on an actual managed-config change do we trigger
-    /// restartClient.
+    /// Called from the UserDefaults notification. The dedup this shared
+    /// channel needs lives in Go: hasMDMPolicyChanged() re-reads through
+    /// the registered fetcher, diffs against its last observation, logs
+    /// the per-key delta and returns true only on a real change. The
+    /// detector is created by setMDMPolicyFetcher, so with no fetcher
+    /// registered this is always false and nothing restarts.
     private func handleManagedConfigDidChangeIfRelevant() {
-        let current = UserDefaults.standard
-            .dictionary(forKey: MDMPolicyFetcher.managedConfigKey) as NSDictionary?
-
-        // Pointer-and-content equality via NSDictionary == handles
-        // nil-vs-nil, empty-vs-empty, and key/value diffs uniformly.
-        if current == lastManagedConfigSnapshot {
+        guard let client = adapter?.client, client.hasMDMPolicyChanged() else {
             return
         }
-        lastManagedConfigSnapshot = current
 
         if isMDMRestartScheduled {
             AppLogger.shared.log("MDM: change detected while a previous restart is in flight; new state will be picked up by that run")
@@ -799,6 +807,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         }
         isMDMRestartScheduled = true
         AppLogger.shared.log("MDM: managed configuration changed; restarting client")
+        signalMDMPolicyApplied()
         // Hand off to the existing restart pipeline. It already
         // serialises against the network-change restart and drives
         // the UI through ConnectionListener — exactly the flow we

--- a/NetbirdNetworkExtension/PacketTunnelProvider.swift
+++ b/NetbirdNetworkExtension/PacketTunnelProvider.swift
@@ -91,6 +91,16 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     /// makes the handler come back for it.
     private var pendingMDMRestart = false
 
+    /// The deferred retry that waits out an in-flight restart. Tracked so
+    /// teardown can cancel it: otherwise it fires afterwards, passes a guard
+    /// that stopTunnel has just reset, and calls adapter.start() on a tunnel
+    /// that is going away.
+    private var mdmRetryWorkItem: DispatchWorkItem?
+
+    /// Set once stopTunnel begins, so anything still queued on monitorQueue
+    /// can tell that starting the client is no longer wanted.
+    private var isTearingDown = false
+
     override func startTunnel(options: [String : NSObject]?, completionHandler: @escaping (Error?) -> Void) {
         if let options = options, let logLevel = options["logLevel"] as? String {
             initializeLogging(loglevel: logLevel)
@@ -124,6 +134,9 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             self?.startMonitoringNetworkChanges()
         }
 
+        monitorQueue.async { [weak self] in
+            self?.isTearingDown = false
+        }
         startObservingMDMConfigChanges()
 
         guard let adapter = adapter else {
@@ -198,8 +211,12 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
 
     override func stopTunnel(with reason: NEProviderStopReason, completionHandler: @escaping () -> Void) {
         monitorQueue.async { [weak self] in
+            self?.isTearingDown = true
             self?.networkChangeWorkItem?.cancel()
             self?.networkChangeWorkItem = nil
+            self?.mdmRetryWorkItem?.cancel()
+            self?.mdmRetryWorkItem = nil
+            self?.pendingMDMRestart = false
             self?.currentNetworkType = nil
             self?.wasStoppedDueToNoNetwork = false
             self?.isRestartInProgress = false
@@ -818,16 +835,20 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         // shared state. Running the two on different queues lets both pass the
         // guard and start their own stop/start pipelines.
         monitorQueue.async { [weak self] in
-            guard let self = self else { return }
+            guard let self = self, !self.isTearingDown else { return }
             guard !self.isRestartInProgress else {
                 self.pendingMDMRestart = true
                 AppLogger.shared.log("MDM: restart already in flight; will retry once it finishes")
-                self.monitorQueue.asyncAfter(deadline: .now() + 2) { [weak self] in
-                    guard let self = self, self.pendingMDMRestart else { return }
+                self.mdmRetryWorkItem?.cancel()
+                let retry = DispatchWorkItem { [weak self] in
+                    guard let self = self, self.pendingMDMRestart, !self.isTearingDown else { return }
                     self.requestMDMRestart()
                 }
+                self.mdmRetryWorkItem = retry
+                self.monitorQueue.asyncAfter(deadline: .now() + 2, execute: retry)
                 return
             }
+            self.mdmRetryWorkItem = nil
             self.pendingMDMRestart = false
             // Only a restart that actually brought the engine back up means the
             // policy is in force; a deferred or failed one must not tell the

--- a/NetbirdNetworkExtension/PacketTunnelProvider.swift
+++ b/NetbirdNetworkExtension/PacketTunnelProvider.swift
@@ -391,7 +391,11 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         }
     }
 
-    func restartClient() {
+    /// - Parameter onRestarted: run only when the engine is back up. Callers
+    ///   that must not report success early — an applied MDM policy, say —
+    ///   hang their side effect here rather than on the call returning, which
+    ///   happens long before the restart finishes.
+    func restartClient(onRestarted: (() -> Void)? = nil) {
         guard let adapter = adapter else {
             AppLogger.shared.log("restartClient: adapter is nil")
             return
@@ -468,6 +472,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
                     self?.updateWidgetStatus("disconnected")
                 } else {
                     AppLogger.shared.log("restartClient: start completed successfully")
+                    onRestarted?()
                     self?.updateWidgetStatus("connected")
                 }
             }
@@ -796,7 +801,6 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         }
 
         AppLogger.shared.log("MDM: managed configuration changed; restarting client")
-        signalMDMPolicyApplied()
         requestMDMRestart()
     }
 
@@ -809,19 +813,28 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     /// marked as seen. Retry instead until the pipeline is free; its own
     /// 30-second timeout bounds the wait.
     private func requestMDMRestart() {
-        DispatchQueue.main.async { [weak self] in
+        // monitorQueue, not the main queue: the network-change path already
+        // drives restartClient() from here, and isRestartInProgress is plain
+        // shared state. Running the two on different queues lets both pass the
+        // guard and start their own stop/start pipelines.
+        monitorQueue.async { [weak self] in
             guard let self = self else { return }
             guard !self.isRestartInProgress else {
                 self.pendingMDMRestart = true
                 AppLogger.shared.log("MDM: restart already in flight; will retry once it finishes")
-                DispatchQueue.main.asyncAfter(deadline: .now() + 2) { [weak self] in
+                self.monitorQueue.asyncAfter(deadline: .now() + 2) { [weak self] in
                     guard let self = self, self.pendingMDMRestart else { return }
                     self.requestMDMRestart()
                 }
                 return
             }
             self.pendingMDMRestart = false
-            self.restartClient()
+            // Only a restart that actually brought the engine back up means the
+            // policy is in force; a deferred or failed one must not tell the
+            // user otherwise.
+            self.restartClient { [weak self] in
+                self?.signalMDMPolicyApplied()
+            }
         }
     }
 }

--- a/NetbirdNetworkExtension/PacketTunnelProvider.swift
+++ b/NetbirdNetworkExtension/PacketTunnelProvider.swift
@@ -146,6 +146,28 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         return _tunnelGeneration
     }
 
+    /// True from the moment startTunnel hands off to adapter.start until that
+    /// call completes.
+    ///
+    /// Initial startup does not set isRestartInProgress, so without this an
+    /// MDM restart arriving in that window would pass the guard and call
+    /// adapter.stop() while client.run() was still being dispatched — the
+    /// adapter does not serialise the two. Deferring instead of dropping means
+    /// the policy is applied as soon as startup finishes.
+    private var _isStartingTunnel = false
+    private var isStartingTunnel: Bool {
+        get {
+            tearDownLock.lock()
+            defer { tearDownLock.unlock() }
+            return _isStartingTunnel
+        }
+        set {
+            tearDownLock.lock()
+            _isStartingTunnel = newValue
+            tearDownLock.unlock()
+        }
+    }
+
     /// True only while `generation` is still the live lifecycle and no
     /// teardown has begun.
     private func isCurrentGeneration(_ generation: Int) -> Bool {
@@ -250,7 +272,9 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             ))
         }
 
+        isStartingTunnel = true
         adapter.start { [weak self] error in
+            self?.isStartingTunnel = false
             completionHandler(error)
             if error == nil {
                 self?.updateWidgetStatus("connected")
@@ -265,6 +289,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         // existing stop handler inline, which would otherwise read the old
         // value and restart into the teardown.
         isTearingDown = true
+        isStartingTunnel = false
         monitorQueue.async { [weak self] in
             self?.networkChangeWorkItem?.cancel()
             self?.networkChangeWorkItem = nil
@@ -917,9 +942,9 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         // guard and start their own stop/start pipelines.
         monitorQueue.async { [weak self] in
             guard let self = self, !self.isTearingDown else { return }
-            guard !self.isRestartInProgress else {
+            guard !self.isRestartInProgress, !self.isStartingTunnel else {
                 self.pendingMDMRestart = true
-                AppLogger.shared.log("MDM: restart already in flight; will retry once it finishes")
+                AppLogger.shared.log("MDM: a start or restart is in flight; will retry once it finishes")
                 self.mdmRetryWorkItem?.cancel()
                 let retry = DispatchWorkItem { [weak self] in
                     guard let self = self, self.pendingMDMRestart, !self.isTearingDown else { return }

--- a/NetbirdNetworkExtension/PacketTunnelProvider.swift
+++ b/NetbirdNetworkExtension/PacketTunnelProvider.swift
@@ -74,8 +74,27 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     private var currentNetworkType: NWInterface.InterfaceType?
     private var wasStoppedDueToNoNetwork = false
     private var isRestartInProgress = false
-    
+
     private var networkChangeWorkItem: DispatchWorkItem?
+
+    /// Observer token for UserDefaults.didChangeNotification — used to
+    /// catch MDM managed-configuration pushes
+    /// (UserDefaults["com.apple.configuration.managed"]) and trigger an
+    /// engine restart so the new policy values flow through
+    /// Config.apply → applyMDMPolicy on the next Run.
+    private var mdmConfigObserver: NSObjectProtocol?
+
+    /// Last-observed snapshot of the managed-config dictionary. Used to
+    /// dedup UserDefaults.didChangeNotification, which fires on ANY
+    /// UserDefaults change — without dedup, every preference write
+    /// would trigger a spurious engine restart.
+    private var lastManagedConfigSnapshot: NSDictionary?
+
+    /// Flag preventing concurrent MDM restarts. The restartClient()
+    /// path already has its own isRestartInProgress guard; this is
+    /// purely to avoid re-entering mdmConfigChanged while a previous
+    /// restart is still in flight.
+    private var isMDMRestartScheduled = false
 
     override func startTunnel(options: [String : NSObject]?, completionHandler: @escaping (Error?) -> Void) {
         if let options = options, let logLevel = options["logLevel"] as? String {
@@ -109,6 +128,15 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             self?.adapter?.isNetworkUnavailable = false
             self?.startMonitoringNetworkChanges()
         }
+
+        // Register the MDM fetcher on the gomobile Client instance so
+        // every Run() that triggers Config.apply consults it via the
+        // Client-held mdm.Loader. Per-Client DI on the Go side — no
+        // process-wide state. Called every startTunnel; if the
+        // adapter was just recreated for a profile switch the fresh
+        // Client picks up the same fetcher.
+        adapter?.client.setMDMPolicyFetcher(MDMPolicyFetcher())
+        startObservingMDMConfigChanges()
 
         guard let adapter = adapter else {
             let error = NSError(
@@ -188,6 +216,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             self?.wasStoppedDueToNoNetwork = false
             self?.isRestartInProgress = false
         }
+        stopObservingMDMConfigChanges()
         // Reset network unavailable flag when tunnel stops
         adapter?.isNetworkUnavailable = false
         setNetworkUnavailableFlag(false)
@@ -707,6 +736,76 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
                 return
             }
             AppLogger.shared.log("Routes set successfully.")
+        }
+    }
+
+    // MARK: - MDM managed-configuration observer
+
+    /// Subscribes to UserDefaults.didChangeNotification so changes to
+    /// the OS-pushed MDM managed-config dictionary
+    /// (UserDefaults["com.apple.configuration.managed"]) trigger an
+    /// engine restart. iOS does NOT fire a dedicated MDM notification
+    /// — the entire UserDefaults change channel is shared — so the
+    /// handler reads the current managed-config snapshot and compares
+    /// it against the last-observed one before restarting; otherwise
+    /// every unrelated UserDefaults write would cause a spurious
+    /// restart.
+    private func startObservingMDMConfigChanges() {
+        // Seed the snapshot so the first post-startup change is what
+        // triggers a restart, not the initial appearance.
+        lastManagedConfigSnapshot = UserDefaults.standard
+            .dictionary(forKey: MDMPolicyFetcher.managedConfigKey) as NSDictionary?
+
+        if mdmConfigObserver != nil {
+            return
+        }
+        mdmConfigObserver = NotificationCenter.default.addObserver(
+            forName: UserDefaults.didChangeNotification,
+            object: nil,
+            queue: nil
+        ) { [weak self] _ in
+            self?.handleManagedConfigDidChangeIfRelevant()
+        }
+        AppLogger.shared.log("MDM: subscribed to managed-configuration changes")
+    }
+
+    private func stopObservingMDMConfigChanges() {
+        if let token = mdmConfigObserver {
+            NotificationCenter.default.removeObserver(token)
+            mdmConfigObserver = nil
+            AppLogger.shared.log("MDM: unsubscribed from managed-configuration changes")
+        }
+        lastManagedConfigSnapshot = nil
+        isMDMRestartScheduled = false
+    }
+
+    /// Called from the UserDefaults notification. Diff vs the last
+    /// snapshot; only on an actual managed-config change do we trigger
+    /// restartClient.
+    private func handleManagedConfigDidChangeIfRelevant() {
+        let current = UserDefaults.standard
+            .dictionary(forKey: MDMPolicyFetcher.managedConfigKey) as NSDictionary?
+
+        // Pointer-and-content equality via NSDictionary == handles
+        // nil-vs-nil, empty-vs-empty, and key/value diffs uniformly.
+        if current == lastManagedConfigSnapshot {
+            return
+        }
+        lastManagedConfigSnapshot = current
+
+        if isMDMRestartScheduled {
+            AppLogger.shared.log("MDM: change detected while a previous restart is in flight; new state will be picked up by that run")
+            return
+        }
+        isMDMRestartScheduled = true
+        AppLogger.shared.log("MDM: managed configuration changed; restarting client")
+        // Hand off to the existing restart pipeline. It already
+        // serialises against the network-change restart and drives
+        // the UI through ConnectionListener — exactly the flow we
+        // want for an MDM-triggered restart.
+        DispatchQueue.main.async { [weak self] in
+            self?.restartClient()
+            self?.isMDMRestartScheduled = false
         }
     }
 }

--- a/NetbirdNetworkExtension/PacketTunnelProvider.swift
+++ b/NetbirdNetworkExtension/PacketTunnelProvider.swift
@@ -84,11 +84,12 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     /// Config.apply → applyMDMPolicy on the next Run.
     private var mdmConfigObserver: NSObjectProtocol?
 
-    /// Flag preventing concurrent MDM restarts. The restartClient()
-    /// path already has its own isRestartInProgress guard; this is
-    /// purely to avoid re-entering mdmConfigChanged while a previous
-    /// restart is still in flight.
-    private var isMDMRestartScheduled = false
+    /// Set when a policy change arrived while a restart was already in
+    /// flight. Go's detector records the newer policy the moment it is
+    /// observed, so it will not report the change again - if this restart
+    /// were simply dropped, that policy would never be applied. The flag
+    /// makes the handler come back for it.
+    private var pendingMDMRestart = false
 
     override func startTunnel(options: [String : NSObject]?, completionHandler: @escaping (Error?) -> Void) {
         if let options = options, let logLevel = options["logLevel"] as? String {
@@ -123,13 +124,6 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             self?.startMonitoringNetworkChanges()
         }
 
-        // Register the MDM fetcher on the gomobile Client instance so
-        // every Run() that triggers Config.apply consults it via the
-        // Client-held mdm.Loader. Per-Client DI on the Go side — no
-        // process-wide state. Called every startTunnel; if the
-        // adapter was just recreated for a profile switch the fresh
-        // Client picks up the same fetcher.
-        adapter?.client.setMDMPolicyFetcher(MDMPolicyFetcher())
         startObservingMDMConfigChanges()
 
         guard let adapter = adapter else {
@@ -787,7 +781,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             mdmConfigObserver = nil
             AppLogger.shared.log("MDM: unsubscribed from managed-configuration changes")
         }
-        isMDMRestartScheduled = false
+        pendingMDMRestart = false
     }
 
     /// Called from the UserDefaults notification. The dedup this shared
@@ -801,20 +795,33 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             return
         }
 
-        if isMDMRestartScheduled {
-            AppLogger.shared.log("MDM: change detected while a previous restart is in flight; new state will be picked up by that run")
-            return
-        }
-        isMDMRestartScheduled = true
         AppLogger.shared.log("MDM: managed configuration changed; restarting client")
         signalMDMPolicyApplied()
-        // Hand off to the existing restart pipeline. It already
-        // serialises against the network-change restart and drives
-        // the UI through ConnectionListener — exactly the flow we
-        // want for an MDM-triggered restart.
+        requestMDMRestart()
+    }
+
+    /// Drives the restart for a policy change, deferring around one already
+    /// in flight.
+    ///
+    /// restartClient() returns immediately and does its work asynchronously,
+    /// and it refuses to start while another restart runs. Calling it during
+    /// one would therefore be a silent no-op for a policy Go has already
+    /// marked as seen. Retry instead until the pipeline is free; its own
+    /// 30-second timeout bounds the wait.
+    private func requestMDMRestart() {
         DispatchQueue.main.async { [weak self] in
-            self?.restartClient()
-            self?.isMDMRestartScheduled = false
+            guard let self = self else { return }
+            guard !self.isRestartInProgress else {
+                self.pendingMDMRestart = true
+                AppLogger.shared.log("MDM: restart already in flight; will retry once it finishes")
+                DispatchQueue.main.asyncAfter(deadline: .now() + 2) { [weak self] in
+                    guard let self = self, self.pendingMDMRestart else { return }
+                    self.requestMDMRestart()
+                }
+                return
+            }
+            self.pendingMDMRestart = false
+            self.restartClient()
         }
     }
 }


### PR DESCRIPTION
## What this does

Completes the iOS side of the MDM integration. The Go layer already made every
policy decision; this wires the native side to it and makes enforcement visible
to the user.

The network extension already registered the policy fetcher on its `Client`,
but the **main app process ran with no policy at all** — login and settings read
an empty policy and silently ignored MDM. The fetcher is now registered on
everything that reads or writes config:

- `Preferences` (`Preferences.newPreferences()`)
- the Go-backed `ProfileManager`
- all four `NetBirdSDKNewAuth` call sites

Registration is unconditional. With no MDM profile installed the fetcher returns
`""`, the policy is empty, and behaviour is identical to today.

## Two things worth flagging for review

**`MDMPolicyFetcher.swift` was in the repository but in no target.** `NetbirdKit/`
is not a synchronized group, so the file the extension referenced was never
compiled — the branch could not build. It is now a member of the four targets
that need it, alongside the new `MDMRestrictions` decoder.

**`getRestrictionsJSON()` is not a throwing call.** gomobile returns a
`_Nonnull NSString*`, which Swift imports as
`getRestrictionsJSON(_ error: NSErrorPointer) -> String`. The Swift brief
described it as `throws`; `hasPreSharedKey` genuinely is.

## UI convention

A gated **feature** (`features.*`) hides its section outright. A managed
**setting** stays visible and is locked, with "Managed by your organization".

A control that silently vanishes reads as a bug; one that is visibly locked
explains itself.

| Key | Effect |
| --- | --- |
| `managementURL` | Hides Settings → Connection; drops the onboarding server step; the profile-creation sheet shows and submits the enforced URL; `ServerView` fails closed |
| `preSharedKey` | Locked "Configured" row, no Save/Remove — the value never crosses the bridge |
| `rosenpassEnabled` / `rosenpassPermissive` | Locks its own toggle, shows the enforced value |
| `disableClientRoutes` | Hides the exit-node selector; the resource list explains instead of listing |
| `disableAutoConnect` | VPN On Demand becomes read-only |
| `disableProfiles` | Hides the Profiles section; no create, switch or remove. Logout stays — Go does not gate it |
| `disableNetworks` | Removes the Resources tab (iOS and tvOS) |
| `disableAdvancedView` | Hides Advanced (the whole section on tvOS) |
| `disableUpdateSettings` | Read-only mode: nothing hidden, every config-mutating control locked |

Keys with no iOS surface (`wireguardPort`, `blockInbound`, `disableServerRoutes`,
`allowServerSSH`, `disableAutostart`, `disableMetricsCollection`,
`splitTunnel*`) are enforced by the engine and have nothing to render.

## Other changes

- Swift-side change detection replaced with `hasMDMPolicyChanged()`, so the
  per-key diff and the dedup the shared `UserDefaults` channel needs both live
  in Go. `lastManagedConfigSnapshot` and the `NSDictionary ==` comparison are
  gone; `isMDMRestartScheduled` stays — it guards restart re-entrancy, not
  diffing.
- `commit()` rejection surfaces as "managed by your organization" and re-reads
  the snapshot, since reaching it means the local view of the policy was stale.
- A policy-applied notification, delivered by the same flag-plus-notification
  path already used for the login-required signal — an extension cannot raise a
  toast itself.
- `Preferences.getPreSharedKey()` is gone from the SDK, so
  `ConfigurationProvider` exposes a write-only setter plus `hasPreSharedKey()`,
  and the screens show whether a key is configured rather than its value.
- `netbird-core` bumped to the `mdm_integration` head, which already contains
  the profile-manager migration `main` points at.

## Decoding

`MDMRestrictions` uses `decodeIfPresent` throughout rather than the synthesized
`Decodable` conformance, so a Go layer that adds or drops a key cannot break the
parse. Any read failure degrades to "nothing managed" — a broken policy must not
lock a user out of their own settings.

## Testing

iOS and tvOS build; the full suite passes. 14 new tests:

- decoder: full snapshot, tri-state `allowServerSSH`, empty, malformed, unknown
  and missing keys
- bridge: a pushed managed configuration read back through Go, partial policies,
  and the no-policy baseline

The bridge tests skip with an explanation when a scheme launch argument pins a
policy — the argument domain outranks every other and cannot be cleared at
runtime, so they would otherwise report a false result.

UI enforcement was verified on a simulator by A/B (the Resources tab disappears
with `disableNetworks` and returns without it) and on a device by injecting the
managed-config dictionary through Xcode launch arguments.

## Known limitations

**The extension reads its own preferences domain.** iOS delivers managed app
configuration to the containing app's domain, and the extension is a separate
process with its own. Under a real MDM it will most likely see an empty policy:
the UI would lock correctly while the engine keeps running the user's old
settings — a compliance illusion rather than compliance.

A throwaway debug build confirmed the extension *can* read a policy placed in
the shared App Group, so the fix is to mirror the dictionary there from the app
process and have the extension read the mirror. Roughly half a day, not included
here.

**Runtime policy changes do not reach the extension.**
`UserDefaults.didChangeNotification` does not cross process boundaries, so the
observer in `PacketTunnelProvider` will not fire for an OS-delivered change. The
same mirroring work needs a Darwin notification alongside it.

**Delivery itself is unverified.** Whether iOS hands the dictionary to the app
under a real MDM has not been exercised — that needs the app installed *by* an
MDM, which requires either the Apple Developer Enterprise Program or a Custom App
through Apple Business Manager. It is Apple plumbing, identical for every app,
and worth checking once rather than blocking on.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added organization-managed settings through mobile device management (MDM).
  * Managed settings display lock indicators and explanatory notices.
  * Organizations can enforce server addresses, profiles, security options, routes, networking, and auto-connect behavior.
  * Policy updates apply automatically, with notifications when configuration changes.
  * Restricted tabs, controls, and profile actions are hidden or read-only on iOS and tvOS.

* **Bug Fixes**
  * Improved handling of managed pre-shared keys and configuration failures.
  * Added clearer explanations when settings are blocked by organizational policy.
  * Improved network extension lifecycle handling during policy-triggered updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->