### PR TITLE
fix: retry a failed restart instead of leaving a tunnel with no engine

### DIFF
--- a/NetBirdTVNetworkExtension/PacketTunnelProvider.swift
+++ b/NetBirdTVNetworkExtension/PacketTunnelProvider.swift
@@ -207,12 +207,16 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
 
     func restartClient() {
         logger.info("restartClient: Restarting client due to network change")
-        adapter?.stop()
-        adapter?.start { error in
-            if let error = error {
-                logger.error("restartClient: Error restarting client: \(error.localizedDescription)")
-            } else {
-                logger.info("restartClient: Client restarted successfully")
+        // Wait for the stop to complete before starting: an overlapping start
+        // inherits the outgoing run's cancellation and fails, leaving the tunnel
+        // installed with no engine behind it (all traffic black-holed).
+        adapter?.stop { [weak self] in
+            self?.adapter?.start { error in
+                if let error = error {
+                    logger.error("restartClient: Error restarting client: \(error.localizedDescription)")
+                } else {
+                    logger.info("restartClient: Client restarted successfully")
+                }
             }
         }
     }

--- a/NetBirdTVNetworkExtension/PacketTunnelProvider.swift
+++ b/NetBirdTVNetworkExtension/PacketTunnelProvider.swift
@@ -95,7 +95,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     }
 
     override func stopTunnel(with reason: NEProviderStopReason, completionHandler: @escaping () -> Void) {
-        adapter?.stop()
+        adapter?.stop(waitForExit: false)
         if let pathMonitor = self.pathMonitor {
             pathMonitor.cancel()
             self.pathMonitor = nil

--- a/NetBirdTVNetworkExtension/PacketTunnelProvider.swift
+++ b/NetBirdTVNetworkExtension/PacketTunnelProvider.swift
@@ -40,6 +40,10 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     let monitorQueue = DispatchQueue(label: "NetworkMonitor")
     var currentNetworkType: NWInterface.InterfaceType?
 
+    /// Restart coalescing state, accessed only on monitorQueue. See restartClient.
+    private var isRestartInProgress = false
+    private var restartPending = false
+
     override func startTunnel(options: [String : NSObject]?, completionHandler: @escaping (Error?) -> Void) {
         // CRITICAL: Log immediately to confirm startTunnel is being called
         // Use privacy: .public to avoid log redaction
@@ -58,6 +62,10 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         }
 
         currentNetworkType = nil
+        monitorQueue.async { [weak self] in
+            self?.isRestartInProgress = false
+            self?.restartPending = false
+        }
         startMonitoringNetworkChanges()
 
         guard let adapter = adapter else {
@@ -205,17 +213,46 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         }
     }
 
+    /// Restarts the client after a network change. Must be called on monitorQueue.
+    ///
+    /// Restarts are coalesced rather than overlapped. NetBirdAdapter.stop fires a
+    /// pending completion as soon as a second stop arrives, so two calls would
+    /// otherwise have their completions run start() concurrently. A network change
+    /// arriving mid-restart therefore only sets a flag, and the restart in flight
+    /// runs one more pass when it finishes.
     func restartClient() {
+        if isRestartInProgress {
+            logger.info("restartClient: restart already in progress, coalescing")
+            restartPending = true
+            return
+        }
+
+        guard let adapter = adapter else {
+            logger.info("restartClient: adapter is nil, nothing to restart")
+            return
+        }
+
+        isRestartInProgress = true
         logger.info("restartClient: Restarting client due to network change")
+
         // Wait for the stop to complete before starting: an overlapping start
         // inherits the outgoing run's cancellation and fails, leaving the tunnel
         // installed with no engine behind it (all traffic black-holed).
-        adapter?.stop { [weak self] in
+        adapter.stop { [weak self] in
             self?.adapter?.start { error in
                 if let error = error {
                     logger.error("restartClient: Error restarting client: \(error.localizedDescription)")
                 } else {
                     logger.info("restartClient: Client restarted successfully")
+                }
+
+                self?.monitorQueue.async {
+                    guard let self = self else { return }
+                    self.isRestartInProgress = false
+                    if self.restartPending {
+                        self.restartPending = false
+                        self.restartClient()
+                    }
                 }
             }
         }

--- a/NetbirdNetworkExtension/NetBirdAdapter.swift
+++ b/NetbirdNetworkExtension/NetBirdAdapter.swift
@@ -556,7 +556,11 @@ public class NetBirdAdapter {
         self.dnsManager.invalidate()
     }
 
-    public func stop(completionHandler: (() -> Void)? = nil) {
+    /// Tears the client down. `waitForExit` blocks until the Go run loop has
+    /// finished, which a restart needs so the next start cannot inherit the
+    /// outgoing run's cancellation. Pass false where the caller is on a
+    /// deadline — stopTunnel gets only a few seconds from iOS.
+    public func stop(waitForExit: Bool = true, completionHandler: (() -> Void)? = nil) {
         stopLock.lock()
 
         // Call any pending handler before setting a new one
@@ -572,7 +576,11 @@ public class NetBirdAdapter {
         self.stopCompletionHandler = completionHandler
         stopLock.unlock()
 
-        self.client.stop()
+        if waitForExit {
+            self.client.stop()
+        } else {
+            self.client.stopWithoutWait()
+        }
 
         // Fallback timeout (15 seconds) in case onDisconnected doesn't fire
         if completionHandler != nil {

--- a/NetbirdNetworkExtension/PacketTunnelProvider.swift
+++ b/NetbirdNetworkExtension/PacketTunnelProvider.swift
@@ -205,7 +205,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         // Reset network unavailable flag when tunnel stops
         adapter?.isNetworkUnavailable = false
         setNetworkUnavailableFlag(false)
-        adapter?.stop()
+        adapter?.stop(waitForExit: false)
         updateWidgetStatus("disconnected")
         guard let pathMonitor = self.pathMonitor else {
             AppLogger.shared.log("pathMonitor is nil; nothing to cancel.")

--- a/NetbirdNetworkExtension/PacketTunnelProvider.swift
+++ b/NetbirdNetworkExtension/PacketTunnelProvider.swift
@@ -77,6 +77,14 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     
     private var networkChangeWorkItem: DispatchWorkItem?
 
+    /// Restart-retry state. A failed restart used to be terminal: the tunnel stayed
+    /// installed with no engine behind it, so every packet was black-holed until the
+    /// user toggled the VPN off. Accessed only on monitorQueue.
+    private var restartRetryCount = 0
+    private var restartRetryWorkItem: DispatchWorkItem?
+    private static let restartMaxRetries = 4
+    private static let restartRetryBaseDelay: TimeInterval = 2.0
+
     override func startTunnel(options: [String : NSObject]?, completionHandler: @escaping (Error?) -> Void) {
         if let options = options, let logLevel = options["logLevel"] as? String {
             initializeLogging(loglevel: logLevel)
@@ -106,6 +114,9 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             self?.currentNetworkType = nil
             self?.wasStoppedDueToNoNetwork = false
             self?.isRestartInProgress = false
+            self?.restartRetryWorkItem?.cancel()
+            self?.restartRetryWorkItem = nil
+            self?.restartRetryCount = 0
             self?.adapter?.isNetworkUnavailable = false
             self?.startMonitoringNetworkChanges()
         }
@@ -184,6 +195,9 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         monitorQueue.async { [weak self] in
             self?.networkChangeWorkItem?.cancel()
             self?.networkChangeWorkItem = nil
+            self?.restartRetryWorkItem?.cancel()
+            self?.restartRetryWorkItem = nil
+            self?.restartRetryCount = 0
             self?.currentNetworkType = nil
             self?.wasStoppedDueToNoNetwork = false
             self?.isRestartInProgress = false
@@ -358,6 +372,10 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             // Cancel any pending restart from previous rapid change
             networkChangeWorkItem?.cancel()
             networkChangeWorkItem = nil
+            // A fresh network change supersedes a pending retry from the previous one.
+            restartRetryWorkItem?.cancel()
+            restartRetryWorkItem = nil
+            restartRetryCount = 0
 
             // Debounce: schedule restart after 1 second
             let workItem = DispatchWorkItem { [weak self] in
@@ -447,14 +465,58 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
                             code: 1001,
                             userInfo: [NSLocalizedDescriptionKey: "Login required."]
                         ))
+                        self?.updateWidgetStatus("disconnected")
+                        return
                     }
                     self?.updateWidgetStatus("disconnected")
+                    // Not a login problem, so the start lost a race with the previous
+                    // run's teardown (its context cancellation lands on the fresh
+                    // client). Retry with backoff; give up by tearing the tunnel down
+                    // rather than leaving it installed with no engine behind it.
+                    self?.monitorQueue.async {
+                        self?.scheduleRestartRetry()
+                    }
                 } else {
                     AppLogger.shared.log("restartClient: start completed successfully")
+                    self?.monitorQueue.async {
+                        self?.restartRetryCount = 0
+                        self?.restartRetryWorkItem?.cancel()
+                        self?.restartRetryWorkItem = nil
+                    }
                     self?.updateWidgetStatus("connected")
                 }
             }
         }
+    }
+
+    /// Retries a failed restart with exponential backoff. Must run on monitorQueue.
+    /// After restartMaxRetries the tunnel is torn down: an installed tunnel with no
+    /// engine behind it black-holes all traffic, which is worse than a clean drop
+    /// the OS and the UI can both see.
+    private func scheduleRestartRetry() {
+        restartRetryWorkItem?.cancel()
+        restartRetryWorkItem = nil
+
+        guard restartRetryCount < Self.restartMaxRetries else {
+            AppLogger.shared.log("restartClient: giving up after \(restartRetryCount) retries — tearing down the tunnel")
+            restartRetryCount = 0
+            cancelTunnelWithError(NSError(
+                domain: "io.netbird.NetbirdNetworkExtension",
+                code: 1005,
+                userInfo: [NSLocalizedDescriptionKey: "Could not restart the NetBird client after a network change."]
+            ))
+            return
+        }
+
+        restartRetryCount += 1
+        let delay = Self.restartRetryBaseDelay * pow(2.0, Double(restartRetryCount - 1))
+        AppLogger.shared.log("restartClient: scheduling retry \(restartRetryCount)/\(Self.restartMaxRetries) in \(delay)s")
+
+        let workItem = DispatchWorkItem { [weak self] in
+            self?.restartClient()
+        }
+        restartRetryWorkItem = workItem
+        monitorQueue.asyncAfter(deadline: .now() + delay, execute: workItem)
     }
 
     /// Signals login required by persisting a flag to the shared app-group container.

--- a/NetbirdNetworkExtension/PacketTunnelProvider.swift
+++ b/NetbirdNetworkExtension/PacketTunnelProvider.swift
@@ -85,6 +85,14 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     private static let restartMaxRetries = 4
     private static let restartRetryBaseDelay: TimeInterval = 2.0
 
+    /// Bumped whenever the tunnel lifecycle moves on: a new tunnel starts, the
+    /// tunnel stops, or a fresh network change supersedes the restart in flight.
+    /// A restart captures it and drops its own callbacks once it no longer
+    /// matches, because NetBirdAdapter.stop fires a pending completion handler
+    /// as soon as a second stop arrives — so a restart's completion can run
+    /// after the lifecycle it belonged to is over. Accessed only on monitorQueue.
+    private var lifecycleToken: UInt64 = 0
+
     override func startTunnel(options: [String : NSObject]?, completionHandler: @escaping (Error?) -> Void) {
         if let options = options, let logLevel = options["logLevel"] as? String {
             initializeLogging(loglevel: logLevel)
@@ -117,6 +125,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             self?.restartRetryWorkItem?.cancel()
             self?.restartRetryWorkItem = nil
             self?.restartRetryCount = 0
+            self?.lifecycleToken &+= 1
             self?.adapter?.isNetworkUnavailable = false
             self?.startMonitoringNetworkChanges()
         }
@@ -198,6 +207,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             self?.restartRetryWorkItem?.cancel()
             self?.restartRetryWorkItem = nil
             self?.restartRetryCount = 0
+            self?.lifecycleToken &+= 1
             self?.currentNetworkType = nil
             self?.wasStoppedDueToNoNetwork = false
             self?.isRestartInProgress = false
@@ -372,10 +382,18 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             // Cancel any pending restart from previous rapid change
             networkChangeWorkItem?.cancel()
             networkChangeWorkItem = nil
-            // A fresh network change supersedes a pending retry from the previous one.
+            // A fresh network change supersedes the restart in flight, pending
+            // retry included: bumping the token also drops the callbacks of a
+            // restart whose stop completion has not fired yet.
             restartRetryWorkItem?.cancel()
             restartRetryWorkItem = nil
             restartRetryCount = 0
+            lifecycleToken &+= 1
+            // The superseded restart's callbacks are now inert, so release the
+            // flags it holds: the debounced restart below must not be refused by
+            // the isRestartInProgress guard.
+            adapter?.isRestarting = false
+            isRestartInProgress = false
 
             // Debounce: schedule restart after 1 second
             let workItem = DispatchWorkItem { [weak self] in
@@ -406,9 +424,15 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         isRestartInProgress = true
         adapter.isRestarting = true
 
+        // The lifecycle this restart belongs to. Every callback below re-checks
+        // it, because adapter.stop fires a pending completion as soon as a
+        // second stop arrives — so this restart's completion can run after
+        // stopTunnel, or after a newer network change took over.
+        let token = lifecycleToken
+
         // Timeout after 30 seconds to reset flags if restart hangs
         let timeoutWorkItem = DispatchWorkItem { [weak self] in
-            guard let self = self, self.isRestartInProgress else { return }
+            guard let self = self, self.isRestartInProgress, self.lifecycleToken == token else { return }
             AppLogger.shared.log("restartClient: timeout - resetting flags")
             self.adapter?.isRestarting = false
             self.isRestartInProgress = false
@@ -416,75 +440,101 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         monitorQueue.asyncAfter(deadline: .now() + 30, execute: timeoutWorkItem)
 
         adapter.stop { [weak self] in
-            AppLogger.shared.log("restartClient: stop completed, checking login status")
+            guard let self = self else { return }
 
-            // Tokens may have expired during a network change (common with self-hosted servers
-            // that have shorter token lifetimes). Check before restarting; if login is required
-            // signal the main app so it can show the re-auth UI instead of silently failing.
-            // The cached check reads the auth state the engine already recorded, so a network
-            // change no longer costs a Login RPC. An expiry the recorder has not seen yet is
-            // still caught one step later: the restarted engine's own login fails with
-            // PermissionDenied and drives onLoginRequired from the connection listener.
-            if self?.adapter?.needsLoginCached() == true {
-                AppLogger.shared.log("restartClient: login required — signaling main app, skipping restart")
-                self?.signalLoginRequired()
-                self?.updateWidgetStatus("disconnected")
-                self?.monitorQueue.async {
-                    self?.adapter?.isRestarting = false
-                    self?.isRestartInProgress = false
+            // Re-check on monitorQueue: the completion can arrive on any thread,
+            // and lifecycleToken is only safe to read there.
+            self.monitorQueue.async {
+                guard self.lifecycleToken == token else {
+                    // Release the flags this restart set, or the next restart is
+                    // refused by the isRestartInProgress guard forever.
+                    AppLogger.shared.log("restartClient: superseded during stop, not starting")
+                    timeoutWorkItem.cancel()
+                    self.adapter?.isRestarting = false
+                    self.isRestartInProgress = false
+                    return
                 }
-                timeoutWorkItem.cancel()
-                return
+                self.continueRestart(token: token, timeoutWorkItem: timeoutWorkItem)
             }
+        }
+    }
 
-            AppLogger.shared.log("restartClient: starting client")
-            self?.adapter?.start { [weak self] error in
-                // Cancel timeout whether start succeeds or not
-                timeoutWorkItem.cancel()
+    /// Second half of restartClient, entered on monitorQueue once the stop that
+    /// belongs to this lifecycle has completed.
+    private func continueRestart(token: UInt64, timeoutWorkItem: DispatchWorkItem) {
+        AppLogger.shared.log("restartClient: stop completed, checking login status")
 
-                self?.monitorQueue.async {
-                    self?.adapter?.isRestarting = false
-                    self?.isRestartInProgress = false
+        // Tokens may have expired during a network change (common with self-hosted servers
+        // that have shorter token lifetimes). Check before restarting; if login is required
+        // signal the main app so it can show the re-auth UI instead of silently failing.
+        // The cached check reads the auth state the engine already recorded, so a network
+        // change no longer costs a Login RPC. An expiry the recorder has not seen yet is
+        // still caught one step later: the restarted engine's own login fails with
+        // PermissionDenied and drives onLoginRequired from the connection listener.
+        if adapter?.needsLoginCached() == true {
+            AppLogger.shared.log("restartClient: login required — signaling main app, skipping restart")
+            signalLoginRequired()
+            updateWidgetStatus("disconnected")
+            adapter?.isRestarting = false
+            isRestartInProgress = false
+            timeoutWorkItem.cancel()
+            return
+        }
+
+        AppLogger.shared.log("restartClient: starting client")
+        adapter?.start { [weak self] error in
+            // Cancel timeout whether start succeeds or not
+            timeoutWorkItem.cancel()
+
+            guard let self = self else { return }
+
+            self.monitorQueue.async {
+                guard self.lifecycleToken == token else {
+                    AppLogger.shared.log("restartClient: superseded during start, dropping the result")
+                    self.adapter?.isRestarting = false
+                    self.isRestartInProgress = false
+                    return
                 }
 
-                if let error = error {
-                    AppLogger.shared.log("restartClient: start failed - \(error.localizedDescription)")
-                    // If the start failed because the session expired, the connection
-                    // listener may have suppressed its login-required signalling: it skips
-                    // both checks while isRestarting is still true, which happens when the
-                    // stop phase never fired onDisconnected (engine already dead) and the
-                    // stop completion arrived via the 15s fallback instead. Re-check the
-                    // recorder here — the engine marks it with PermissionDenied before
-                    // Run() returns — and signal + tear down so the dead tunnel doesn't
-                    // linger and black-hole traffic.
-                    if self?.adapter?.needsLoginCached() == true {
-                        AppLogger.shared.log("restartClient: start failed due to expired login — signaling and tearing down")
-                        self?.signalLoginRequired()
-                        self?.cancelTunnelWithError(NSError(
-                            domain: "io.netbird.NetbirdNetworkExtension",
-                            code: 1001,
-                            userInfo: [NSLocalizedDescriptionKey: "Login required."]
-                        ))
-                        self?.updateWidgetStatus("disconnected")
-                        return
-                    }
-                    self?.updateWidgetStatus("disconnected")
-                    // Not a login problem, so the start lost a race with the previous
-                    // run's teardown (its context cancellation lands on the fresh
-                    // client). Retry with backoff; give up by tearing the tunnel down
-                    // rather than leaving it installed with no engine behind it.
-                    self?.monitorQueue.async {
-                        self?.scheduleRestartRetry()
-                    }
-                } else {
+                self.adapter?.isRestarting = false
+                self.isRestartInProgress = false
+
+                guard let error = error else {
                     AppLogger.shared.log("restartClient: start completed successfully")
-                    self?.monitorQueue.async {
-                        self?.restartRetryCount = 0
-                        self?.restartRetryWorkItem?.cancel()
-                        self?.restartRetryWorkItem = nil
-                    }
-                    self?.updateWidgetStatus("connected")
+                    self.restartRetryCount = 0
+                    self.restartRetryWorkItem?.cancel()
+                    self.restartRetryWorkItem = nil
+                    self.updateWidgetStatus("connected")
+                    return
                 }
+
+                AppLogger.shared.log("restartClient: start failed - \(error.localizedDescription)")
+                self.updateWidgetStatus("disconnected")
+
+                // If the start failed because the session expired, the connection
+                // listener may have suppressed its login-required signalling: it skips
+                // both checks while isRestarting is still true, which happens when the
+                // stop phase never fired onDisconnected (engine already dead) and the
+                // stop completion arrived via the 15s fallback instead. Re-check the
+                // recorder here — the engine marks it with PermissionDenied before
+                // Run() returns — and signal + tear down so the dead tunnel doesn't
+                // linger and black-hole traffic.
+                if self.adapter?.needsLoginCached() == true {
+                    AppLogger.shared.log("restartClient: start failed due to expired login — signaling and tearing down")
+                    self.signalLoginRequired()
+                    self.cancelTunnelWithError(NSError(
+                        domain: "io.netbird.NetbirdNetworkExtension",
+                        code: 1001,
+                        userInfo: [NSLocalizedDescriptionKey: "Login required."]
+                    ))
+                    return
+                }
+
+                // Not a login problem, so the start lost a race with the previous
+                // run's teardown (its context cancellation lands on the fresh
+                // client). Retry with backoff; give up by tearing the tunnel down
+                // rather than leaving it installed with no engine behind it.
+                self.scheduleRestartRetry(token: token)
             }
         }
     }
@@ -492,8 +542,9 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     /// Retries a failed restart with exponential backoff. Must run on monitorQueue.
     /// After restartMaxRetries the tunnel is torn down: an installed tunnel with no
     /// engine behind it black-holes all traffic, which is worse than a clean drop
-    /// the OS and the UI can both see.
-    private func scheduleRestartRetry() {
+    /// the OS and the UI can both see. The token is re-checked when the retry fires,
+    /// so a retry queued before a stop or a newer network change does not run.
+    private func scheduleRestartRetry(token: UInt64) {
         restartRetryWorkItem?.cancel()
         restartRetryWorkItem = nil
 
@@ -513,7 +564,8 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         AppLogger.shared.log("restartClient: scheduling retry \(restartRetryCount)/\(Self.restartMaxRetries) in \(delay)s")
 
         let workItem = DispatchWorkItem { [weak self] in
-            self?.restartClient()
+            guard let self = self, self.lifecycleToken == token else { return }
+            self.restartClient()
         }
         restartRetryWorkItem = workItem
         monitorQueue.asyncAfter(deadline: .now() + delay, execute: workItem)


### PR DESCRIPTION
## Description

A user switching from wifi to cellular lost all Internet traffic until they turned NetBird off. The debug bundle shows `restartClient` tearing the client down, then the restart's `start` failing with `context canceled` because it inherited the outgoing run's cancellation. `needsLoginCached()` was false, so the existing login-expiry branch never ran and the failure handler only logged and set the widget to disconnected. The tunnel stayed installed with no engine behind it — traffic black-holed, no retry, no teardown. `status.txt`, generated ~14 hours later, still reads `Management: Disconnected` / `Peers count: 0/0`.

- The start-failure path now retries with exponential backoff (2/4/8/16s, four attempts) when the failure isn't a login expiry. After the last attempt it calls `cancelTunnelWithError` — a clean drop the OS and UI can both see beats a tunnel that silently black-holes traffic. Pending retries are cancelled on `startTunnel`, `stopTunnel`, and on a fresh network change.
- The tvOS extension called `adapter?.stop()` with no completion handler and started immediately, which guaranteed the overlap. It now waits for the stop to finish.
- Bumps `netbird-core` for the Go-side fix (netbirdio/netbird#7329): `Stop()` waits for the run loop to exit, so a stop completion no longer fires mid-teardown. **That PR should merge first.**

Not verified: no Swift toolchain available where this was written, so the two extension files were reviewed structurally rather than compiled.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tunnel restart reliability when network conditions change.
  * Prevented overlapping or outdated restart attempts from disrupting the current connection.
  * Improved handling of tunnel shutdowns and repeated restart failures.
  * Kept the tunnel available while waiting for device authentication instead of failing immediately.
  * Completed or cancelled pending tunnel starts based on authentication results.
  * Updated connection status to disconnected when login is required.
  * Added diagnostic details to help identify authentication startup issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->