### PR TITLE
fix: harden iOS handoff recovery and resource lifecycle

### DIFF
--- a/NetBird/Source/App/NetBirdApp.swift
+++ b/NetBird/Source/App/NetBirdApp.swift
@@ -37,7 +37,10 @@ private func configureFirebaseIfNeeded() {
           let apiKey = configuration["API_KEY"] as? String,
           apiKey.hasPrefix("AIza"),
           let appID = configuration["GOOGLE_APP_ID"] as? String,
-          appID.contains(":ios:"),
+          appID.range(
+              of: #"^1:[0-9]+:ios:[0-9a-fA-F]+$"#,
+              options: .regularExpression
+          ) != nil,
           let options = FirebaseOptions(contentsOfFile: path) else {
         // Firebase throws an Objective-C exception (which Swift cannot catch)
         // for placeholder or malformed values. Firebase is optional, so local

--- a/NetBird/Source/App/NetBirdApp.swift
+++ b/NetBird/Source/App/NetBirdApp.swift
@@ -32,10 +32,21 @@ private var isRunningUnitTests: Bool {
 /// invalid app ID, aborting the test host before the runner can connect.
 private func configureFirebaseIfNeeded() {
     guard !isRunningUnitTests else { return }
-    if let path = Bundle.main.path(forResource: "GoogleService-Info", ofType: "plist"),
-       let options = FirebaseOptions(contentsOfFile: path) {
-        FirebaseApp.configure(options: options)
+    guard let path = Bundle.main.path(forResource: "GoogleService-Info", ofType: "plist"),
+          let configuration = NSDictionary(contentsOfFile: path) as? [String: Any],
+          let apiKey = configuration["API_KEY"] as? String,
+          apiKey.hasPrefix("AIza"),
+          let appID = configuration["GOOGLE_APP_ID"] as? String,
+          appID.contains(":ios:"),
+          let options = FirebaseOptions(contentsOfFile: path) else {
+        // Firebase throws an Objective-C exception (which Swift cannot catch)
+        // for placeholder or malformed values. Firebase is optional, so local
+        // and CI builds should continue without analytics instead of aborting.
+        NSLog("NetBird: Firebase configuration is absent or invalid; skipping Firebase startup")
+        return
     }
+
+    FirebaseApp.configure(options: options)
 }
 
 #if os(iOS)

--- a/NetBird/Source/App/ViewModels/MainViewModel.swift
+++ b/NetBird/Source/App/ViewModels/MainViewModel.swift
@@ -244,6 +244,15 @@ class ViewModel: ObservableObject {
             }
             .assign(to: &$showInvalidSetupKeyHint)
     }
+
+    deinit {
+        networkMonitor.cancel()
+        #if os(iOS)
+        if let vpnStatusObserver {
+            NotificationCenter.default.removeObserver(vpnStatusObserver)
+        }
+        #endif
+    }
     
     func connect()  {
         logger.info("connect: ENTRY POINT - function called")
@@ -575,7 +584,8 @@ class ViewModel: ObservableObject {
         #if os(iOS)
         refreshCurrentSSID()
         #endif
-        networkExtensionAdapter.startTimer { details in
+        networkExtensionAdapter.startTimer { [weak self] details in
+            guard let self else { return }
             self.checkExtensionState()
             self.checkNetworkUnavailableFlag()
             self.checkLoginRequiredFlag()

--- a/NetBird/Source/App/ViewModels/MainViewModel.swift
+++ b/NetBird/Source/App/ViewModels/MainViewModel.swift
@@ -186,6 +186,7 @@ class ViewModel: ObservableObject {
     @Published var peerViewModel: PeerViewModel
     @Published var routeViewModel: RoutesViewModel
     
+    /// Initializes VPN state, profile caches, network monitoring, and status observers.
     init() {
         let networkExtensionAdapter = NetworkExtensionAdapter()
         self.networkExtensionAdapter = networkExtensionAdapter
@@ -251,6 +252,7 @@ class ViewModel: ObservableObject {
             .assign(to: &$showInvalidSetupKeyHint)
     }
 
+    /// Stops long-lived monitors and removes the VPN status observer.
     deinit {
         networkMonitor.cancel()
         #if os(iOS)
@@ -505,6 +507,9 @@ class ViewModel: ObservableObject {
         }
     }
 
+    /// Reconciles the user-visible VPN state with the extension state and pending user intent.
+    /// - Parameter priorExtensionState: The preceding extension state, used to suppress transient
+    ///   disconnecting events that iOS emits while starting a tunnel.
     func updateVPNDisplayState(priorExtensionState: NEVPNStatus? = nil) {
         let newState: VPNDisplayState
 
@@ -601,6 +606,7 @@ class ViewModel: ObservableObject {
     }
     #endif
 
+    /// Starts periodic extension-status polling and performs an immediate refresh.
     func startPollingDetails() {
         #if os(iOS)
         refreshCurrentSSID()
@@ -674,6 +680,7 @@ class ViewModel: ObservableObject {
     // completion can arrive after a newer .disconnected one, causing a spurious Disconnecting flash.
     private var isCheckingExtensionState = false
 
+    /// Refreshes the status of the flavor-scoped Network Extension manager.
     func checkExtensionState() {
         guard !isCheckingExtensionState else { return }
         isCheckingExtensionState = true
@@ -685,6 +692,8 @@ class ViewModel: ObservableObject {
         }
     }
 
+    /// Applies a newly loaded extension status and updates dependent UI state.
+    /// - Parameter status: The current status reported by Network Extension.
     private func applyExtensionStatus(_ status: NEVPNStatus) {
         let knownStatuses: Set<NEVPNStatus> = [.connected, .disconnected, .connecting, .disconnecting]
         guard knownStatuses.contains(status), extensionState != status else { return }

--- a/NetBird/Source/App/ViewModels/MainViewModel.swift
+++ b/NetBird/Source/App/ViewModels/MainViewModel.swift
@@ -232,7 +232,13 @@ class ViewModel: ObservableObject {
             object: nil,
             queue: .main
         ) { [weak self] _ in
-            self?.handleVPNStatusChangeForNotification()
+            guard let self else { return }
+            self.handleVPNStatusChangeForNotification()
+            // The regular details poll runs every 10 seconds. Refresh the
+            // flavor-scoped manager immediately on each NE status event so
+            // transitions such as .disconnecting -> .disconnected do not wait
+            // for the next polling tick before updating the UI.
+            self.checkExtensionState()
         }
         #endif
 
@@ -448,6 +454,10 @@ class ViewModel: ObservableObject {
 
     /// Performs the actual VPN disconnect.
     func performClose() {
+        // A disconnect also cancels any in-progress connect intent. Keep the
+        // disconnect intent set until iOS confirms .disconnected so the UI can
+        // respond immediately instead of waiting for the next NE status update.
+        self.connectPressed = false
         self.disconnectPressed = true
         DispatchQueue.main.async {
             print("Stopping extension")
@@ -503,16 +513,23 @@ class ViewModel: ObservableObject {
         // between button press and extension state change.
         switch extensionState {
         case .connected:
-            // Extension confirmed connected — clear both flags
-            connectPressed = false
-            disconnectPressed = false
-            newState = .connected
+            if disconnectPressed {
+                newState = .disconnecting
+            } else {
+                // Extension confirmed connected — clear stale connect intent.
+                connectPressed = false
+                newState = .connected
+            }
         case .connecting:
-            // Do NOT clear connectPressed here — iOS can emit .disconnecting right after
-            // .connecting during tunnel startup (cleanup of old instance). Keeping
-            // connectPressed=true lets the .disconnecting handler suppress that noise.
-            // connectPressed is cleared only on .connected or .disconnected.
-            newState = .connecting
+            if disconnectPressed {
+                newState = .disconnecting
+            } else {
+                // Do NOT clear connectPressed here — iOS can emit .disconnecting right after
+                // .connecting during tunnel startup (cleanup of old instance). Keeping
+                // connectPressed=true lets the .disconnecting handler suppress that noise.
+                // connectPressed is cleared only on .connected or .disconnected.
+                newState = .connecting
+            }
         case .disconnecting:
             // Ignore transient .disconnecting emitted by iOS VPN framework during tunnel startup.
             // When startVPNTunnel() is called, iOS briefly reports .disconnecting while cleaning
@@ -520,19 +537,23 @@ class ViewModel: ObservableObject {
             // connectPressed handles this for app-initiated connects.
             // priorExtensionState handles widget-initiated connects where connectPressed is never set.
             let wasConnecting = priorExtensionState == .connecting
-            if connectPressed || wasConnecting {
+            if disconnectPressed {
+                newState = .disconnecting
+            } else if connectPressed || wasConnecting {
                 newState = .connecting
             } else {
-                disconnectPressed = false
                 newState = .disconnecting
             }
         case .disconnected:
             // Extension confirmed disconnected — clear both flags,
             // unless a flag was JUST set (immediate feedback)
-            if connectPressed {
+            if disconnectPressed {
+                connectPressed = false
+                disconnectPressed = false
+                newState = .disconnected
+            } else if connectPressed {
                 newState = .connecting
             } else {
-                disconnectPressed = false
                 newState = .disconnected
             }
         default:

--- a/NetBird/Source/App/ViewModels/MainViewModel.swift
+++ b/NetBird/Source/App/ViewModels/MainViewModel.swift
@@ -468,8 +468,17 @@ class ViewModel: ObservableObject {
                 self.buttonLock = false
             }
             self.networkExtensionAdapter.stop()
-            self.updateVPNDisplayState()
+            self.publishPendingDisconnectState()
         }
+    }
+
+    /// Publishes immediate disconnect feedback while Network Extension processes the request.
+    private func publishPendingDisconnectState() {
+        vpnDisplayState = .disconnecting
+        extensionStateText = "Disconnecting..."
+        #if os(iOS)
+        updateWidgetState()
+        #endif
     }
 
     /// Called when the user dismisses the interactive login browser without completing
@@ -518,23 +527,20 @@ class ViewModel: ObservableObject {
         // between button press and extension state change.
         switch extensionState {
         case .connected:
-            if disconnectPressed {
-                newState = .disconnecting
-            } else {
-                // Extension confirmed connected — clear stale connect intent.
-                connectPressed = false
-                newState = .connected
-            }
+            // A connected extension is authoritative. On Demand may have reconnected
+            // between polls without the app ever sampling .disconnected.
+            connectPressed = false
+            disconnectPressed = false
+            newState = .connected
         case .connecting:
-            if disconnectPressed {
-                newState = .disconnecting
-            } else {
-                // Do NOT clear connectPressed here — iOS can emit .disconnecting right after
-                // .connecting during tunnel startup (cleanup of old instance). Keeping
-                // connectPressed=true lets the .disconnecting handler suppress that noise.
-                // connectPressed is cleared only on .connected or .disconnected.
-                newState = .connecting
-            }
+            // A connecting extension after a disconnect request represents an On Demand
+            // reconnect, so the stale disconnect intent must no longer override it.
+            disconnectPressed = false
+            // Do NOT clear connectPressed here — iOS can emit .disconnecting right after
+            // .connecting during tunnel startup (cleanup of old instance). Keeping
+            // connectPressed=true lets the .disconnecting handler suppress that noise.
+            // connectPressed is cleared only on .connected or .disconnected.
+            newState = .connecting
         case .disconnecting:
             // Ignore transient .disconnecting emitted by iOS VPN framework during tunnel startup.
             // When startVPNTunnel() is called, iOS briefly reports .disconnecting while cleaning
@@ -696,11 +702,18 @@ class ViewModel: ObservableObject {
     /// - Parameter status: The current status reported by Network Extension.
     private func applyExtensionStatus(_ status: NEVPNStatus) {
         let knownStatuses: Set<NEVPNStatus> = [.connected, .disconnected, .connecting, .disconnecting]
-        guard knownStatuses.contains(status), extensionState != status else { return }
+        guard knownStatuses.contains(status) else { return }
 
         let priorState = extensionState
-        extensionState = status
+        let statusChanged = priorState != status
+        if statusChanged {
+            extensionState = status
+        }
         updateVPNDisplayState(priorExtensionState: priorState)
+
+        // Even an unchanged status is an authoritative refresh. Reconciling it above is
+        // important when a short On Demand cycle skipped .disconnected between polls.
+        guard statusChanged else { return }
 
         applyRouteSideEffects(for: status)
 

--- a/NetbirdKit/AppLogger.swift
+++ b/NetbirdKit/AppLogger.swift
@@ -16,6 +16,10 @@ public class AppLogger {
     private var fileHandle: FileHandle?
     private var logFileURL: URL?
     private var isReady = false
+    private var bytesSinceLastSync = 0
+    private var lastSyncDate = Date()
+    private let syncByteThreshold = 16 * 1024
+    private let syncInterval: TimeInterval = 2
     private let setupSemaphore = DispatchSemaphore(value: 0)
 
     private let iso8601Formatter: ISO8601DateFormatter = {
@@ -103,7 +107,12 @@ public class AppLogger {
         rotateLogIfNeeded()
 
         fileHandle?.write(data)
-        try? fileHandle?.synchronize()
+        bytesSinceLastSync += data.count
+        if bytesSinceLastSync >= syncByteThreshold || Date().timeIntervalSince(lastSyncDate) >= syncInterval {
+            try? fileHandle?.synchronize()
+            bytesSinceLastSync = 0
+            lastSyncDate = Date()
+        }
     }
 
     private func rotateLogIfNeeded() {
@@ -120,6 +129,8 @@ public class AppLogger {
                     return
                 }
                 fileHandle = try FileHandle(forWritingTo: url)
+                bytesSinceLastSync = 0
+                lastSyncDate = Date()
             }
         } catch {
             print("AppLogger: Failed to rotate log: \(error)")
@@ -140,6 +151,8 @@ public class AppLogger {
                     return
                 }
                 self?.fileHandle = try FileHandle(forWritingTo: url)
+                self?.bytesSinceLastSync = 0
+                self?.lastSyncDate = Date()
             } catch {
                 print("AppLogger: Failed to clear logs: \(error)")
                 self?.isReady = false

--- a/NetbirdKit/AppLogger.swift
+++ b/NetbirdKit/AppLogger.swift
@@ -17,7 +17,7 @@ public class AppLogger {
     private var logFileURL: URL?
     private var isReady = false
     private var bytesSinceLastSync = 0
-    private var lastSyncDate = Date()
+    private var syncWorkItem: DispatchWorkItem?
     private let syncByteThreshold = 16 * 1024
     private let syncInterval: TimeInterval = 2
     private let setupSemaphore = DispatchSemaphore(value: 0)
@@ -108,10 +108,35 @@ public class AppLogger {
 
         fileHandle?.write(data)
         bytesSinceLastSync += data.count
-        if bytesSinceLastSync >= syncByteThreshold || Date().timeIntervalSince(lastSyncDate) >= syncInterval {
-            try? fileHandle?.synchronize()
+        if bytesSinceLastSync >= syncByteThreshold {
+            synchronizePendingData()
+        } else if syncWorkItem == nil {
+            scheduleSync()
+        }
+    }
+
+    private func scheduleSync() {
+        let workItem = DispatchWorkItem { [weak self] in
+            self?.syncWorkItem = nil
+            self?.synchronizePendingData()
+        }
+        syncWorkItem = workItem
+        queue.asyncAfter(deadline: .now() + syncInterval, execute: workItem)
+    }
+
+    private func synchronizePendingData() {
+        guard bytesSinceLastSync > 0, let fileHandle else { return }
+
+        do {
+            try fileHandle.synchronize()
             bytesSinceLastSync = 0
-            lastSyncDate = Date()
+            syncWorkItem?.cancel()
+            syncWorkItem = nil
+        } catch {
+            // Keep the pending byte count intact and retry even if no more logs arrive.
+            if syncWorkItem == nil {
+                scheduleSync()
+            }
         }
     }
 
@@ -129,8 +154,9 @@ public class AppLogger {
                     return
                 }
                 fileHandle = try FileHandle(forWritingTo: url)
+                syncWorkItem?.cancel()
+                syncWorkItem = nil
                 bytesSinceLastSync = 0
-                lastSyncDate = Date()
             }
         } catch {
             print("AppLogger: Failed to rotate log: \(error)")
@@ -151,8 +177,9 @@ public class AppLogger {
                     return
                 }
                 self?.fileHandle = try FileHandle(forWritingTo: url)
+                self?.syncWorkItem?.cancel()
+                self?.syncWorkItem = nil
                 self?.bytesSinceLastSync = 0
-                self?.lastSyncDate = Date()
             } catch {
                 print("AppLogger: Failed to clear logs: \(error)")
                 self?.isReady = false

--- a/NetbirdKit/AppLogger.swift
+++ b/NetbirdKit/AppLogger.swift
@@ -89,6 +89,7 @@ public class AppLogger {
         setupSemaphore.signal()
     }
 
+    /// Enqueues a timestamped diagnostic message for persistent logging.
     public func log(_ message: String, file: String = #file, function: String = #function, line: Int = #line) {
         let fileName = (file as NSString).lastPathComponent
         let timestamp = iso8601Formatter.string(from: Date())
@@ -101,6 +102,7 @@ public class AppLogger {
         }
     }
 
+    /// Appends one encoded message and schedules or performs a durability sync.
     private func writeToFile(_ message: String) {
         guard isReady, let data = message.data(using: .utf8) else { return }
 
@@ -115,6 +117,7 @@ public class AppLogger {
         }
     }
 
+    /// Schedules a delayed file sync when the byte threshold has not been reached.
     private func scheduleSync() {
         let workItem = DispatchWorkItem { [weak self] in
             self?.syncWorkItem = nil
@@ -124,6 +127,7 @@ public class AppLogger {
         queue.asyncAfter(deadline: .now() + syncInterval, execute: workItem)
     }
 
+    /// Flushes buffered log bytes to durable storage and retains failed work for retry.
     private func synchronizePendingData() {
         guard bytesSinceLastSync > 0, let fileHandle else { return }
 
@@ -140,6 +144,7 @@ public class AppLogger {
         }
     }
 
+    /// Recreates the log file when it exceeds the configured size limit.
     private func rotateLogIfNeeded() {
         guard let url = logFileURL else { return }
 
@@ -165,6 +170,7 @@ public class AppLogger {
         }
     }
 
+    /// Removes existing log contents and creates a fresh writable log file.
     public func clearLogs() {
         queue.async { [weak self] in
             guard let url = self?.logFileURL else { return }

--- a/NetbirdKit/ConnectionListener.swift
+++ b/NetbirdKit/ConnectionListener.swift
@@ -20,6 +20,7 @@ class ConnectionListener: NSObject, NetBirdSDKConnectionListenerProtocol {
     private let pathStatusLock = NSLock()
     private var currentPathStatus: NWPath.Status?
 
+    /// Creates a listener that mirrors engine and physical-network state into the adapter.
     init(adapter: NetBirdAdapter, completionHandler: @escaping (Error?) -> Void) {
         self.completionHandler = completionHandler
         self.adapter = adapter
@@ -33,10 +34,12 @@ class ConnectionListener: NSObject, NetBirdSDKConnectionListenerProtocol {
         pathMonitor.start(queue: pathMonitorQueue)
     }
 
+    /// Stops monitoring the physical network path.
     deinit {
         pathMonitor.cancel()
     }
 
+    /// Whether the physical network is unavailable or has not produced an initial path yet.
     private var isNetworkUnavailableOrUnknown: Bool {
         if adapter.isNetworkUnavailable {
             return true
@@ -49,10 +52,12 @@ class ConnectionListener: NSObject, NetBirdSDKConnectionListenerProtocol {
         return currentPathStatus != .satisfied
     }
 
+    /// Receives address changes; no additional state update is required by the iOS client.
     func onAddressChanged(_ p0: String?, p1: String?) {
         // do nothing
     }
 
+    /// Publishes a successful engine connection and completes tunnel startup.
     func onConnected() {
         let wasRestarting = adapter.isRestarting
         adapter.clientState = .connected
@@ -63,6 +68,7 @@ class ConnectionListener: NSObject, NetBirdSDKConnectionListenerProtocol {
         }
     }
 
+    /// Publishes an engine connection attempt unless a controlled restart is underway.
     func onConnecting() {
         if adapter.isRestarting {
             AppLogger.shared.log("onConnecting: suppressed (isRestarting=true)")
@@ -72,6 +78,7 @@ class ConnectionListener: NSObject, NetBirdSDKConnectionListenerProtocol {
         }
     }
 
+    /// Reconciles an engine disconnect with authentication, network loss, and restart state.
     func onDisconnected() {
         let wasRestarting = adapter.isRestarting
         let shouldKeepTunnelAlive = isNetworkUnavailableOrUnknown
@@ -117,6 +124,7 @@ class ConnectionListener: NSObject, NetBirdSDKConnectionListenerProtocol {
         adapter.notifyStopCompleted()
     }
 
+    /// Publishes an engine disconnect transition unless a controlled restart is underway.
     func onDisconnecting() {
         if adapter.isRestarting {
             AppLogger.shared.log("onDisconnecting: suppressed (isRestarting=true)")
@@ -126,6 +134,7 @@ class ConnectionListener: NSObject, NetBirdSDKConnectionListenerProtocol {
         }
     }
     
+    /// Receives peer-count changes; peer details are loaded through the status endpoint.
     func onPeersListChanged(_ p0: Int) {
         // do nothing
     }

--- a/NetbirdKit/ConnectionListener.swift
+++ b/NetbirdKit/ConnectionListener.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import Network
 import NetBirdSDK
 
 class ConnectionListener: NSObject, NetBirdSDKConnectionListenerProtocol {
@@ -26,7 +25,6 @@ class ConnectionListener: NSObject, NetBirdSDKConnectionListenerProtocol {
 
     func onConnected() {
         let wasRestarting = adapter.isRestarting
-        adapter.isRestarting = false
         adapter.clientState = .connected
         AppLogger.shared.log("onConnected: state=connected, wasRestarting=\(wasRestarting)")
 
@@ -44,31 +42,9 @@ class ConnectionListener: NSObject, NetBirdSDKConnectionListenerProtocol {
         }
     }
 
-    /// Check if network is currently available using synchronous path check
-    private func isNetworkAvailable() -> Bool {
-        let monitor = NWPathMonitor()
-        let semaphore = DispatchSemaphore(value: 0)
-        var isAvailable = false
-
-        monitor.pathUpdateHandler = { path in
-            isAvailable = path.status == .satisfied
-            semaphore.signal()
-        }
-
-        let queue = DispatchQueue(label: "NetworkCheck")
-        monitor.start(queue: queue)
-
-        // Wait up to 100ms for network status
-        _ = semaphore.wait(timeout: .now() + 0.1)
-        monitor.cancel()
-
-        return isAvailable
-    }
-
     func onDisconnected() {
         let wasRestarting = adapter.isRestarting
         let isNetworkUnavailableFlag = adapter.isNetworkUnavailable
-        adapter.isRestarting = false
 
         // Session expiry takes priority over the keep-alive-on-network-loss logic below.
         // If the last management error was an auth failure there is nothing to reconnect
@@ -85,16 +61,14 @@ class ConnectionListener: NSObject, NetBirdSDKConnectionListenerProtocol {
             return
         }
 
-        // Check both the flag AND actual network status
-        // This handles race condition where Go SDK fires onDisconnected before our handler sets the flag
-        let networkAvailable = isNetworkAvailable()
-        let shouldStayConnecting = isNetworkUnavailableFlag || !networkAvailable
-
         // When network is unavailable, keep the tunnel alive by staying in "connecting" state
         // instead of "disconnected". This allows automatic reconnection when network returns.
-        if shouldStayConnecting {
+        // PacketTunnelProvider owns the long-lived NWPathMonitor and publishes its result
+        // through this flag. Creating another monitor here and waiting only 100 ms often
+        // timed out before its first update, falsely reporting an available path as down.
+        if isNetworkUnavailableFlag {
             adapter.clientState = .connecting
-            AppLogger.shared.log("onDisconnected: network unavailable (flag=\(isNetworkUnavailableFlag), networkAvailable=\(networkAvailable)) - staying in connecting state for auto-reconnect, wasRestarting=\(wasRestarting)")
+            AppLogger.shared.log("onDisconnected: network unavailable - staying in connecting state for auto-reconnect, wasRestarting=\(wasRestarting)")
         } else {
             adapter.clientState = .disconnected
             AppLogger.shared.log("onDisconnected: state=disconnected, wasRestarting=\(wasRestarting)")

--- a/NetbirdKit/ConnectionListener.swift
+++ b/NetbirdKit/ConnectionListener.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import Network
 import NetBirdSDK
 
 class ConnectionListener: NSObject, NetBirdSDKConnectionListenerProtocol {
@@ -14,9 +15,38 @@ class ConnectionListener: NSObject, NetBirdSDKConnectionListenerProtocol {
 
     var adapter: NetBirdAdapter
 
+    private let pathMonitor = NWPathMonitor()
+    private let pathMonitorQueue = DispatchQueue(label: "io.netbird.connection-listener.path")
+    private let pathStatusLock = NSLock()
+    private var currentPathStatus: NWPath.Status?
+
     init(adapter: NetBirdAdapter, completionHandler: @escaping (Error?) -> Void) {
         self.completionHandler = completionHandler
         self.adapter = adapter
+        super.init()
+
+        pathMonitor.pathUpdateHandler = { [weak self] path in
+            self?.pathStatusLock.lock()
+            self?.currentPathStatus = path.status
+            self?.pathStatusLock.unlock()
+        }
+        pathMonitor.start(queue: pathMonitorQueue)
+    }
+
+    deinit {
+        pathMonitor.cancel()
+    }
+
+    private var isNetworkUnavailableOrUnknown: Bool {
+        if adapter.isNetworkUnavailable {
+            return true
+        }
+
+        pathStatusLock.lock()
+        defer { pathStatusLock.unlock() }
+        // Until the monitor publishes its first path, avoid turning a transient SDK
+        // disconnect into a terminal state. Authentication failures are handled first.
+        return currentPathStatus != .satisfied
     }
 
     func onAddressChanged(_ p0: String?, p1: String?) {
@@ -44,7 +74,7 @@ class ConnectionListener: NSObject, NetBirdSDKConnectionListenerProtocol {
 
     func onDisconnected() {
         let wasRestarting = adapter.isRestarting
-        let isNetworkUnavailableFlag = adapter.isNetworkUnavailable
+        let shouldKeepTunnelAlive = isNetworkUnavailableOrUnknown
 
         // Session expiry takes priority over the keep-alive-on-network-loss logic below.
         // If the last management error was an auth failure there is nothing to reconnect
@@ -63,10 +93,10 @@ class ConnectionListener: NSObject, NetBirdSDKConnectionListenerProtocol {
 
         // When network is unavailable, keep the tunnel alive by staying in "connecting" state
         // instead of "disconnected". This allows automatic reconnection when network returns.
-        // PacketTunnelProvider owns the long-lived NWPathMonitor and publishes its result
-        // through this flag. Creating another monitor here and waiting only 100 ms often
-        // timed out before its first update, falsely reporting an available path as down.
-        if isNetworkUnavailableFlag {
+        // Prefer the provider's published flag and use this listener's long-lived cached
+        // path as a fallback. That closes the callback-ordering window without blocking
+        // an SDK callback while waiting for a newly-created monitor's first update.
+        if shouldKeepTunnelAlive {
             adapter.clientState = .connecting
             AppLogger.shared.log("onDisconnected: network unavailable - staying in connecting state for auto-reconnect, wasRestarting=\(wasRestarting)")
         } else {

--- a/NetbirdKit/NetworkExtensionAdapter.swift
+++ b/NetbirdKit/NetworkExtensionAdapter.swift
@@ -92,7 +92,7 @@ public class NetworkExtensionAdapter: ObservableObject {
     var extensionName = "NetBird"
     private let loginRetryState = LoginRetryState()
     #else
-    var extensionID = "io.netbird.app.NetbirdNetworkExtension"
+    var extensionID = "\(Bundle.main.bundleIdentifier ?? "io.netbird.app").NetbirdNetworkExtension"
     var extensionName = "NetBird Network Extension"
     #endif
 

--- a/NetbirdKit/NetworkExtensionAdapter.swift
+++ b/NetbirdKit/NetworkExtensionAdapter.swift
@@ -1313,7 +1313,7 @@ public class NetworkExtensionAdapter: ObservableObject {
     func startTimer(completion: @escaping (StatusDetails) -> Void) {
         self.timer.invalidate()
         self.fetchData(completion: completion)
-        self.timer = Timer.scheduledTimer(withTimeInterval: 3, repeats: true, block: { [weak self] _ in
+        self.timer = Timer.scheduledTimer(withTimeInterval: 10, repeats: true, block: { [weak self] _ in
             self?.fetchData(completion: completion)
         })
     }

--- a/NetbirdKit/NetworkExtensionAdapter.swift
+++ b/NetbirdKit/NetworkExtensionAdapter.swift
@@ -1258,13 +1258,17 @@ public class NetworkExtensionAdapter: ObservableObject {
         // This is to make sure completion is called only once
         let safeCompletion: (StatusDetails) -> Void = { [weak self] status in
             completionLock.lock()
-            defer { completionLock.unlock() }
-            
-            guard !hasCompleted else { return }
+            guard !hasCompleted else {
+                completionLock.unlock()
+                return
+            }
             hasCompleted = true
-            
-            self?.isFetchingStatus = false
-            completion(status)
+            completionLock.unlock()
+
+            DispatchQueue.main.async {
+                self?.isFetchingStatus = false
+                completion(status)
+            }
         }
         
         // Timeout after 10 seconds to reset fetching status to false
@@ -1309,8 +1313,8 @@ public class NetworkExtensionAdapter: ObservableObject {
     func startTimer(completion: @escaping (StatusDetails) -> Void) {
         self.timer.invalidate()
         self.fetchData(completion: completion)
-        self.timer = Timer.scheduledTimer(withTimeInterval: 3, repeats: true, block: { _ in
-            self.fetchData(completion: completion)
+        self.timer = Timer.scheduledTimer(withTimeInterval: 3, repeats: true, block: { [weak self] _ in
+            self?.fetchData(completion: completion)
         })
     }
     

--- a/NetbirdKit/NetworkExtensionAdapter.swift
+++ b/NetbirdKit/NetworkExtensionAdapter.swift
@@ -1239,6 +1239,7 @@ public class NetworkExtensionAdapter: ObservableObject {
         }
     }
 
+    /// Requests current tunnel status, completing once even when IPC times out or fails.
     func fetchData(completion: @escaping (StatusDetails) -> Void) {
         guard !isFetchingStatus else {
             return
@@ -1310,6 +1311,7 @@ public class NetworkExtensionAdapter: ObservableObject {
         }
     }
     
+    /// Starts status polling and delivers an immediate first result.
     func startTimer(completion: @escaping (StatusDetails) -> Void) {
         self.timer.invalidate()
         self.fetchData(completion: completion)
@@ -1318,6 +1320,7 @@ public class NetworkExtensionAdapter: ObservableObject {
         })
     }
     
+    /// Stops periodic status polling.
     func stopTimer() {
         self.timer.invalidate()
     }
@@ -1393,6 +1396,7 @@ public class NetworkExtensionAdapter: ObservableObject {
     }
     #endif
 
+    /// Loads the manager matching this build flavor and returns its connection status.
     func getExtensionStatus(completion: @escaping (NEVPNStatus) -> Void) {
         Task {
             do {

--- a/NetbirdKit/NetworkExtensionAdapter.swift
+++ b/NetbirdKit/NetworkExtensionAdapter.swift
@@ -1397,7 +1397,10 @@ public class NetworkExtensionAdapter: ObservableObject {
         Task {
             do {
                 let managers = try await NETunnelProviderManager.loadAllFromPreferences()
-                if let manager = managers.first(where: { $0.localizedDescription == self.extensionName }) {
+                if let manager = managers.first(where: {
+                    $0.localizedDescription == self.extensionName &&
+                    ($0.protocolConfiguration as? NETunnelProviderProtocol)?.providerBundleIdentifier == self.extensionID
+                }) {
                     completion(manager.connection.status)
                 } else {
                     // No VPN manager exists yet (e.g. first connect before the iOS permission

--- a/NetbirdKit/Preferences.swift
+++ b/NetbirdKit/Preferences.swift
@@ -80,7 +80,24 @@ class Preferences {
     static func configFile() -> String? {
         #if os(iOS)
         // Use profile-aware paths on iOS
-        return ProfileManager.shared.activeConfigPath()
+        guard let path = ProfileManager.shared.activeConfigPath() else {
+            return nil
+        }
+
+        // A development reinstall or app-group container migration can preserve
+        // shared defaults while leaving the file-backed SDK configuration absent.
+        // Restore the authenticated legacy snapshot before the first login/status
+        // check so the tunnel is not started with a non-existent config path.
+        if !FileManager.default.fileExists(atPath: path),
+           let configJSON = loadConfigFromUserDefaults() {
+            do {
+                try configJSON.write(toFile: path, atomically: true, encoding: .utf8)
+                AppLogger.shared.log("Restored missing active profile configuration from shared defaults")
+            } catch {
+                AppLogger.shared.log("Failed to restore active profile configuration: \(error)")
+            }
+        }
+        return path
         #elseif os(tvOS)
         // App Group container is not writable on tvOS, so the config path handed
         // to NetBirdSDKNewAuth must live in a writable directory — otherwise the

--- a/NetbirdKit/Preferences.swift
+++ b/NetbirdKit/Preferences.swift
@@ -80,24 +80,7 @@ class Preferences {
     static func configFile() -> String? {
         #if os(iOS)
         // Use profile-aware paths on iOS
-        guard let path = ProfileManager.shared.activeConfigPath() else {
-            return nil
-        }
-
-        // A development reinstall or app-group container migration can preserve
-        // shared defaults while leaving the file-backed SDK configuration absent.
-        // Restore the authenticated legacy snapshot before the first login/status
-        // check so the tunnel is not started with a non-existent config path.
-        if !FileManager.default.fileExists(atPath: path),
-           let configJSON = loadConfigFromUserDefaults() {
-            do {
-                try configJSON.write(toFile: path, atomically: true, encoding: .utf8)
-                AppLogger.shared.log("Restored missing active profile configuration from shared defaults")
-            } catch {
-                AppLogger.shared.log("Failed to restore active profile configuration: \(error)")
-            }
-        }
-        return path
+        return ProfileManager.shared.activeConfigPath()
         #elseif os(tvOS)
         // App Group container is not writable on tvOS, so the config path handed
         // to NetBirdSDKNewAuth must live in a writable directory — otherwise the

--- a/NetbirdNetworkExtension/PacketTunnelProvider.swift
+++ b/NetbirdNetworkExtension/PacketTunnelProvider.swift
@@ -91,6 +91,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     
     private var networkChangeWorkItem: DispatchWorkItem?
 
+    /// Starts the selected profile's NetBird engine and completes Network Extension startup.
     override func startTunnel(options: [String : NSObject]?, completionHandler: @escaping (Error?) -> Void) {
         if let options = options, let logLevel = options["logLevel"] as? String {
             initializeLogging(loglevel: logLevel)
@@ -200,6 +201,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         }
     }
 
+    /// Stops monitoring and the NetBird engine before completing tunnel teardown.
     override func stopTunnel(with reason: NEProviderStopReason, completionHandler: @escaping () -> Void) {
         monitorQueue.async { [weak self] in
             self?.networkChangeWorkItem?.cancel()
@@ -304,6 +306,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         }
     }
 
+    /// Starts a long-lived path monitor used to reconcile Wi-Fi and cellular transitions.
     func startMonitoringNetworkChanges() {
         pathMonitor?.cancel()
         let monitor = NWPathMonitor()
@@ -315,6 +318,8 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         pathMonitor = monitor
     }
 
+    /// Debounces and reconciles physical path loss, recovery, and interface changes.
+    /// - Parameter path: The latest path published by the provider's network monitor.
     func handleNetworkChange(path: Network.NWPath) {
         guard !isTunnelStopping else { return }
         latestPathIsSatisfied = path.status == .satisfied
@@ -413,6 +418,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         }
     }
 
+    /// Runs one serialized engine stop/start transaction against the latest usable path.
     func restartClient() {
         networkChangeWorkItem = nil
 

--- a/NetbirdNetworkExtension/PacketTunnelProvider.swift
+++ b/NetbirdNetworkExtension/PacketTunnelProvider.swift
@@ -74,6 +74,20 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     private var currentNetworkType: NWInterface.InterfaceType?
     private var wasStoppedDueToNoNetwork = false
     private var isRestartInProgress = false
+    /// A path change that arrived while a stop/start transaction was in flight.
+    /// Handoffs commonly emit several path updates; dropping the later update can
+    /// leave the newly-started client bound to an intermediate path indefinitely.
+    private var restartPending = false
+    private var latestPathIsSatisfied = false
+    /// Identifies the only restart transaction whose asynchronous callbacks may
+    /// mutate state. Incrementing this invalidates callbacks from a timed-out or
+    /// stopped transaction so they cannot overlap a newer engine instance.
+    private var restartGeneration: UInt64 = 0
+    private var activeRestartGeneration: UInt64?
+    private var isTunnelStopping = false
+    private var restartRetryCount = 0
+    private static let restartMaxRetries = 4
+    private static let restartRetryBaseDelay: TimeInterval = 2.0
     
     private var networkChangeWorkItem: DispatchWorkItem?
 
@@ -106,6 +120,12 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             self?.currentNetworkType = nil
             self?.wasStoppedDueToNoNetwork = false
             self?.isRestartInProgress = false
+            self?.restartPending = false
+            self?.latestPathIsSatisfied = false
+            self?.restartGeneration &+= 1
+            self?.activeRestartGeneration = nil
+            self?.isTunnelStopping = false
+            self?.restartRetryCount = 0
             self?.adapter?.isNetworkUnavailable = false
             self?.startMonitoringNetworkChanges()
         }
@@ -187,6 +207,13 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             self?.currentNetworkType = nil
             self?.wasStoppedDueToNoNetwork = false
             self?.isRestartInProgress = false
+            self?.restartPending = false
+            self?.latestPathIsSatisfied = false
+            self?.restartGeneration &+= 1
+            self?.activeRestartGeneration = nil
+            self?.isTunnelStopping = true
+            self?.restartRetryCount = 0
+            self?.adapter?.isRestarting = false
         }
         // Reset network unavailable flag when tunnel stops
         adapter?.isNetworkUnavailable = false
@@ -278,6 +305,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     }
 
     func startMonitoringNetworkChanges() {
+        pathMonitor?.cancel()
         let monitor = NWPathMonitor()
         monitor.pathUpdateHandler = { [weak self] path in
             self?.handleNetworkChange(path: path)
@@ -288,6 +316,8 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     }
 
     func handleNetworkChange(path: Network.NWPath) {
+        guard !isTunnelStopping else { return }
+        latestPathIsSatisfied = path.status == .satisfied
         AppLogger.shared.log("""
                   Path update:
                   - status: \(path.status)
@@ -303,6 +333,13 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             // Cancel any pending restart
             networkChangeWorkItem?.cancel()
             networkChangeWorkItem = nil
+
+            // If the physical path disappears during a restart, do not let the
+            // in-flight transaction be considered final. Recovery must reconcile
+            // once more against the path that eventually becomes usable.
+            if isRestartInProgress {
+                restartPending = true
+            }
 
             // Signal UI to show disconnecting animation via shared flag
             // We don't call adapter.stop() to avoid race conditions with Go SDK callbacks
@@ -355,17 +392,19 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         if networkTypeChanged || shouldRestartDueToRecovery {
             AppLogger.shared.log("Scheduling restart: networkTypeChanged=\(networkTypeChanged), shouldRestartDueToRecovery=\(shouldRestartDueToRecovery)")
 
-            // Cancel any pending restart from previous rapid change
-            networkChangeWorkItem?.cancel()
-            networkChangeWorkItem = nil
-
-            // Debounce: schedule restart after 1 second
-            let workItem = DispatchWorkItem { [weak self] in
-                self?.restartClient()
+            // A restart already in progress cannot absorb a new path. Remember it
+            // and run another reconciliation after the current transaction ends.
+            if isRestartInProgress {
+                restartPending = true
+                if let newType = newNetworkType {
+                    currentNetworkType = newType
+                }
+                return
             }
 
-            networkChangeWorkItem = workItem
-            monitorQueue.asyncAfter(deadline: .now() + 1.0, execute: workItem)
+            // Cancel any pending restart from previous rapid change
+            restartRetryCount = 0
+            scheduleRestart(after: 1.0)
         }
 
         // Update current network type only if known
@@ -375,30 +414,66 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     }
 
     func restartClient() {
+        networkChangeWorkItem = nil
+
+        guard !isTunnelStopping else {
+            AppLogger.shared.log("restartClient: ignored while tunnel is stopping")
+            return
+        }
+
         guard let adapter = adapter else {
             AppLogger.shared.log("restartClient: adapter is nil")
             return
         }
 
         if isRestartInProgress {
-            AppLogger.shared.log("restartClient: skipping - restart already in progress")
+            AppLogger.shared.log("restartClient: queuing follow-up - restart already in progress")
+            restartPending = true
             return
         }
         AppLogger.shared.log("restartClient: starting restart sequence")
         isRestartInProgress = true
         adapter.isRestarting = true
+        restartGeneration &+= 1
+        let generation = restartGeneration
+        activeRestartGeneration = generation
 
-        // Timeout after 30 seconds to reset flags if restart hangs
+        // A hung Go stop/start must fail closed. Merely clearing the flags would
+        // allow another restart to overlap it, and its late callback could revive
+        // an engine attached to a stale network path.
         let timeoutWorkItem = DispatchWorkItem { [weak self] in
-            guard let self = self, self.isRestartInProgress else { return }
-            AppLogger.shared.log("restartClient: timeout - resetting flags")
-            self.adapter?.isRestarting = false
-            self.isRestartInProgress = false
+            guard let self = self,
+                  self.activeRestartGeneration == generation else { return }
+            AppLogger.shared.log("restartClient[\(generation)]: timeout - tearing down stale tunnel")
+            self.restartPending = false
+            self.finishRestartTransaction(generation: generation, schedulePending: false)
+            self.updateWidgetStatus("disconnected")
+            self.cancelTunnelWithError(NSError(
+                domain: "io.netbird.NetbirdNetworkExtension",
+                code: 1002,
+                userInfo: [NSLocalizedDescriptionKey: "VPN restart timed out."]
+            ))
         }
         monitorQueue.asyncAfter(deadline: .now() + 30, execute: timeoutWorkItem)
 
         adapter.stop { [weak self] in
-            AppLogger.shared.log("restartClient: stop completed, checking login status")
+            self?.monitorQueue.async { [weak self] in
+                guard let self = self else { return }
+                guard self.activeRestartGeneration == generation else {
+                    AppLogger.shared.log("restartClient[\(generation)]: ignoring stale stop completion")
+                    return
+                }
+                AppLogger.shared.log("restartClient[\(generation)]: stop completed, checking path and login status")
+
+                // Never start the engine against an unavailable path. The next
+                // satisfied NWPath update will schedule the pending reconciliation.
+                guard self.latestPathIsSatisfied else {
+                    AppLogger.shared.log("restartClient: path unavailable after stop - waiting for recovery")
+                    self.restartPending = true
+                    timeoutWorkItem.cancel()
+                    self.finishRestartTransaction(generation: generation)
+                    return
+                }
 
             // Tokens may have expired during a network change (common with self-hosted servers
             // that have shorter token lifetimes). Check before restarting; if login is required
@@ -407,29 +482,27 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             // change no longer costs a Login RPC. An expiry the recorder has not seen yet is
             // still caught one step later: the restarted engine's own login fails with
             // PermissionDenied and drives onLoginRequired from the connection listener.
-            if self?.adapter?.needsLoginCached() == true {
+            if self.adapter?.needsLoginCached() == true {
                 AppLogger.shared.log("restartClient: login required — signaling main app, skipping restart")
-                self?.signalLoginRequired()
-                self?.updateWidgetStatus("disconnected")
-                self?.monitorQueue.async {
-                    self?.adapter?.isRestarting = false
-                    self?.isRestartInProgress = false
-                }
+                self.signalLoginRequired()
+                self.updateWidgetStatus("disconnected")
                 timeoutWorkItem.cancel()
+                self.finishRestartTransaction(generation: generation, schedulePending: false)
                 return
             }
 
             AppLogger.shared.log("restartClient: starting client")
-            self?.adapter?.start { [weak self] error in
+            self.adapter?.start { [weak self] error in
                 // Cancel timeout whether start succeeds or not
                 timeoutWorkItem.cancel()
 
-                self?.monitorQueue.async {
-                    self?.adapter?.isRestarting = false
-                    self?.isRestartInProgress = false
-                }
-
-                if let error = error {
+                self?.monitorQueue.async { [weak self] in
+                    guard let self = self else { return }
+                    guard self.activeRestartGeneration == generation else {
+                        AppLogger.shared.log("restartClient[\(generation)]: ignoring stale start completion")
+                        return
+                    }
+                    if let error = error {
                     AppLogger.shared.log("restartClient: start failed - \(error.localizedDescription)")
                     // If the start failed because the session expired, the connection
                     // listener may have suppressed its login-required signalling: it skips
@@ -439,22 +512,99 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
                     // recorder here — the engine marks it with PermissionDenied before
                     // Run() returns — and signal + tear down so the dead tunnel doesn't
                     // linger and black-hole traffic.
-                    if self?.adapter?.needsLoginCached() == true {
+                    if self.adapter?.needsLoginCached() == true {
                         AppLogger.shared.log("restartClient: start failed due to expired login — signaling and tearing down")
-                        self?.signalLoginRequired()
-                        self?.cancelTunnelWithError(NSError(
+                        self.signalLoginRequired()
+                        self.cancelTunnelWithError(NSError(
                             domain: "io.netbird.NetbirdNetworkExtension",
                             code: 1001,
                             userInfo: [NSLocalizedDescriptionKey: "Login required."]
                         ))
+                        self.updateWidgetStatus("disconnected")
+                        self.finishRestartTransaction(generation: generation, schedulePending: false)
+                        return
                     }
-                    self?.updateWidgetStatus("disconnected")
+                    self.updateWidgetStatus("disconnected")
+                    let pathChangedAgain = self.restartPending && self.latestPathIsSatisfied
+                    self.finishRestartTransaction(generation: generation)
+                    if !pathChangedAgain {
+                        self.scheduleRestartRetry(afterFailureOf: generation)
+                    }
                 } else {
                     AppLogger.shared.log("restartClient: start completed successfully")
-                    self?.updateWidgetStatus("connected")
+                    self.restartRetryCount = 0
+                    self.updateWidgetStatus("connected")
+                    self.finishRestartTransaction(generation: generation)
+                }
                 }
             }
+            }
         }
+    }
+
+    /// Completes one serialized stop/start transaction and, if the path changed
+    /// while it was running, schedules exactly one follow-up reconciliation.
+    /// Must be called on monitorQueue.
+    private func finishRestartTransaction(generation: UInt64, schedulePending: Bool = true) {
+        guard activeRestartGeneration == generation else { return }
+        adapter?.isRestarting = false
+        isRestartInProgress = false
+        activeRestartGeneration = nil
+
+        guard schedulePending else {
+            restartPending = false
+            return
+        }
+        guard restartPending, latestPathIsSatisfied else { return }
+        restartPending = false
+        scheduleRestart(after: 1.0)
+    }
+
+    /// Replaces any not-yet-started reconciliation with one debounce timer.
+    /// Must be called on monitorQueue.
+    private func scheduleRestart(after delay: TimeInterval) {
+        networkChangeWorkItem?.cancel()
+        let workItem = DispatchWorkItem { [weak self] in
+            self?.networkChangeWorkItem = nil
+            self?.restartClient()
+        }
+        networkChangeWorkItem = workItem
+        monitorQueue.asyncAfter(deadline: .now() + delay, execute: workItem)
+    }
+
+    /// Retries a failed engine start with bounded exponential backoff. A stop,
+    /// newer path change, or newer restart invalidates/cancels the queued work.
+    /// Must be called on monitorQueue.
+    private func scheduleRestartRetry(afterFailureOf generation: UInt64) {
+        guard !isTunnelStopping, latestPathIsSatisfied else { return }
+
+        guard restartRetryCount < Self.restartMaxRetries else {
+            AppLogger.shared.log("restartClient: exhausted \(Self.restartMaxRetries) retries - tearing down tunnel")
+            restartRetryCount = 0
+            cancelTunnelWithError(NSError(
+                domain: "io.netbird.NetbirdNetworkExtension",
+                code: 1005,
+                userInfo: [NSLocalizedDescriptionKey: "Could not restart NetBird after a network change."]
+            ))
+            return
+        }
+
+        restartRetryCount += 1
+        let attempt = restartRetryCount
+        let delay = Self.restartRetryBaseDelay * pow(2.0, Double(attempt - 1))
+        AppLogger.shared.log("restartClient: scheduling retry \(attempt)/\(Self.restartMaxRetries) in \(delay)s")
+
+        networkChangeWorkItem?.cancel()
+        let workItem = DispatchWorkItem { [weak self] in
+            guard let self = self,
+                  !self.isTunnelStopping,
+                  self.latestPathIsSatisfied,
+                  self.restartGeneration == generation else { return }
+            self.networkChangeWorkItem = nil
+            self.restartClient()
+        }
+        networkChangeWorkItem = workItem
+        monitorQueue.asyncAfter(deadline: .now() + delay, execute: workItem)
     }
 
     /// Signals login required by persisting a flag to the shared app-group container.
@@ -714,7 +864,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
 func initializeLogging(loglevel: String) {
     let fileManager = FileManager.default
 
-    let groupURL = fileManager.containerURL(forSecurityApplicationGroupIdentifier: "group.io.netbird.app")
+    let groupURL = fileManager.containerURL(forSecurityApplicationGroupIdentifier: GlobalConstants.userPreferencesSuiteName)
     let logURL = groupURL?.appendingPathComponent("logfile.log")
 
     var error: NSError?


### PR DESCRIPTION
## Summary

This change hardens the iOS packet-tunnel lifecycle during Wi-Fi/cellular handoffs and reduces avoidable foreground memory, polling, and logging overhead.

### Network handoff and recovery

- serialize each engine stop/start as one restart transaction
- queue a follow-up reconciliation when another path update arrives during a restart instead of dropping that update
- track restart generations and ignore stale stop/start completions after a timeout, tunnel stop, or newer transaction
- never start the engine while `NWPath` is unavailable; wait for a satisfied path and reconcile then
- retry non-authentication startup failures with bounded exponential backoff at 2, 4, 8, and 16 seconds
- tear down the tunnel after a hung restart or exhausted retries rather than leaving an installed tunnel with no engine behind it to black-hole traffic
- make path monitoring idempotent and ignore path callbacks while the tunnel is stopping
- keep `isRestarting` owned by the complete restart transaction instead of clearing it early from connection callbacks
- use the provider’s long-lived path state during disconnect callbacks instead of creating another `NWPathMonitor` and waiting only 100 ms for its first update

### Resource and memory lifecycle

- break the retain cycle between `ViewModel`, `NetworkExtensionAdapter`, its `Timer`, and the polling callback
- cancel the view model path monitor and remove its VPN-status observer during teardown
- release the status completion lock before invoking client code
- deliver status updates on the main queue
- reduce foreground full-status polling from every 3 seconds to every 10 seconds

### Logging and startup robustness

- batch file synchronization by elapsed time or buffered byte count rather than forcing a filesystem sync for every Swift log line
- validate optional Firebase configuration before calling `FirebaseApp.configure`; malformed or CI-placeholder configuration now disables Firebase instead of raising an uncaught Objective-C exception at startup

## Why

Wi-Fi/cellular transitions can produce several `NWPath` updates while the previous Go engine is still stopping. The previous implementation discarded updates received during an active restart and allowed connection callbacks to clear restart state before the transaction completed. A late completion could then act on a newer lifecycle, while a failed start left the tunnel installed without a working engine.

`ConnectionListener` also created a new path monitor for each disconnect and waited only 100 ms. A fresh monitor is not guaranteed to publish its initial path in that window, so this could report an unreliable availability result while the provider already had an authoritative long-lived monitor.

Separately, foreground polling formed a retain cycle and repeatedly decoded the full status/peer response every three seconds. Swift logging also forced a storage synchronization for every line.

## Validation and proof

### Automated

```text
xcodebuild -project NetBird.xcodeproj \
  -scheme NetBird \
  -destination "platform=iOS Simulator,name=iPhone 17" \
  ENABLE_DEBUG_DYLIB=NO test

** TEST SUCCEEDED **
36 tests passed
```

`git diff --check upstream/main...HEAD` also passes.

### Physical device

Built, signed, installed, and launched an optimized Release build on:

- iPhone 16 Pro Max
- iOS 27
- app version `0.3.4 (35)` supplied through the same build-time version overrides used by TestFlight

Verified:

- `codesign --verify --deep --strict` passed for the Release app bundle
- the app, packet-tunnel extension, and widget all contained `0.3.4 (35)`
- the independently launched app and `NetbirdNetworkExtension` processes were both active after installation
- the tunnel reported connected and returned its routes and peer status

The automated and device checks validate compilation, tests, signing, launch, and an active tunnel. They do not claim a controlled long-duration Wi-Fi/cellular soak test; that remains useful follow-up validation.

## Related work

- #207 contains related restart retry and Go lifecycle work. This PR includes the Swift-side transaction generation, pending-path reconciliation, unavailable-path gating, timeout behavior, and the resource fixes validated together on device.
- #38 contains a broader adaptive polling proposal. This PR only changes the existing foreground interval to 10 seconds and fixes the associated retain cycle and completion locking.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - VPN connection and disconnection states now update more promptly and accurately.
  - Improved recovery when network connectivity changes or tunnels restart.
  - Prevented stale connection events from causing incorrect VPN status displays.
  - Improved compatibility across different app variants.
  - Invalid Firebase configuration is safely ignored instead of preventing app startup.

- **Reliability**
  - Improved diagnostic log syncing while reducing unnecessary background activity.
  - Enhanced network monitoring and connection status handling for more reliable VPN behavior.
  - Improved handling of VPN status checks and background monitoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->