### PR TITLE
Stop the tunnel from restarting itself during a normal connect

### DIFF
--- a/NetbirdKit/NetworkExtensionAdapter.swift
+++ b/NetbirdKit/NetworkExtensionAdapter.swift
@@ -1057,21 +1057,23 @@ public class NetworkExtensionAdapter: ObservableObject {
     }
 
     /// Writes the On Demand state and matching rules to the given manager.
+    ///
+    /// A request that matches what the manager already holds is answered without a write:
+    /// saveToPreferences on a configured manager makes NE emit NEVPNStatusDidChange — a
+    /// transient .disconnecting among them — and rewriting the rules of a live tunnel can
+    /// have the system reassert it. applyExtensionStatus arms On Demand on every transition
+    /// to .connected, so an unconditional write added a spurious disconnect to every connect.
     private func applyOnDemandState(_ enabled: Bool, to manager: NETunnelProviderManager, completion: ((OnDemandUpdate) -> Void)? = nil) {
-        if enabled {
-            // Build rules from saved settings
-            let rules = buildOnDemandRules()
-            if rules.isEmpty {
-                // All policies are "Do Nothing" — don't interfere with connection state
-                let ignoreRule = NEOnDemandRuleIgnore()
-                ignoreRule.interfaceTypeMatch = .any
-                manager.onDemandRules = [ignoreRule]
-            } else {
-                manager.onDemandRules = rules
-            }
-        } else {
-            manager.onDemandRules = []
+        let rules = enabled ? onDemandRulesForStoredSettings() : []
+
+        if manager.isOnDemandEnabled == enabled,
+           onDemandRulesMatch(manager.onDemandRules ?? [], rules) {
+            logger.info("setOnDemandEnabled: already \(enabled ? "enabled" : "disabled") with the same rules, skipping write")
+            completion?(.applied)
+            return
         }
+
+        manager.onDemandRules = rules
         manager.isOnDemandEnabled = enabled
 
         manager.saveToPreferences { error in
@@ -1082,6 +1084,38 @@ public class NetworkExtensionAdapter: ObservableObject {
                 self.logger.info("setOnDemandEnabled: On Demand \(enabled ? "enabled" : "disabled") successfully")
                 completion?(.applied)
             }
+        }
+    }
+
+    /// Rules to arm On Demand with, built from the persisted policies. An explicit Ignore
+    /// rule stands in for "all policies are Do Nothing" so the system does not interfere
+    /// with the connection state.
+    private func onDemandRulesForStoredSettings() -> [NEOnDemandRule] {
+        let rules = buildOnDemandRules()
+        guard rules.isEmpty else { return rules }
+
+        let ignoreRule = NEOnDemandRuleIgnore()
+        ignoreRule.interfaceTypeMatch = .any
+        return [ignoreRule]
+    }
+
+    /// Compares two rule sets by their archived form. NEOnDemandRule has no value-based
+    /// isEqual, so comparing the objects would report every freshly built set as different
+    /// and defeat the skip above. An archive that cannot be produced counts as "different",
+    /// which falls back to writing — the old, always-write behaviour.
+    private func onDemandRulesMatch(_ lhs: [NEOnDemandRule], _ rhs: [NEOnDemandRule]) -> Bool {
+        guard lhs.count == rhs.count else { return false }
+        guard let lhsData = archivedOnDemandRules(lhs),
+              let rhsData = archivedOnDemandRules(rhs) else { return false }
+        return lhsData == rhsData
+    }
+
+    private func archivedOnDemandRules(_ rules: [NEOnDemandRule]) -> Data? {
+        do {
+            return try NSKeyedArchiver.archivedData(withRootObject: rules, requiringSecureCoding: true)
+        } catch {
+            logger.debug("archivedOnDemandRules: could not archive rules: \(error.localizedDescription)")
+            return nil
         }
     }
 

--- a/NetbirdKit/NetworkExtensionAdapter.swift
+++ b/NetbirdKit/NetworkExtensionAdapter.swift
@@ -1001,6 +1001,16 @@ public class NetworkExtensionAdapter: ObservableObject {
         set { onDemandLock.lock(); defer { onDemandLock.unlock() }; _requestedOnDemandState = newValue }
     }
 
+    /// Set when a save fails, cleared when one succeeds. A failed save leaves the requested
+    /// values on the retained manager while the system preferences still hold the old ones,
+    /// so the manager can no longer be trusted to answer "is this already in force?". While
+    /// set, the no-write path is closed and every request writes.
+    private var _onDemandWriteFailed = false
+    private var onDemandWriteFailed: Bool {
+        get { onDemandLock.lock(); defer { onDemandLock.unlock() }; return _onDemandWriteFailed }
+        set { onDemandLock.lock(); defer { onDemandLock.unlock() }; _onDemandWriteFailed = newValue }
+    }
+
     /// Updates the VPN On Demand configuration on the current manager.
     /// When enabled, iOS will automatically reconnect the VPN after network changes or reboot.
     /// Should only be enabled when the user is logged in to avoid reconnect loops.
@@ -1063,10 +1073,14 @@ public class NetworkExtensionAdapter: ObservableObject {
     /// transient .disconnecting among them — and rewriting the rules of a live tunnel can
     /// have the system reassert it. applyExtensionStatus arms On Demand on every transition
     /// to .connected, so an unconditional write added a spurious disconnect to every connect.
+    ///
+    /// The skip trusts the manager to reflect what the system holds, which is only true while
+    /// saves keep succeeding — hence `onDemandWriteFailed`.
     private func applyOnDemandState(_ enabled: Bool, to manager: NETunnelProviderManager, completion: ((OnDemandUpdate) -> Void)? = nil) {
         let rules = enabled ? onDemandRulesForStoredSettings() : []
 
-        if manager.isOnDemandEnabled == enabled,
+        if !onDemandWriteFailed,
+           manager.isOnDemandEnabled == enabled,
            onDemandRulesMatch(manager.onDemandRules ?? [], rules) {
             logger.info("setOnDemandEnabled: already \(enabled ? "enabled" : "disabled") with the same rules, skipping write")
             completion?(.applied)
@@ -1077,13 +1091,33 @@ public class NetworkExtensionAdapter: ObservableObject {
         manager.isOnDemandEnabled = enabled
 
         manager.saveToPreferences { error in
-            if let error = error {
-                self.logger.error("setOnDemandEnabled: Failed to save preferences: \(error.localizedDescription)")
-                completion?(.failed(error))
-            } else {
+            guard let error = error else {
+                self.onDemandWriteFailed = false
                 self.logger.info("setOnDemandEnabled: On Demand \(enabled ? "enabled" : "disabled") successfully")
                 completion?(.applied)
+                return
             }
+
+            self.logger.error("setOnDemandEnabled: Failed to save preferences: \(error.localizedDescription)")
+            self.recoverFromFailedOnDemandWrite(on: manager) {
+                completion?(.failed(error))
+            }
+        }
+    }
+
+    /// Restores the manager to what the system actually holds after a save failed, then
+    /// reports the failure. The assignments that were not persisted stay on the retained
+    /// manager otherwise, and a reload is also what clears NEVPNError.configurationStale —
+    /// the documented cause when another process wrote the configuration in between.
+    /// The write latch stays closed until a save succeeds, so the next request writes even
+    /// if this reload fails too.
+    private func recoverFromFailedOnDemandWrite(on manager: NETunnelProviderManager, completion: @escaping () -> Void) {
+        onDemandWriteFailed = true
+        manager.loadFromPreferences { loadError in
+            if let loadError = loadError {
+                self.logger.error("setOnDemandEnabled: reload after a failed save also failed: \(loadError.localizedDescription)")
+            }
+            completion()
         }
     }
 

--- a/NetbirdNetworkExtension/PacketTunnelProvider.swift
+++ b/NetbirdNetworkExtension/PacketTunnelProvider.swift
@@ -163,7 +163,9 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         }
 
         adapter.start { [weak self] error in
-            self?.completeTunnelStart(with: error)
+            if self?.completeTunnelStart(with: error) == false {
+                AppLogger.shared.log("startTunnel: engine reported connected again, start outcome stays as first reported")
+            }
             self?.monitorQueue.async {
                 self?.endInitialStart()
             }
@@ -188,21 +190,35 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     }
 
     /// Reports the tunnel's start outcome to NE, at most once per startTunnel.
-    private func completeTunnelStart(with error: Error?) {
+    /// Returns true when this call is the one that delivered it.
+    @discardableResult
+    private func completeTunnelStart(with error: Error?) -> Bool {
         startCompletionLock.lock()
         let handler = startCompletionHandler
         startCompletionHandler = nil
         startCompletionLock.unlock()
 
-        guard let handler = handler else {
-            let outcome = error?.localizedDescription ?? "success"
-            AppLogger.shared.log("completeTunnelStart: outcome already reported, dropping '\(outcome)'")
-            return
-        }
+        guard let handler = handler else { return false }
         handler(error)
+        return true
     }
 
     override func stopTunnel(with reason: NEProviderStopReason, completionHandler: @escaping () -> Void) {
+        // A stop that lands before the engine ever reported connected would otherwise leave
+        // NE waiting on the start outcome forever: the outcome is delivered from the
+        // connection listener's onConnected, and stopping just makes the engine's run loop
+        // return without connecting — nothing calls it. Close it out here, bound to the end
+        // of the start attempt rather than to its success. Latched, so a start that already
+        // reported is untouched.
+        let stoppedBeforeConnect = completeTunnelStart(with: NSError(
+            domain: "io.netbird.NetbirdNetworkExtension",
+            code: 1005,
+            userInfo: [NSLocalizedDescriptionKey: "Tunnel stopped before the connection was established (reason \(reason.rawValue))."]
+        ))
+        if stoppedBeforeConnect {
+            AppLogger.shared.log("stopTunnel: stopped before the connection was established, reported the start failure to NE")
+        }
+
         monitorQueue.async { [weak self] in
             guard let self = self else { return }
             self.networkChangeWorkItem?.cancel()

--- a/NetbirdNetworkExtension/PacketTunnelProvider.swift
+++ b/NetbirdNetworkExtension/PacketTunnelProvider.swift
@@ -33,10 +33,37 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     private var currentNetworkType: NWInterface.InterfaceType?
     private var wasStoppedDueToNoNetwork = false
     private var isRestartInProgress = false
+    /// Set from the moment startTunnel arms the connection until the adapter reports its
+    /// outcome. Network-change restarts are held off while it is set, so a connection that
+    /// is still being established is never torn down mid-flight.
+    private var isInitialStartInFlight = false
     
     private var networkChangeWorkItem: DispatchWorkItem?
+    private var networkLossWorkItem: DispatchWorkItem?
+    private var initialStartTimeoutWorkItem: DispatchWorkItem?
+
+    /// A path that stays unsatisfied for less than this is a blip, not an outage. The engine
+    /// pushes the interface address, the routes and the DNS config separately during a single
+    /// connect, and each one re-applies the tunnel settings; treating the resulting flap as an
+    /// outage plus a recovery is what made the tunnel connect and disconnect repeatedly
+    /// before settling.
+    private static let networkLossDebounce: TimeInterval = 2.0
+    /// Upper bound on the initial-start guard. A start that never reports its outcome must not
+    /// block network-change restarts for the rest of the tunnel's life.
+    private static let initialStartGuardTimeout: TimeInterval = 30.0
+
+    /// NE requires the startTunnel completion handler to be called exactly once. The Go
+    /// engine's connection listener reports every management/signal reconnect as a fresh
+    /// onConnected, so the adapter's start callback fires repeatedly over one tunnel's life;
+    /// this latch keeps the first outcome and drops the rest. Locked because the outcome can
+    /// arrive on the main queue (connection listener) or a global queue (adapter start
+    /// errors).
+    private let startCompletionLock = NSLock()
+    private var startCompletionHandler: ((Error?) -> Void)?
 
     override func startTunnel(options: [String : NSObject]?, completionHandler: @escaping (Error?) -> Void) {
+        armTunnelStartCompletion(completionHandler)
+
         if let options = options, let logLevel = options["logLevel"] as? String {
             initializeLogging(loglevel: logLevel)
         }
@@ -62,11 +89,17 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         #endif
 
         monitorQueue.async { [weak self] in
-            self?.currentNetworkType = nil
-            self?.wasStoppedDueToNoNetwork = false
-            self?.isRestartInProgress = false
-            self?.adapter?.isNetworkUnavailable = false
-            self?.startMonitoringNetworkChanges()
+            guard let self = self else { return }
+            self.currentNetworkType = nil
+            self.wasStoppedDueToNoNetwork = false
+            self.isRestartInProgress = false
+            self.networkChangeWorkItem?.cancel()
+            self.networkChangeWorkItem = nil
+            self.networkLossWorkItem?.cancel()
+            self.networkLossWorkItem = nil
+            self.adapter?.isNetworkUnavailable = false
+            self.beginInitialStart()
+            self.startMonitoringNetworkChanges()
         }
 
         guard let adapter = adapter else {
@@ -75,7 +108,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
                 code: 1003,
                 userInfo: [NSLocalizedDescriptionKey: "Failed to initialize NetBird adapter."]
             )
-            completionHandler(error)
+            completeTunnelStart(with: error)
             return
         }
 
@@ -103,7 +136,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             // A deferred completionHandler keeps the tunnel interface alive (black-hole state)
             // and intercepts all network traffic — including ASWebAuthenticationSession requests
             // to the OAuth server — causing "Page not found" during re-auth with On Demand enabled.
-            completionHandler(NSError(
+            completeTunnelStart(with: NSError(
                 domain: "io.netbird.NetbirdNetworkExtension",
                 code: 1001,
                 userInfo: [NSLocalizedDescriptionKey: "Login required."]
@@ -130,7 +163,10 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         }
 
         adapter.start { [weak self] error in
-            completionHandler(error)
+            self?.completeTunnelStart(with: error)
+            self?.monitorQueue.async {
+                self?.endInitialStart()
+            }
             if error == nil {
                 self?.updateWidgetStatus("connected")
             } else {
@@ -139,28 +175,51 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         }
     }
 
+    /// Records the handler NE is waiting on for this tunnel session.
+    private func armTunnelStartCompletion(_ handler: @escaping (Error?) -> Void) {
+        startCompletionLock.lock()
+        let pending = startCompletionHandler != nil
+        startCompletionHandler = handler
+        startCompletionLock.unlock()
+
+        if pending {
+            AppLogger.shared.log("armTunnelStartCompletion: replacing a start outcome that was never reported")
+        }
+    }
+
+    /// Reports the tunnel's start outcome to NE, at most once per startTunnel.
+    private func completeTunnelStart(with error: Error?) {
+        startCompletionLock.lock()
+        let handler = startCompletionHandler
+        startCompletionHandler = nil
+        startCompletionLock.unlock()
+
+        guard let handler = handler else {
+            let outcome = error?.localizedDescription ?? "success"
+            AppLogger.shared.log("completeTunnelStart: outcome already reported, dropping '\(outcome)'")
+            return
+        }
+        handler(error)
+    }
+
     override func stopTunnel(with reason: NEProviderStopReason, completionHandler: @escaping () -> Void) {
         monitorQueue.async { [weak self] in
-            self?.networkChangeWorkItem?.cancel()
-            self?.networkChangeWorkItem = nil
-            self?.currentNetworkType = nil
-            self?.wasStoppedDueToNoNetwork = false
-            self?.isRestartInProgress = false
+            guard let self = self else { return }
+            self.networkChangeWorkItem?.cancel()
+            self.networkChangeWorkItem = nil
+            self.networkLossWorkItem?.cancel()
+            self.networkLossWorkItem = nil
+            self.endInitialStart()
+            self.currentNetworkType = nil
+            self.wasStoppedDueToNoNetwork = false
+            self.isRestartInProgress = false
         }
         // Reset network unavailable flag when tunnel stops
         adapter?.isNetworkUnavailable = false
         setNetworkUnavailableFlag(false)
         adapter?.stop()
         updateWidgetStatus("disconnected")
-        guard let pathMonitor = self.pathMonitor else {
-            AppLogger.shared.log("pathMonitor is nil; nothing to cancel.")
-            DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-                completionHandler()
-            }
-            return
-        }
-        pathMonitor.cancel()
-        self.pathMonitor = nil
+        stopMonitoringNetworkChanges()
         DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
             completionHandler()
         }
@@ -236,14 +295,88 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         }
     }
 
+    /// Starts monitoring the physical network. Must run on `monitorQueue`.
+    ///
+    /// The provider's own tunnel interface is excluded. An unfiltered path also covers the
+    /// utun this provider creates, so every `setTunnelNetworkSettings` call — several per
+    /// connect — flapped the monitored path. `handleNetworkChange` read that as an outage
+    /// followed by a recovery and answered it with a client restart, which re-applied the
+    /// settings and flapped the path again: a loop that kept the tunnel cycling until the
+    /// timing happened to miss the detection window.
     func startMonitoringNetworkChanges() {
-        let monitor = NWPathMonitor()
+        // Only one monitor may be live. A second startTunnel in the same extension process
+        // (On Demand re-trigger, widget start after a failed attempt) would otherwise leave
+        // the previous monitor running, and both would handle every path update.
+        pathMonitor?.cancel()
+
+        let monitor = NWPathMonitor(prohibitedInterfaceTypes: [.other])
         monitor.pathUpdateHandler = { [weak self] path in
             self?.handleNetworkChange(path: path)
         }
         monitor.start(queue: monitorQueue)
-    
+
         pathMonitor = monitor
+    }
+
+    /// Tears the path monitor down on the queue that starts it and handles its updates, so
+    /// cancellation cannot race an in-flight path update.
+    private func stopMonitoringNetworkChanges() {
+        monitorQueue.async { [weak self] in
+            guard let self = self else { return }
+            guard let monitor = self.pathMonitor else {
+                AppLogger.shared.log("stopMonitoringNetworkChanges: no monitor to cancel")
+                return
+            }
+            monitor.cancel()
+            self.pathMonitor = nil
+        }
+    }
+
+    /// Arms the guard that keeps a network-change restart from tearing down a connection that
+    /// is still coming up. Must run on `monitorQueue`.
+    private func beginInitialStart() {
+        initialStartTimeoutWorkItem?.cancel()
+        isInitialStartInFlight = true
+
+        let timeout = DispatchWorkItem { [weak self] in
+            guard let self = self, self.isInitialStartInFlight else { return }
+            AppLogger.shared.log("beginInitialStart: timeout - releasing the initial start guard")
+            self.isInitialStartInFlight = false
+            self.initialStartTimeoutWorkItem = nil
+        }
+        initialStartTimeoutWorkItem = timeout
+        monitorQueue.asyncAfter(deadline: .now() + Self.initialStartGuardTimeout, execute: timeout)
+    }
+
+    /// Releases the initial-start guard. Must run on `monitorQueue`.
+    private func endInitialStart() {
+        initialStartTimeoutWorkItem?.cancel()
+        initialStartTimeoutWorkItem = nil
+        isInitialStartInFlight = false
+    }
+
+    /// Declares the network unavailable only once the path has stayed unsatisfied for
+    /// `networkLossDebounce`. Must run on `monitorQueue`.
+    ///
+    /// We don't call adapter.stop() here to avoid race conditions with Go SDK callbacks —
+    /// the Go SDK handles network loss internally and reconnects when the network is back.
+    /// The flag only signals the UI so it can show the disconnecting animation.
+    private func scheduleNetworkLossIfSustained() {
+        guard !wasStoppedDueToNoNetwork, networkLossWorkItem == nil else { return }
+
+        let workItem = DispatchWorkItem { [weak self] in
+            guard let self = self, !self.wasStoppedDueToNoNetwork else { return }
+            self.networkLossWorkItem = nil
+
+            let stateDesc = self.adapter?.clientState.description ?? "unknown"
+            AppLogger.shared.log("Network unavailable - signaling UI for disconnecting animation, clientState=\(stateDesc)")
+            self.wasStoppedDueToNoNetwork = true
+            self.adapter?.isNetworkUnavailable = true
+            self.setNetworkUnavailableFlag(true)
+        }
+
+        networkLossWorkItem = workItem
+        monitorQueue.asyncAfter(deadline: .now() + Self.networkLossDebounce, execute: workItem)
     }
 
     func handleNetworkChange(path: Network.NWPath) {
@@ -257,26 +390,21 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
                   """)
 
         if path.status != .satisfied {
-            AppLogger.shared.log("No network connection detected")
+            AppLogger.shared.log("Path not satisfied - confirming over \(Self.networkLossDebounce)s before treating it as an outage")
 
             // Cancel any pending restart
             networkChangeWorkItem?.cancel()
             networkChangeWorkItem = nil
 
-            // Signal UI to show disconnecting animation via shared flag
-            // We don't call adapter.stop() to avoid race conditions with Go SDK callbacks
-            // The Go SDK will handle network loss internally and reconnect when available
-            if !wasStoppedDueToNoNetwork {
-                let stateDesc = adapter?.clientState.description ?? "unknown"
-                AppLogger.shared.log("Network unavailable - signaling UI for disconnecting animation, clientState=\(stateDesc)")
-                wasStoppedDueToNoNetwork = true
-                adapter?.isNetworkUnavailable = true
-                setNetworkUnavailableFlag(true)
-            }
+            scheduleNetworkLossIfSustained()
             return
         }
 
-        // Network is available again
+        // Network is available again. A loss that never lasted long enough to be confirmed is
+        // a blip: drop it so it produces neither the UI's network warning nor a restart.
+        networkLossWorkItem?.cancel()
+        networkLossWorkItem = nil
+
         let shouldRestartDueToRecovery = wasStoppedDueToNoNetwork
         if wasStoppedDueToNoNetwork {
             AppLogger.shared.log("Network restored after unavailability - signaling UI")
@@ -336,6 +464,11 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     func restartClient() {
         guard let adapter = adapter else {
             AppLogger.shared.log("restartClient: adapter is nil")
+            return
+        }
+
+        if isInitialStartInFlight {
+            AppLogger.shared.log("restartClient: skipping - initial connection still in flight")
             return
         }
 


### PR DESCRIPTION
## Problem

Connecting through the app makes the VPN connect and disconnect several times in a row before the connection finally settles.

The extension monitored an unfiltered network path, which also covers the `utun` interface the provider itself creates. A single connect applies the tunnel settings several times (the engine pushes the interface address, the routes and the DNS config separately), and each apply flapped that path. `handleNetworkChange` read every flap as an outage followed by a recovery and answered it with a full client restart — which applied the settings again and flapped the path again. A self-feeding loop that only stopped when the timing happened to miss the detection window.

## Fix

- Exclude the provider's own tunnel interface from the path monitor. This breaks the loop.
- Keep only one monitor live; `startMonitoringNetworkChanges` overwrote `pathMonitor` without cancelling it. Tear it down on the queue that delivers its updates so cancellation cannot race one.
- Require the path to stay unsatisfied for 2s before declaring an outage.
- Hold off network-change restarts until the initial connect reports its outcome.
- Skip the On Demand preferences write when state and rules already match — `saveToPreferences` makes NE emit a transient `.disconnecting`, and On Demand was armed on every transition to `.connected`.
- Report the `startTunnel` outcome to NE exactly once; the Go notifier re-fires `OnConnected` on any mid-session management/signal reconnect.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented unnecessary tunnel preference updates that could cause unexpected disconnect notifications.
  - Improved tunnel startup handling so completion results are reported consistently and only once.
  - Prevented restart attempts while the initial connection is still in progress.
  - Reduced interruptions caused by brief network changes by ignoring transient connection loss.
  - Improved network monitoring cleanup when stopping the tunnel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
