### PR TITLE
Build the SDK from the pinned netbird-core commit in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,18 +26,6 @@ jobs:
           path: ios-client
           submodules: recursive
 
-      # TEMPORARY: builds the core from netbirdio/netbird#7193, which adds the iOS
-      # login_hint wiring this branch depends on. The submodule pointer stays on an
-      # upstream commit so a plain clone still works — only the SDK build uses the PR.
-      # Runs before the core-sha step on purpose: the cache key is derived from the
-      # checked-out commit, so a framework built from the pinned commit is not reused.
-      # Remove this step and re-pin the submodule once #7193 is merged.
-      - name: Use pending netbird-core PR 7193
-        working-directory: ios-client/netbird-core
-        run: |
-          git fetch --no-tags https://github.com/netbirdio/netbird.git refs/pull/7193/head
-          git checkout --detach FETCH_HEAD
-
       - name: Get netbird-core commit
         id: core-sha
         working-directory: ios-client/netbird-core
@@ -174,18 +162,6 @@ jobs:
         with:
           path: ios-client
           submodules: recursive
-
-      # TEMPORARY: builds the core from netbirdio/netbird#7193, which adds the iOS
-      # login_hint wiring this branch depends on. The submodule pointer stays on an
-      # upstream commit so a plain clone still works — only the SDK build uses the PR.
-      # Runs before the core-sha step on purpose: the cache key is derived from the
-      # checked-out commit, so a framework built from the pinned commit is not reused.
-      # Remove this step and re-pin the submodule once #7193 is merged.
-      - name: Use pending netbird-core PR 7193
-        working-directory: ios-client/netbird-core
-        run: |
-          git fetch --no-tags https://github.com/netbirdio/netbird.git refs/pull/7193/head
-          git checkout --detach FETCH_HEAD
 
       - name: Get netbird-core commit
         id: core-sha

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,18 +26,6 @@ jobs:
           path: ios-client
           submodules: recursive
 
-      # TEMPORARY: builds the core from netbirdio/netbird#7193, which adds the iOS
-      # login_hint wiring this branch depends on. The submodule pointer stays on an
-      # upstream commit so a plain clone still works — only the SDK build uses the PR.
-      # Runs before the core-sha step on purpose: the cache key is derived from the
-      # checked-out commit, so a framework built from the pinned commit is not reused.
-      # Remove this step and re-pin the submodule once #7193 is merged.
-      - name: Use pending netbird-core PR 7193
-        working-directory: ios-client/netbird-core
-        run: |
-          git fetch --no-tags https://github.com/netbirdio/netbird.git refs/pull/7193/head
-          git checkout --detach FETCH_HEAD
-
       - name: Get netbird-core commit
         id: core-sha
         working-directory: ios-client/netbird-core


### PR DESCRIPTION
## Description

The temporary workflow step that checked out netbirdio/netbird#7193 is obsolete: the PR was merged on 2026-09-01 and the submodule pointer already contains it. Keeping the step forced every CI build onto that stale head, which lacks the RemoteJobsAllowed preference accessors and broke builds against the current submodule commit.





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated iOS and tvOS builds to use the checked-out `netbird-core` commit.
  * Updated test caching to reflect the pinned `netbird-core` submodule revision.
  * Removed temporary workflow handling for a specific upstream pull request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->