### PR TITLE
Fire the adapter's stop completion only after the Go run loop has exited

### DIFF
--- a/NetBirdTVNetworkExtension/PacketTunnelProvider.swift
+++ b/NetBirdTVNetworkExtension/PacketTunnelProvider.swift
@@ -118,7 +118,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             code: 1005,
             userInfo: [NSLocalizedDescriptionKey: "Login cancelled."]
         ))
-        adapter?.stop()
+        adapter?.stop(waitForExit: false)
         if let pathMonitor = self.pathMonitor {
             pathMonitor.cancel()
             self.pathMonitor = nil
@@ -332,12 +332,13 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
 
     func restartClient() {
         logger.info("restartClient: Restarting client due to network change")
-        adapter?.stop()
-        adapter?.start { error in
-            if let error = error {
-                logger.error("restartClient: Error restarting client: \(error.localizedDescription)")
-            } else {
-                logger.info("restartClient: Client restarted successfully")
+        adapter?.stop { [weak self] in
+            self?.adapter?.start { error in
+                if let error = error {
+                    logger.error("restartClient: Error restarting client: \(error.localizedDescription, privacy: .public)")
+                } else {
+                    logger.info("restartClient: Client restarted successfully")
+                }
             }
         }
     }

--- a/NetbirdKit/ConnectionListener.swift
+++ b/NetbirdKit/ConnectionListener.swift
@@ -94,7 +94,6 @@ class ConnectionListener: NSObject, NetBirdSDKConnectionListenerProtocol {
             adapter.clientState = .disconnected
             AppLogger.shared.log("onDisconnected: login required — signalling teardown")
             adapter.onLoginRequired?()
-            adapter.notifyStopCompleted()
             return
         }
 
@@ -121,7 +120,6 @@ class ConnectionListener: NSObject, NetBirdSDKConnectionListenerProtocol {
                 adapter.onLoginRequired?()
             }
         }
-        adapter.notifyStopCompleted()
     }
 
     /// Publishes an engine disconnect transition unless a controlled restart is underway.

--- a/NetbirdNetworkExtension/NetBirdAdapter.swift
+++ b/NetbirdNetworkExtension/NetBirdAdapter.swift
@@ -118,7 +118,7 @@ public class NetBirdAdapter {
     /// trigger flag + notification from the extension.
     var onLoginRequired: (() -> Void)?
 
-    private let stopLock = NSLock()
+    private let stopQueue = DispatchQueue(label: "io.netbird.adapter.stop")
 
     /// Tunnel device file descriptor.
     /// On iOS: searches for the utun control socket file descriptor by iterating through
@@ -250,8 +250,6 @@ public class NetBirdAdapter {
     }
     #endif
     
-    private var stopCompletionHandler: (() -> Void)?
-    
     // MARK: - Initialization
 
     /// Designated initializer.
@@ -371,8 +369,14 @@ public class NetBirdAdapter {
 
                 try self.client.run(fd, interfaceName: ifName, envList: envList)
             } catch {
-                completionHandler(NSError(domain: "io.netbird.NetbirdNetworkExtension", code: 1001, userInfo: [NSLocalizedDescriptionKey: "Netbird client startup failed."]))
-                self.stop()
+                completionHandler(NSError(
+                    domain: "io.netbird.NetbirdNetworkExtension",
+                    code: 1001,
+                    userInfo: [
+                        NSLocalizedDescriptionKey: "Netbird client startup failed: \(error.localizedDescription)",
+                        NSUnderlyingErrorKey: error
+                    ]
+                ))
             }
         }
     }
@@ -573,43 +577,26 @@ public class NetBirdAdapter {
         self.dnsManager.invalidate()
     }
 
-    public func stop(completionHandler: (() -> Void)? = nil) {
-        stopLock.lock()
-
-        // Call any pending handler before setting a new one
-        if let existingHandler = self.stopCompletionHandler {
-            self.stopCompletionHandler = nil
-            stopLock.unlock()
-            existingHandler()
-        } else {
-            stopLock.unlock()
-        }
-
-        stopLock.lock()
-        self.stopCompletionHandler = completionHandler
-        stopLock.unlock()
-
-        self.client.stop()
-
-        // Fallback timeout (15 seconds) in case onDisconnected doesn't fire
-        if completionHandler != nil {
-            DispatchQueue.global().asyncAfter(deadline: .now() + 15) { [weak self] in
-                self?.notifyStopCompleted()
-            }
-        }
-    }
-
-    func notifyStopCompleted() {
-        stopLock.lock()
-
-        guard let handler = self.stopCompletionHandler else {
-            stopLock.unlock()
+    /// Stops the Go client. With `waitForExit` the Go side blocks until its run loop has
+    /// exited, so a start issued afterwards cannot overlap the outgoing run. A completion
+    /// handler moves that wait onto the adapter's stop queue and runs once the wait is
+    /// over. Pass `waitForExit: false` where the caller is on a deadline, such as stopTunnel.
+    public func stop(waitForExit: Bool = true, completionHandler: (() -> Void)? = nil) {
+        guard waitForExit else {
+            client.stopWithoutWait()
+            completionHandler?()
             return
         }
 
-        self.stopCompletionHandler = nil
-        stopLock.unlock()
-        handler()
+        guard let completionHandler = completionHandler else {
+            stopQueue.sync { self.client.stop() }
+            return
+        }
+
+        stopQueue.async { [client] in
+            client.stop()
+            completionHandler()
+        }
     }
 
     // MARK: - Config Helpers

--- a/NetbirdNetworkExtension/PacketTunnelProvider.swift
+++ b/NetbirdNetworkExtension/PacketTunnelProvider.swift
@@ -98,10 +98,10 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     /// Set once stopTunnel begins, so anything still in flight can tell that
     /// starting the client is no longer wanted.
     ///
-    /// Lock-guarded rather than confined to monitorQueue: adapter.stop() can
-    /// run an existing stop handler synchronously, and the restart pipeline's
-    /// completions arrive on a global queue, so both the write and the reads
-    /// happen off that queue. Queueing the write would let a reader see the
+    /// Lock-guarded rather than confined to monitorQueue: the restart
+    /// pipeline's stop completions arrive on the adapter's stop queue and its
+    /// start completions on a global queue, so both the write and the reads
+    /// happen off monitorQueue. Queueing the write would let a reader see the
     /// stale value and start the engine into a teardown.
     private let tearDownLock = NSLock()
     private var _isTearingDown = false
@@ -213,6 +213,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             self.activeRestartGeneration = nil
             self.isTunnelStopping = false
             self.restartRetryCount = 0
+            self.adapter?.isRestarting = false
             self.networkChangeWorkItem?.cancel()
             self.networkChangeWorkItem = nil
             self.networkLossWorkItem?.cancel()
@@ -330,9 +331,10 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
 
     /// Stops monitoring and the NetBird engine before completing tunnel teardown.
     override func stopTunnel(with reason: NEProviderStopReason, completionHandler: @escaping () -> Void) {
-        // Synchronously, and before adapter.stop(): that call can invoke an
-        // existing stop handler inline, which would otherwise read the old
-        // value and restart into the teardown.
+        // Synchronously, and before adapter.stop(): a restart whose stop
+        // completion is still in flight reads this latch off monitorQueue, and
+        // a queued write would let it see the old value and restart into the
+        // teardown.
         isTearingDown = true
         isStartingTunnel = false
 
@@ -376,7 +378,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         // Reset network unavailable flag when tunnel stops
         adapter?.isNetworkUnavailable = false
         setNetworkUnavailableFlag(false)
-        adapter?.stop()
+        adapter?.stop(waitForExit: false)
         updateWidgetStatus("disconnected")
         stopMonitoringNetworkChanges()
         DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
@@ -748,9 +750,8 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
                     AppLogger.shared.log("restartClient: start failed - \(error.localizedDescription)")
                     // If the start failed because the session expired, the connection
                     // listener may have suppressed its login-required signalling: it skips
-                    // both checks while isRestarting is still true, which happens when the
-                    // stop phase never fired onDisconnected (engine already dead) and the
-                    // stop completion arrived via the 15s fallback instead. Re-check the
+                    // both checks while isRestarting is still true, which covers every
+                    // onDisconnected delivered during the stop phase. Re-check the
                     // recorder here — the engine marks it with PermissionDenied before
                     // Run() returns — and signal + tear down so the dead tunnel doesn't
                     // linger and black-hole traffic.


### PR DESCRIPTION
## Description

A community tester on 0.3.4 reported that the app "sometimes kills my whole network" until the VPN is toggled off and on. The debug bundle shows a dead tunnel, not a crash: on 2026-09-09 a wifi → cellular → wifi flap within 7 s triggered two back-to-back restarts, the second start failed 5 ms after it was issued, and the tunnel stayed installed with no engine behind it for 13 minutes until the user toggled it. The stderr capture contains no panic. Across the bundle's 13 days there are 161 engine starts and 15 failed restarts of this shape; six ended in a blackhole until the user intervened.

### Root cause

The restart path used the Go connection listener's `onDisconnected` as its "stop completed" signal and started the next engine from inside that callback. The Go notifier delivers the callback synchronously from the outgoing `Run()`, during `ClientTeardown`, before `finishRun()` releases the run slot. The immediate `Run()` therefore raced the outgoing run and, since netbirdio/netbird#7329 (v0.78.0), lost that race deterministically: `startRun()` returns `errClientAlreadyRunning`. `Run()` does not log it, `NetBirdAdapter.start` replaced it with a generic "Netbird client startup failed.", and the provider's non-auth failure branch left the tunnel in place.

The Go side already guarantees the right thing: `Client.Stop()` blocks until the run loop has exited. The Swift side just did not wait for it.

### Changes

- `NetBirdAdapter.stop(waitForExit:completionHandler:)`: the blocking `client.stop()` runs on a dedicated serial queue and the completion fires only after it returns. The 15 s fallback, the stored completion handler and the listener-driven `notifyStopCompleted` are gone. Consecutive stops queue up instead of firing each other's handler. Without a completion the call stays synchronous; `waitForExit: false` uses `StopWithoutWait` for `stopTunnel`, which iOS gives only a few seconds.
- `ConnectionListener.onDisconnected` only reports state.
- `NetBirdAdapter.start` no longer calls `stop()` from its catch path. `Stop()` cancels whichever run is currently registered, so a late failure of a superseded run could kill the healthy one. The real Go error text is forwarded, with the original error as `NSUnderlyingErrorKey`.
- iOS `startTunnel` resets `adapter.isRestarting` alongside `isRestartInProgress`; `stopTunnel` uses `waitForExit: false`.
- tvOS: `restartClient` uses the completion-based stop so the path monitor's queue is not blocked for the duration of the Go teardown; `stopTunnel` uses `waitForExit: false`; the restart error is logged as public.

The `restartClient` logic from #212 is unchanged and remains the safety net: a start that still fails for another reason is retried and, if the retries are exhausted, the tunnel is torn down instead of black-holing traffic.

### Not in this PR

- Go side: `Run()` should log the `startRun` error and `startRun()` could wait a bounded time for the previous run instead of refusing. Separate core PR.
- Every stop still waits 5 s for the utun interface to disappear, which never happens on iOS. Separate core PR.
- The 30 s restart timeout from #212 covers stop and start together and tears the tunnel down on expiry; a slow but healthy connect can exceed it. Worth a separate discussion.

### Verification

Not compiled here: no Swift toolchain on the machine this was written on. Needs an Xcode build of the iOS and tvOS extension targets and a wifi/cellular walk-out test on a device. Expected in the logs afterwards: "restartClient: stop completed" always follows the Go "stopped NetBird client", and "Run: loading config from file" is never the last Go line of a start.

### Related

- #212 retry and teardown on failed restarts (merged)
- #207 earlier attempt, closed in favour of this
- netbirdio/netbird#7329 introduced the one-run-at-a-time guard
- #167, #196 user reports with the same symptom
