### PR TITLE
Gate tvOS writes and bound the MDM restart retry

### DIFF
--- a/NetBird/Source/App/ViewModels/MainViewModel.swift
+++ b/NetBird/Source/App/ViewModels/MainViewModel.swift
@@ -852,6 +852,34 @@ class ViewModel: ObservableObject {
     
     // MARK: - Configuration Methods (via ConfigurationProvider)
 
+    /// One wording for a policy refusal, so the app cannot drift into several
+    /// phrasings of the same condition.
+    nonisolated static let managedSettingMessage = "This setting is managed by your organization and cannot be changed."
+
+    /// Turns a rejected commit into something the user can act on.
+    ///
+    /// Go wraps ErrMDMManagedFields with the offending keys —
+    /// "fields managed by MDM cannot be modified: [rosenpassEnabled]" — so
+    /// name them instead of throwing away the half of the message that says
+    /// which setting was refused. Returns nil when the failure was not a
+    /// policy refusal, leaving the caller to report it as an ordinary error.
+    /// nonisolated: pure text handling that touches no view-model state, so
+    /// it stays callable off the main actor - not least from tests.
+    nonisolated static func managedRejectionMessage(from reason: String) -> String? {
+        guard reason.localizedCaseInsensitiveContains("managed by MDM") else {
+            return nil
+        }
+        guard let separator = reason.range(of: ": ", options: .backwards) else {
+            return managedSettingMessage
+        }
+        let keys = reason[separator.upperBound...]
+            .trimmingCharacters(in: CharacterSet(charactersIn: "[] "))
+        guard !keys.isEmpty else {
+            return managedSettingMessage
+        }
+        return "\(managedSettingMessage) (\(keys))"
+    }
+
     /// Whether the policy owns the pre-shared key, by managing it directly or
     /// by forbidding settings edits at all.
     private var preSharedKeyForbiddenByPolicy: Bool {
@@ -864,7 +892,7 @@ class ViewModel: ObservableObject {
         // while a key-entry alert is open would otherwise be overwritten.
         guard !preSharedKeyForbiddenByPolicy else {
             AppLogger.shared.log("MDM: refusing to change the pre-shared key while it is managed")
-            settingsRejectedMessage = "This setting is managed by your organization and cannot be changed."
+            settingsRejectedMessage = Self.managedSettingMessage
             showSettingsRejectedAlert = true
             return
         }
@@ -889,7 +917,7 @@ class ViewModel: ObservableObject {
     func removePreSharedKey() {
         guard !preSharedKeyForbiddenByPolicy else {
             AppLogger.shared.log("MDM: refusing to remove the pre-shared key while it is managed")
-            settingsRejectedMessage = "This setting is managed by your organization and cannot be changed."
+            settingsRejectedMessage = Self.managedSettingMessage
             showSettingsRejectedAlert = true
             return
         }
@@ -920,8 +948,8 @@ class ViewModel: ObservableObject {
         }
         let reason = configProvider.lastCommitError ?? ""
         refreshMDMRestrictions()
-        if reason.localizedCaseInsensitiveContains("managed by MDM") {
-            settingsRejectedMessage = "This setting is managed by your organization and cannot be changed."
+        if let managed = Self.managedRejectionMessage(from: reason) {
+            settingsRejectedMessage = managed
         } else {
             settingsRejectedMessage = reason.isEmpty
                 ? "The setting could not be saved."

--- a/NetBird/Source/App/ViewModels/MainViewModel.swift
+++ b/NetBird/Source/App/ViewModels/MainViewModel.swift
@@ -852,34 +852,6 @@ class ViewModel: ObservableObject {
     
     // MARK: - Configuration Methods (via ConfigurationProvider)
 
-    /// One wording for a policy refusal, so the app cannot drift into several
-    /// phrasings of the same condition.
-    nonisolated static let managedSettingMessage = "This setting is managed by your organization and cannot be changed."
-
-    /// Turns a rejected commit into something the user can act on.
-    ///
-    /// Go wraps ErrMDMManagedFields with the offending keys —
-    /// "fields managed by MDM cannot be modified: [rosenpassEnabled]" — so
-    /// name them instead of throwing away the half of the message that says
-    /// which setting was refused. Returns nil when the failure was not a
-    /// policy refusal, leaving the caller to report it as an ordinary error.
-    /// nonisolated: pure text handling that touches no view-model state, so
-    /// it stays callable off the main actor - not least from tests.
-    nonisolated static func managedRejectionMessage(from reason: String) -> String? {
-        guard reason.localizedCaseInsensitiveContains("managed by MDM") else {
-            return nil
-        }
-        guard let separator = reason.range(of: ": ", options: .backwards) else {
-            return managedSettingMessage
-        }
-        let keys = reason[separator.upperBound...]
-            .trimmingCharacters(in: CharacterSet(charactersIn: "[] "))
-        guard !keys.isEmpty else {
-            return managedSettingMessage
-        }
-        return "\(managedSettingMessage) (\(keys))"
-    }
-
     /// Whether the policy owns the pre-shared key, by managing it directly or
     /// by forbidding settings edits at all.
     private var preSharedKeyForbiddenByPolicy: Bool {
@@ -892,7 +864,7 @@ class ViewModel: ObservableObject {
         // while a key-entry alert is open would otherwise be overwritten.
         guard !preSharedKeyForbiddenByPolicy else {
             AppLogger.shared.log("MDM: refusing to change the pre-shared key while it is managed")
-            settingsRejectedMessage = Self.managedSettingMessage
+            settingsRejectedMessage = MDMRestrictions.managedSettingMessage
             showSettingsRejectedAlert = true
             return
         }
@@ -917,7 +889,7 @@ class ViewModel: ObservableObject {
     func removePreSharedKey() {
         guard !preSharedKeyForbiddenByPolicy else {
             AppLogger.shared.log("MDM: refusing to remove the pre-shared key while it is managed")
-            settingsRejectedMessage = Self.managedSettingMessage
+            settingsRejectedMessage = MDMRestrictions.managedSettingMessage
             showSettingsRejectedAlert = true
             return
         }
@@ -948,7 +920,7 @@ class ViewModel: ObservableObject {
         }
         let reason = configProvider.lastCommitError ?? ""
         refreshMDMRestrictions()
-        if let managed = Self.managedRejectionMessage(from: reason) {
+        if let managed = MDMRestrictions.rejectionMessage(from: reason) {
             settingsRejectedMessage = managed
         } else {
             settingsRejectedMessage = reason.isEmpty

--- a/NetBirdTests/MDMRestrictionsTests.swift
+++ b/NetBirdTests/MDMRestrictionsTests.swift
@@ -116,6 +116,29 @@ final class MDMRestrictionsTests: XCTestCase {
         XCTAssertFalse(r.features.disableProfiles)
     }
 
+    /// A rejected commit must name the setting the policy refused, and must
+    /// not swallow an ordinary failure as a policy one.
+    func testManagedRejectionMessage() {
+        let refusal = "fields managed by MDM cannot be modified: [rosenpassEnabled]"
+        let message = ViewModel.managedRejectionMessage(from: refusal)
+        XCTAssertNotNil(message)
+        XCTAssertTrue(message!.contains("rosenpassEnabled"), "message was: \(message!)")
+        XCTAssertTrue(message!.contains("managed by your organization"))
+
+        // Several keys come through as Go formats them.
+        let many = ViewModel.managedRejectionMessage(
+            from: "fields managed by MDM cannot be modified: [rosenpassEnabled preSharedKey]"
+        )
+        XCTAssertEqual(many?.contains("preSharedKey"), true)
+
+        // No key list still yields the generic explanation.
+        XCTAssertNotNil(ViewModel.managedRejectionMessage(from: "fields managed by MDM cannot be modified"))
+
+        // An unrelated failure is not a policy refusal.
+        XCTAssertNil(ViewModel.managedRejectionMessage(from: "no space left on device"))
+        XCTAssertNil(ViewModel.managedRejectionMessage(from: ""))
+    }
+
     /// Only a non-empty managementURL means the URL is enforced.
     func testManagesManagementURLRequiresNonEmptyValue() {
         XCTAssertFalse(MDMRestrictions.decode(#"{"mdm":{"managementURL":""}}"#).mdm.managesManagementURL)

--- a/NetBirdTests/MDMRestrictionsTests.swift
+++ b/NetBirdTests/MDMRestrictionsTests.swift
@@ -120,23 +120,23 @@ final class MDMRestrictionsTests: XCTestCase {
     /// not swallow an ordinary failure as a policy one.
     func testManagedRejectionMessage() {
         let refusal = "fields managed by MDM cannot be modified: [rosenpassEnabled]"
-        let message = ViewModel.managedRejectionMessage(from: refusal)
+        let message = MDMRestrictions.rejectionMessage(from: refusal)
         XCTAssertNotNil(message)
         XCTAssertTrue(message!.contains("rosenpassEnabled"), "message was: \(message!)")
         XCTAssertTrue(message!.contains("managed by your organization"))
 
         // Several keys come through as Go formats them.
-        let many = ViewModel.managedRejectionMessage(
+        let many = MDMRestrictions.rejectionMessage(
             from: "fields managed by MDM cannot be modified: [rosenpassEnabled preSharedKey]"
         )
         XCTAssertEqual(many?.contains("preSharedKey"), true)
 
         // No key list still yields the generic explanation.
-        XCTAssertNotNil(ViewModel.managedRejectionMessage(from: "fields managed by MDM cannot be modified"))
+        XCTAssertNotNil(MDMRestrictions.rejectionMessage(from: "fields managed by MDM cannot be modified"))
 
         // An unrelated failure is not a policy refusal.
-        XCTAssertNil(ViewModel.managedRejectionMessage(from: "no space left on device"))
-        XCTAssertNil(ViewModel.managedRejectionMessage(from: ""))
+        XCTAssertNil(MDMRestrictions.rejectionMessage(from: "no space left on device"))
+        XCTAssertNil(MDMRestrictions.rejectionMessage(from: ""))
     }
 
     /// Only a non-empty managementURL means the URL is enforced.

--- a/NetbirdKit/ConfigurationProvider.swift
+++ b/NetbirdKit/ConfigurationProvider.swift
@@ -173,28 +173,62 @@ final class tvOSConfigurationProvider: ConfigurationProvider {
 
     init() {}
 
+    /// Reason the most recent write was refused, or nil.
+    private var refusal: String?
+
+    /// Refuses a write the policy owns.
+    ///
+    /// iOS reaches Go's CheckMDMConflicts through Preferences.commit(); tvOS
+    /// writes straight to the config JSON and never crosses that bridge, so
+    /// without this gate a managed field would stay writable here while iOS
+    /// rejects it. `key` names the field the way the Go error does, so the
+    /// message a user sees is the same on both platforms.
+    private func policyRefuses(_ key: String, managed: Bool) -> Bool {
+        let restrictions = MDMRestrictions.current()
+        guard managed || restrictions.features.disableUpdateSettings else {
+            return false
+        }
+        refusal = "fields managed by MDM cannot be modified: [\(key)]"
+        AppLogger.shared.log("ConfigurationProvider: refused a write to \(key) — managed by MDM policy")
+        return true
+    }
+
     // MARK: - Rosenpass
 
     var rosenpassEnabled: Bool {
         get { extractJSONBool(field: "RosenpassEnabled") ?? false }
-        set { updateJSONField(field: "RosenpassEnabled", value: newValue) }
+        set {
+            let managed = MDMRestrictions.current().mdm.rosenpassEnabled
+            guard !policyRefuses("rosenpassEnabled", managed: managed) else { return }
+            updateJSONField(field: "RosenpassEnabled", value: newValue)
+        }
     }
 
     var rosenpassPermissive: Bool {
         get { extractJSONBool(field: "RosenpassPermissive") ?? false }
-        set { updateJSONField(field: "RosenpassPermissive", value: newValue) }
+        set {
+            let managed = MDMRestrictions.current().mdm.rosenpassPermissive
+            guard !policyRefuses("rosenpassPermissive", managed: managed) else { return }
+            updateJSONField(field: "RosenpassPermissive", value: newValue)
+        }
     }
 
     // MARK: - IPv6
 
     var disableIPv6: Bool {
         get { extractJSONBool(field: "DisableIPv6") ?? false }
-        set { updateJSONField(field: "DisableIPv6", value: newValue) }
+        set {
+            // No MDM key of its own; only the blanket settings gate applies.
+            guard !policyRefuses("disableIPv6", managed: false) else { return }
+            updateJSONField(field: "DisableIPv6", value: newValue)
+        }
     }
 
     // MARK: - Pre-Shared Key
 
     func setPreSharedKey(_ key: String) {
+        let managed = MDMRestrictions.current().mdm.preSharedKey
+        guard !policyRefuses("preSharedKey", managed: managed) else { return }
         updateJSONField(field: "PreSharedKey", value: key)
     }
 
@@ -212,11 +246,15 @@ final class tvOSConfigurationProvider: ConfigurationProvider {
 
     @discardableResult
     func commit() -> Bool {
-        // Settings are written directly to config JSON, no separate commit needed
-        return true
+        // Settings are written straight to the config JSON, so there is no
+        // separate commit to make — but a write the policy refused must still
+        // be reported, since callers treat commit() as the success signal.
+        lastCommitError = refusal
+        defer { refusal = nil }
+        return refusal == nil
     }
 
-    var lastCommitError: String? { nil }
+    private(set) var lastCommitError: String?
 
     func reload() {
         // Config JSON is always read fresh from UserDefaults

--- a/NetbirdKit/ConfigurationProvider.swift
+++ b/NetbirdKit/ConfigurationProvider.swift
@@ -183,9 +183,13 @@ final class tvOSConfigurationProvider: ConfigurationProvider {
     /// without this gate a managed field would stay writable here while iOS
     /// rejects it. `key` names the field the way the Go error does, so the
     /// message a user sees is the same on both platforms.
-    private func policyRefuses(_ key: String, managed: Bool) -> Bool {
+    private func policyRefuses(_ key: String, managedBy: (MDMRestrictions.Fields) -> Bool) -> Bool {
+        // One snapshot per write. Reading the field's own flag separately from
+        // the blanket gate would let a policy landing between the two reads
+        // slip a managed write through on the stale value - and it costs a
+        // second trip across the bridge for nothing.
         let restrictions = MDMRestrictions.current()
-        guard managed || restrictions.features.disableUpdateSettings else {
+        guard managedBy(restrictions.mdm) || restrictions.features.disableUpdateSettings else {
             return false
         }
         refusal = "fields managed by MDM cannot be modified: [\(key)]"
@@ -198,8 +202,7 @@ final class tvOSConfigurationProvider: ConfigurationProvider {
     var rosenpassEnabled: Bool {
         get { extractJSONBool(field: "RosenpassEnabled") ?? false }
         set {
-            let managed = MDMRestrictions.current().mdm.rosenpassEnabled
-            guard !policyRefuses("rosenpassEnabled", managed: managed) else { return }
+            guard !policyRefuses("rosenpassEnabled", managedBy: { $0.rosenpassEnabled }) else { return }
             updateJSONField(field: "RosenpassEnabled", value: newValue)
         }
     }
@@ -207,8 +210,7 @@ final class tvOSConfigurationProvider: ConfigurationProvider {
     var rosenpassPermissive: Bool {
         get { extractJSONBool(field: "RosenpassPermissive") ?? false }
         set {
-            let managed = MDMRestrictions.current().mdm.rosenpassPermissive
-            guard !policyRefuses("rosenpassPermissive", managed: managed) else { return }
+            guard !policyRefuses("rosenpassPermissive", managedBy: { $0.rosenpassPermissive }) else { return }
             updateJSONField(field: "RosenpassPermissive", value: newValue)
         }
     }
@@ -219,7 +221,7 @@ final class tvOSConfigurationProvider: ConfigurationProvider {
         get { extractJSONBool(field: "DisableIPv6") ?? false }
         set {
             // No MDM key of its own; only the blanket settings gate applies.
-            guard !policyRefuses("disableIPv6", managed: false) else { return }
+            guard !policyRefuses("disableIPv6", managedBy: { _ in false }) else { return }
             updateJSONField(field: "DisableIPv6", value: newValue)
         }
     }
@@ -227,8 +229,7 @@ final class tvOSConfigurationProvider: ConfigurationProvider {
     // MARK: - Pre-Shared Key
 
     func setPreSharedKey(_ key: String) {
-        let managed = MDMRestrictions.current().mdm.preSharedKey
-        guard !policyRefuses("preSharedKey", managed: managed) else { return }
+        guard !policyRefuses("preSharedKey", managedBy: { $0.preSharedKey }) else { return }
         updateJSONField(field: "PreSharedKey", value: key)
     }
 

--- a/NetbirdKit/MDMRestrictions.swift
+++ b/NetbirdKit/MDMRestrictions.swift
@@ -171,3 +171,37 @@ extension MDMRestrictions {
         return decode(json)
     }
 }
+
+// MARK: - Reporting a refused change
+
+extension MDMRestrictions {
+
+    /// One wording for a policy refusal, so the app cannot drift into several
+    /// phrasings of the same condition.
+    static let managedSettingMessage = "This setting is managed by your organization and cannot be changed."
+
+    /// Turns a rejected commit into something the user can act on.
+    ///
+    /// Go wraps ErrMDMManagedFields with the offending keys -
+    /// "fields managed by MDM cannot be modified: [rosenpassEnabled]" - so
+    /// name them instead of discarding the half of the message that says which
+    /// setting was refused. Returns nil when the failure was not a policy
+    /// refusal, leaving the caller to report it as an ordinary error.
+    ///
+    /// Lives here rather than on the view model: it is pure text handling over
+    /// a bridge string, with no view state and no main-actor business.
+    static func rejectionMessage(from reason: String) -> String? {
+        guard reason.localizedCaseInsensitiveContains("managed by MDM") else {
+            return nil
+        }
+        guard let separator = reason.range(of: ": ", options: .backwards) else {
+            return managedSettingMessage
+        }
+        let keys = reason[separator.upperBound...]
+            .trimmingCharacters(in: CharacterSet(charactersIn: "[] "))
+        guard !keys.isEmpty else {
+            return managedSettingMessage
+        }
+        return "\(managedSettingMessage) (\(keys))"
+    }
+}

--- a/NetbirdNetworkExtension/PacketTunnelProvider.swift
+++ b/NetbirdNetworkExtension/PacketTunnelProvider.swift
@@ -162,28 +162,6 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         return _tunnelGeneration
     }
 
-    /// True from the moment startTunnel hands off to adapter.start until that
-    /// call completes.
-    ///
-    /// Initial startup does not set isRestartInProgress, so without this an
-    /// MDM restart arriving in that window would pass the guard and call
-    /// adapter.stop() while client.run() was still being dispatched — the
-    /// adapter does not serialise the two. Deferring instead of dropping means
-    /// the policy is applied as soon as startup finishes.
-    private var _isStartingTunnel = false
-    private var isStartingTunnel: Bool {
-        get {
-            tearDownLock.lock()
-            defer { tearDownLock.unlock() }
-            return _isStartingTunnel
-        }
-        set {
-            tearDownLock.lock()
-            _isStartingTunnel = newValue
-            tearDownLock.unlock()
-        }
-    }
-
     /// True only while `generation` is still the live lifecycle and no
     /// teardown has begun.
     private func isCurrentGeneration(_ generation: Int) -> Bool {
@@ -304,9 +282,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             ))
         }
 
-        isStartingTunnel = true
         adapter.start { [weak self] error in
-            self?.isStartingTunnel = false
             if self?.completeTunnelStart(with: error) == false {
                 AppLogger.shared.log("startTunnel: engine reported connected again, start outcome stays as first reported")
             }
@@ -354,7 +330,6 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         // a queued write would let it see the old value and restart into the
         // teardown.
         isTearingDown = true
-        isStartingTunnel = false
 
         // A stop that lands before the engine ever reported connected would otherwise leave
         // NE waiting on the start outcome forever: the outcome is delivered from the
@@ -1224,7 +1199,12 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         // guard and start their own stop/start pipelines.
         monitorQueue.async { [weak self] in
             guard let self = self, !self.isTearingDown else { return }
-            guard !self.isRestartInProgress, !self.isStartingTunnel else {
+            // isInitialStartInFlight, not a latch of our own: restartClient()
+            // consults exactly this flag and returns early while it is set, so
+            // a second guard would leave a window where this request passes,
+            // clears pendingMDMRestart, and then finds the restart refused with
+            // nothing left to retry it.
+            guard !self.isRestartInProgress, !self.isInitialStartInFlight else {
                 guard self.mdmRetryAttempts < Self.maxMDMRetryAttempts else {
                     // The pipeline should clear its guard within its own
                     // 30-second timeout; past that something is wedged, and a

--- a/NetbirdNetworkExtension/PacketTunnelProvider.swift
+++ b/NetbirdNetworkExtension/PacketTunnelProvider.swift
@@ -87,7 +87,25 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     /// observed, so it will not report the change again - if this restart
     /// were simply dropped, that policy would never be applied. The flag
     /// makes the handler come back for it.
-    private var pendingMDMRestart = false
+    private var _pendingMDMRestart = false
+    private var pendingMDMRestart: Bool {
+        get {
+            tearDownLock.lock()
+            defer { tearDownLock.unlock() }
+            return _pendingMDMRestart
+        }
+        set {
+            tearDownLock.lock()
+            _pendingMDMRestart = newValue
+            tearDownLock.unlock()
+        }
+    }
+
+    /// Attempts the deferred retry has already made. Bounded so a restart
+    /// pipeline that never clears its guard cannot leave a timer rescheduling
+    /// itself for the life of the tunnel.
+    private var mdmRetryAttempts = 0
+    private static let maxMDMRetryAttempts = 15
 
     /// The deferred retry that waits out an in-flight restart. Tracked so
     /// teardown can cancel it: otherwise it fires afterwards, passes a guard
@@ -1185,6 +1203,9 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         }
 
         AppLogger.shared.log("MDM: managed configuration changed; restarting client")
+        monitorQueue.async { [weak self] in
+            self?.mdmRetryAttempts = 0
+        }
         requestMDMRestart()
     }
 
@@ -1204,8 +1225,19 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         monitorQueue.async { [weak self] in
             guard let self = self, !self.isTearingDown else { return }
             guard !self.isRestartInProgress, !self.isStartingTunnel else {
+                guard self.mdmRetryAttempts < Self.maxMDMRetryAttempts else {
+                    // The pipeline should clear its guard within its own
+                    // 30-second timeout; past that something is wedged, and a
+                    // timer rescheduling itself forever would only hide it.
+                    AppLogger.shared.log("MDM: giving up after \(self.mdmRetryAttempts) retries — a start or restart never finished; the policy will apply on the next change or tunnel start")
+                    self.mdmRetryWorkItem = nil
+                    self.mdmRetryAttempts = 0
+                    self.pendingMDMRestart = false
+                    return
+                }
+                self.mdmRetryAttempts += 1
                 self.pendingMDMRestart = true
-                AppLogger.shared.log("MDM: a start or restart is in flight; will retry once it finishes")
+                AppLogger.shared.log("MDM: a start or restart is in flight; retry \(self.mdmRetryAttempts)/\(Self.maxMDMRetryAttempts)")
                 self.mdmRetryWorkItem?.cancel()
                 let retry = DispatchWorkItem { [weak self] in
                     guard let self = self, self.pendingMDMRestart, !self.isTearingDown else { return }
@@ -1216,6 +1248,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
                 return
             }
             self.mdmRetryWorkItem = nil
+            self.mdmRetryAttempts = 0
             self.pendingMDMRestart = false
             // Only a restart that actually brought the engine back up means the
             // policy is in force; a deferred or failed one must not tell the


### PR DESCRIPTION
## What this does

Follow-ups from review of the MDM integration (#206). Four findings, each
verified against the code before fixing.

### tvOS never reached `CheckMDMConflicts`

`tvOSConfigurationProvider.commit()` returned `true` without consulting
anything. Unlike iOS, which goes through `Preferences.commit()` and Go's
conflict gate, tvOS writes settings straight to the config JSON — so a managed
field stayed writable there while iOS rejected it.

The gate belongs in the setters, not in `commit()`: by the time `commit()` runs
the write has already happened. `commit()` now reports whether a write was
refused, and the refusal is phrased the way Go phrases it
(`fields managed by MDM cannot be modified: [key]`), so a user sees the same
message on both platforms.

### The refusal text was written three times, and Go's key list was discarded

Go wraps `ErrMDMManagedFields` with the offending keys:

```go
fmt.Errorf("%w: %v", ErrMDMManagedFields, conflicts)
```

We threw away the half of that message which says *which* setting was refused,
and hardcoded a generic sentence in three places. There is one constant now, and
the conflicts are parsed out and shown. The substring match remains — the bridge
gives us a string, not a typed error — but it lives in one place and is covered
by tests, including the case where the failure is not a policy refusal at all
and must not be reported as one.

### `pendingMDMRestart` was written off `monitorQueue`

`stopObservingMDMConfigChanges()` set it synchronously while `stopTunnel` also
queued a write to it. `_isTearingDown`, `_isStartingTunnel` and
`_tunnelGeneration` are behind `tearDownLock` for exactly this reason; this flag
now joins them.

### The deferred restart retried forever

`requestMDMRestart()` rescheduled itself every two seconds for as long as
`isRestartInProgress` stayed set. Capped at 15 attempts — thirty seconds, which
is the restart pipeline's own timeout — then it logs and gives up. Waiting
longer cannot help: past that timeout something is wedged, and a timer
rescheduling itself for the life of the tunnel would only hide it. The budget
resets on a genuine policy change and on a restart that starts.

## Testing

iOS and tvOS build; the suite passes, including a new test for the rejection
parsing (key list present, several keys, no list, non-policy failure, empty).

The tvOS gate has no unit coverage — it needs a tvOS host and a live policy —
so it was exercised by inspection against the iOS path it mirrors.

## Note for whoever picks this up

`NetBirdSDK.xcframework` in the working tree was built from an unrelated commit
and without the tvOS slices, which surfaces as
`no member 'setMDMPolicyFetcher'` and `no library for this platform` rather than
as anything to do with the framework. Rebuild with `./build-go-lib.sh --tvos`
and check the version baked into the binary before chasing a compile error:

```
strings NetBirdSDK.xcframework/ios-arm64/NetBirdSDK.framework/NetBirdSDK \
  | grep -E '^dev-[0-9a-f]+$'
```

It should match the recorded submodule commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Settings restriction alerts now identify the specific fields managed by your organization.
  - tvOS settings changes now respect MDM policies for managed security, IPv6, and pre-shared key settings.

- **Bug Fixes**
  - MDM-controlled settings can no longer be changed through unsupported configuration paths.
  - Automatic restarts triggered by policy changes now retry safely and stop after a limited number of attempts, preventing indefinite retry loops.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->