### PR TITLE
Fix exit node

### DIFF
--- a/NetBird/Source/App/NetBirdApp.swift
+++ b/NetBird/Source/App/NetBirdApp.swift
@@ -127,12 +127,31 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
 }
 #endif
 
+#if os(tvOS)
+/// Live mirror of the tvOS scene phase.
+///
+/// `scenePhase` is an `@Environment` value on the App *struct*, so the activation task
+/// captures a copy of the struct and keeps reading the phase as it was when the closure
+/// was created — the guards after each `await` would re-check a snapshot, not the app.
+/// A reference type is read through, so those guards see the phase the app is actually in.
+/// iOS reads `UIApplication.shared.applicationState` live and needs none of this; tvOS has
+/// no equivalent. Written and read on the main thread only, from the scene callbacks and
+/// the `@MainActor` activation task.
+private final class ScenePhaseMirror {
+    var isActive = false
+}
+#endif
+
 @main
 struct NetBirdApp: App {
     @StateObject private var viewModelLoader = ViewModelLoader()
     @Environment(\.scenePhase) var scenePhase
     @State private var activationTask: Task<Void, Never>?
     @State private var pendingURL: URL?
+
+    #if os(tvOS)
+    @State private var scenePhaseMirror = ScenePhaseMirror()
+    #endif
 
     #if os(iOS)
     @UIApplicationDelegateAdaptor(AppDelegate.self) var delegate
@@ -178,11 +197,17 @@ struct NetBirdApp: App {
                     #endif
                     #if os(tvOS)
                     .onAppear {
+                        // Seed the mirror before anything can read it: the activation task
+                        // below bails out immediately if it still says inactive.
+                        scenePhaseMirror.isActive = scenePhase == .active
                         if scenePhase == .active {
                             startActivation(viewModel: viewModel)
                         }
                     }
                     .onChange(of: scenePhase) { _, newPhase in
+                        // Update the mirror first — it is what the in-flight activation
+                        // task re-checks after each await to notice it has been superseded.
+                        scenePhaseMirror.isActive = newPhase == .active
                         if newPhase == .active {
                             startActivation(viewModel: viewModel)
                         } else {
@@ -220,21 +245,25 @@ struct NetBirdApp: App {
 
                 // Assigning extensionState directly means the checkExtensionState() below
                 // hits applyExtensionStatus' `extensionState != status` guard and returns
-                // early — taking its route side effects with it. Apply them here instead.
+                // early — taking every side effect of the state with it. Apply them here
+                // instead.
                 //
                 // Launching (or foregrounding) onto an already-connected tunnel would
                 // otherwise leave the exit node selector stuck on "No exit nodes
                 // available" until the user visits the Resources tab, whose own onAppear
                 // does the fetch. Foregrounding onto a tunnel that dropped while the app
                 // was away is the mirror case: the routes are never cleared, so the
-                // selector stays enabled over nodes the core can no longer apply.
+                // selector stays enabled over nodes the core can no longer apply. And a
+                // tunnel that connected while the app was away — the usual end of a
+                // login-required cycle, which disarms On Demand at the manager — needs its
+                // On Demand rules put back, which is the other half of this call.
                 //
                 // loadCurrentConnectionState can await past this activation's lifetime:
                 // its 200 ms retry sleep uses `try?`, which swallows cancellation. The
-                // assignment above is a cheap local update, but the route sync below is
-                // an IPC round-trip — don't make it for an activation already superseded.
+                // assignment above is a cheap local update, but the work below is IPC —
+                // don't do it for an activation already superseded.
                 guard isAppActive, !Task.isCancelled else { return }
-                viewModel.applyRouteSideEffects(for: initialStatus)
+                viewModel.applyStatusSideEffects(for: initialStatus)
             } else {
                 // No matching VPN profile found — still force a widget timeline refresh so
                 // the widget doesn't stay stuck on a transitioning state from a prior
@@ -267,11 +296,13 @@ struct NetBirdApp: App {
         viewModel.stopPollingDetails()
     }
 
+    /// The app's *current* foreground state, safe to re-check after an `await`.
     private var isAppActive: Bool {
         #if os(iOS)
         UIApplication.shared.applicationState == .active
         #else
-        scenePhase == .active
+        // Not `scenePhase`: see ScenePhaseMirror.
+        scenePhaseMirror.isActive
         #endif
     }
 

--- a/NetBird/Source/App/ViewModels/MainViewModel.swift
+++ b/NetBird/Source/App/ViewModels/MainViewModel.swift
@@ -757,31 +757,58 @@ class ViewModel: ObservableObject {
         // important when a short On Demand cycle skipped .disconnected between polls.
         guard statusChanged else { return }
 
-        applyRouteSideEffects(for: status)
-
-        // `connectOnDemand` is the user's saved preference, which the policy
-        // deliberately leaves intact so it can be restored later - so it is
-        // not on its own permission to arm the rules.
-        if status == .connected, connectOnDemand, !autoConnectForbiddenByPolicy {
-            networkExtensionAdapter.setOnDemandEnabled(true)
-        }
+        applyStatusSideEffects(for: status)
     }
 
-    /// Brings the cached route list in line with `status`.
+    /// Everything that has to happen when the extension reaches `status`, beyond publishing
+    /// the state itself: the cached route list, and re-arming On Demand.
     ///
     /// Separate from `applyExtensionStatus` so that callers which assign `extensionState`
     /// themselves — and therefore trip its `extensionState != status` guard — can still
-    /// apply this part. Idempotent: re-running it for an unchanged status costs one
-    /// GetRoutes round-trip while connected, and nothing at all while disconnected.
-    func applyRouteSideEffects(for status: NEVPNStatus) {
+    /// apply all of it. Every such caller must go through this one function: when the On
+    /// Demand re-arm lived in `applyExtensionStatus` alone, an activation that restored
+    /// `.connected` by direct assignment silently skipped it. Idempotent: re-running it for
+    /// an unchanged status costs one GetRoutes round-trip and at most one no-op On Demand
+    /// write while connected, and nothing at all while disconnected.
+    func applyStatusSideEffects(for status: NEVPNStatus) {
         if status == .connected {
             routeViewModel.getRoutes()
+            rearmOnDemandIfNeeded()
         } else if status == .disconnected {
             // Routes only exist while the extension is up. Drop them so the exit node
             // selector on the connection screen falls back to its disabled state instead
             // of listing nodes that can no longer be applied. The core keeps the actual
             // selection, so it comes back with the next getRoutes on reconnect.
             routeViewModel.clearRoutes()
+        }
+    }
+
+    /// Puts the On Demand rules back after a successful connection when the saved
+    /// preference asks for them.
+    ///
+    /// `checkLoginRequiredFlag()` disarms the rules at the manager to stop iOS looping
+    /// reconnects while the user is logged out, deliberately leaving the stored preference
+    /// on so it can be restored — this is what restores it.
+    ///
+    /// A refusal is not swallowed. `connectOnDemand` drives the Settings toggle and, on
+    /// tvOS, the disconnect confirmation prompt, so leaving it `true` over rules the manager
+    /// refused to arm would have the UI claim protection that is not in force. `.deferred`
+    /// (nothing to arm yet) leaves the preference standing; only an outright rejection
+    /// writes it down to match reality.
+    private func rearmOnDemandIfNeeded() {
+        // `connectOnDemand` is the user's saved preference, which the policy
+        // deliberately leaves intact so it can be restored later - so it is
+        // not on its own permission to arm the rules.
+        guard connectOnDemand, !autoConnectForbiddenByPolicy else { return }
+        networkExtensionAdapter.setOnDemandEnabled(true) { [weak self] update in
+            guard case .failed(let error) = update else { return }
+            DispatchQueue.main.async {
+                guard let self, self.connectOnDemand else { return }
+                AppLogger.shared.log("On Demand re-arm rejected by the tunnel manager (\(error?.localizedDescription ?? "no details")) - clearing the saved preference to match what is in force")
+                self.connectOnDemand = false
+                UserDefaults(suiteName: GlobalConstants.userPreferencesSuiteName)?
+                    .set(false, forKey: GlobalConstants.keyConnectOnDemand)
+            }
         }
     }
     
@@ -844,6 +871,12 @@ class ViewModel: ObservableObject {
                     AppLogger.shared.log("resetForServerChange: On Demand disarm failed, resetting anyway")
                 }
                 self.performClose()
+                // Don't wait for the disconnect to come back through polling (up to one
+                // 3 s tick away, and only while polling is running at all) — the routes
+                // belong to the server being left, so drop them now. This mirrors what
+                // handleServerChanged does on iOS, so both platforms clear on the server
+                // change itself rather than on two different mechanisms.
+                self.applyStatusSideEffects(for: .disconnected)
                 self.clearDetails()
                 completion()
             }
@@ -1133,7 +1166,7 @@ class ViewModel: ObservableObject {
     ///
     /// The preference is written up front because it is the user's *intent*: when there is
     /// nothing to arm yet (no manager, or no login), the choice has to survive so
-    /// `applyExtensionStatus` can arm it after the next successful connection. Only a manager
+    /// `applyStatusSideEffects` can arm it after the next successful connection. Only a manager
     /// that actively rejects the change rolls the stored value back, so UI, storage and the
     /// tunnel manager never disagree about what is in force.
     ///
@@ -1276,6 +1309,14 @@ class ViewModel: ObservableObject {
         managementStatus = .disconnected
         updateVPNDisplayState()
 
+        // Assigning extensionState directly means no later .disconnected update can carry
+        // the state's side effects: applyExtensionStatus returns early on an unchanged
+        // status, and stopPollingDetails() above has stopped the timer that would deliver
+        // one anyway. Apply them here, or the exit node selector stays enabled over the
+        // previous account's nodes — which the core, now pointed at another server, would
+        // never accept.
+        applyStatusSideEffects(for: .disconnected)
+
         // Clear peer info
         peerViewModel.peerInfo = []
 
@@ -1402,7 +1443,7 @@ class ViewModel: ObservableObject {
         updateVPNDisplayState()
         // Temporarily disable On Demand to stop iOS from looping reconnect attempts
         // while the user is not authenticated. It will be re-enabled automatically
-        // after a successful connection (see applyExtensionStatus).
+        // after a successful connection (see applyStatusSideEffects).
         networkExtensionAdapter.setOnDemandEnabled(false)
         #endif
     }

--- a/NetBird/Source/App/ViewModels/RoutesViewModel.swift
+++ b/NetBird/Source/App/ViewModels/RoutesViewModel.swift
@@ -92,6 +92,7 @@ class RoutesViewModel: ObservableObject {
         // selector keeps showing the old value until the getRoutes round-trip lands.
         guard let exitNode else {
             guard let current = selectedExitNode else { return }
+            let revertPoint = beginSelectionMutation()
             objectWillChange.send()
             current.objectWillChange.send()
             current.selected = false
@@ -102,10 +103,19 @@ class RoutesViewModel: ObservableObject {
             // actually dropped the node. Hop to main before touching the generation and
             // @Published state: this completion runs on whatever queue the extension
             // replies on.
-            networkExtensionAdapter.deselectRoutes(id: current.name) { [weak self] _ in
+            networkExtensionAdapter.deselectRoutes(id: current.name) { [weak self] result in
                 DispatchQueue.main.async {
                     guard let self, self.exitNodeGeneration == generation else { return }
-                    self.getRoutes()
+                    switch result {
+                    case .success:
+                        self.getRoutes()
+                    case .failure(let error):
+                        // The request never reached the core, so the node is still in
+                        // force. Put the selector back rather than leaving it showing a
+                        // "None" the core never applied.
+                        print("Deselecting exit node failed: \(error.localizedDescription)")
+                        self.revert(to: revertPoint)
+                    }
                 }
             }
             return
@@ -139,17 +149,69 @@ class RoutesViewModel: ObservableObject {
         let generation = routeReadGeneration
         // Hop to main before touching the generation and @Published state: this completion
         // runs on whatever queue the extension replies on.
-        networkExtensionAdapter.getRoutes { [weak self] details in
+        networkExtensionAdapter.getRoutes { [weak self] result in
             DispatchQueue.main.async {
                 guard let self, self.routeReadGeneration == generation else { return }
-                self.routeInfo = details.routeSelectionInfo
-                print("Route count: \(details.routeSelectionInfo.count)")
+                switch result {
+                case .success(let details):
+                    self.routeInfo = details.routeSelectionInfo
+                    print("Route count: \(details.routeSelectionInfo.count)")
+                case .failure(let error):
+                    // A request that never reached the core says nothing about the network
+                    // map, so the cached list stands. Only an answer from the core — an
+                    // empty one included — is allowed to replace it. Views may therefore
+                    // call this unconditionally: with no tunnel session the read fails and
+                    // leaves valid routes alone, and `clearRoutes()` remains the one path
+                    // that empties them on a real disconnect.
+                    print("Failed to read routes, keeping the cached list: \(error.localizedDescription)")
+                }
             }
         }
+    }
+
+    /// The selection state before an optimistic mutation, tagged with the mutation that
+    /// took it, so a round-trip the user has already superseded reverts nothing.
+    private struct SelectionRevertPoint {
+        let generation: Int
+        let selection: [UUID: Bool]
+    }
+
+    /// Bumped by every optimistic selection change. `revert(to:)` compares against it, so a
+    /// failure arriving after the user has moved on is dropped instead of undoing the newer
+    /// choice. Main-thread only, matching every caller.
+    private var selectionGeneration = 0
+
+    /// Records a revert point covering every cached route and claims the next generation.
+    /// Call immediately before writing an optimistic selection.
+    private func beginSelectionMutation() -> SelectionRevertPoint {
+        selectionGeneration &+= 1
+        return SelectionRevertPoint(
+            generation: selectionGeneration,
+            selection: Dictionary(routeInfo.map { ($0.id, $0.selected) }, uniquingKeysWith: { first, _ in first })
+        )
+    }
+
+    /// Undoes the optimistic writes covered by `point`, skipping routes that are no longer
+    /// cached. `selected` is a plain property on a reference type held in a @Published
+    /// array, so every restored route has to announce its own change.
+    private func revert(to point: SelectionRevertPoint) {
+        guard selectionGeneration == point.generation else { return }
+        var changed = false
+        for route in routeInfo {
+            guard let wasSelected = point.selection[route.id], route.selected != wasSelected else { continue }
+            route.objectWillChange.send()
+            route.selected = wasSelected
+            changed = true
+        }
+        if changed { objectWillChange.send() }
     }
     
     func selectRoute(route: RoutesSelectionInfo) {
         guard let index = self.routeInfo.firstIndex(where: { $0.id == route.id }) else { return }
+
+        // Taken before the optimistic writes below so a rejected round-trip can undo all of
+        // them — this route's selection and, for an exit node, its siblings' deselection.
+        let revertPoint = beginSelectionMutation()
 
         // `selected` is not @Published (kept for Codable); notify both observers explicitly.
         self.objectWillChange.send()
@@ -158,7 +220,7 @@ class RoutesViewModel: ObservableObject {
 
         // Non-exit routes select independently.
         guard route.isExitNode else {
-            sendSelectAndReconcile(route: route)
+            sendSelectAndReconcile(route: route, revertingTo: revertPoint)
             return
         }
 
@@ -179,7 +241,7 @@ class RoutesViewModel: ObservableObject {
 
         let siblings = routeInfo.filter { $0.id != route.id && $0.selected && $0.isExitNode }
         guard !siblings.isEmpty else {
-            sendSelectAndReconcile(route: route)
+            sendSelectAndReconcile(route: route, revertingTo: revertPoint)
             return
         }
 
@@ -192,6 +254,10 @@ class RoutesViewModel: ObservableObject {
             sibling.objectWillChange.send()
             sibling.selected = false
             group.enter()
+            // A failed deselect is not fatal here: the select still goes out, and the
+            // GetRoutes reconcile below reports whatever the core actually ended up with.
+            // When there is no session at all the select fails too, and that failure is
+            // what reverts the whole optimistic change.
             networkExtensionAdapter.deselectRoutes(id: sibling.name) { _ in
                 group.leave()
             }
@@ -199,7 +265,7 @@ class RoutesViewModel: ObservableObject {
 
         group.notify(queue: .main) { [weak self] in
             guard let self, self.exitNodeGeneration == generation else { return }
-            self.sendSelectAndReconcile(route: route)
+            self.sendSelectAndReconcile(route: route, revertingTo: revertPoint)
         }
     }
 
@@ -208,36 +274,63 @@ class RoutesViewModel: ObservableObject {
     // extension swallows errors and always replies "true"), so re-read the truth via
     // GetRoutes: if the core rejected the change the toggle reverts instead of leaving a
     // stale optimistic selection in place.
-    private func sendSelectAndReconcile(route: RoutesSelectionInfo) {
-        networkExtensionAdapter.selectRoutes(id: route.name) { [weak self] _ in
+    //
+    // A select that never reached the core at all — no tunnel session, a send that threw —
+    // gets no reconcile to revert it, because GetRoutes would fail for the same reason and
+    // deliberately leaves the cache (optimistic writes included) untouched. So undo the
+    // optimistic writes here instead, from the revert point taken before them.
+    private func sendSelectAndReconcile(route: RoutesSelectionInfo, revertingTo revertPoint: SelectionRevertPoint) {
+        networkExtensionAdapter.selectRoutes(id: route.name) { [weak self] result in
             DispatchQueue.main.async {
-                self?.getRoutes()
+                guard let self else { return }
+                switch result {
+                case .success:
+                    self.getRoutes()
+                case .failure(let error):
+                    print("Selecting route failed: \(error.localizedDescription)")
+                    self.revert(to: revertPoint)
+                }
             }
         }
     }
     
     func selectAllRoutes() {
-        networkExtensionAdapter.selectRoutes(id: "All") { details in
-            print("selected all routes")
+        networkExtensionAdapter.selectRoutes(id: "All") { result in
+            switch result {
+            case .success: print("selected all routes")
+            case .failure(let error): print("Selecting all routes failed: \(error.localizedDescription)")
+            }
         }
     }
     
     func deselectRoute(route: RoutesSelectionInfo) {
         guard let index = self.routeInfo.firstIndex(where: { $0.id == route.id }) else { return }
+        let revertPoint = beginSelectionMutation()
         self.objectWillChange.send()
         self.routeInfo[index].objectWillChange.send()
         self.routeInfo[index].selected = false
-        // Reconcile with the core's real state, mirroring selectRoute.
-        networkExtensionAdapter.deselectRoutes(id: route.name) { [weak self] _ in
+        // Reconcile with the core's real state, mirroring selectRoute — and revert the
+        // optimistic write when the request never got there.
+        networkExtensionAdapter.deselectRoutes(id: route.name) { [weak self] result in
             DispatchQueue.main.async {
-                self?.getRoutes()
+                guard let self else { return }
+                switch result {
+                case .success:
+                    self.getRoutes()
+                case .failure(let error):
+                    print("Deselecting route failed: \(error.localizedDescription)")
+                    self.revert(to: revertPoint)
+                }
             }
         }
     }
     
     func deselectAllRoutes() {
-        networkExtensionAdapter.deselectRoutes(id: "All") { details in
-            print("deselect all routes")
+        networkExtensionAdapter.deselectRoutes(id: "All") { result in
+            switch result {
+            case .success: print("deselect all routes")
+            case .failure(let error): print("Deselecting all routes failed: \(error.localizedDescription)")
+            }
         }
     }
     

--- a/NetBird/Source/App/Views/TV/TVMainView.swift
+++ b/NetBird/Source/App/Views/TV/TVMainView.swift
@@ -266,12 +266,10 @@ struct TVConnectionView: View {
         }
         .onAppear {
             // Coming back to this tab doesn't go through applyExtensionStatus, so refresh
-            // the network map here to keep the exit node selector current. Only while
-            // connected: GetRoutes answers with an empty list when there is no tunnel
-            // session and would wipe a list that is still valid.
-            if viewModel.vpnDisplayState == .connected {
-                viewModel.routeViewModel.getRoutes()
-            }
+            // the network map here to keep the exit node selector current. Unconditional: a
+            // read with no tunnel session fails instead of answering "zero routes", and a
+            // failed read leaves the cached list alone (see RoutesViewModel.getRoutes).
+            viewModel.routeViewModel.getRoutes()
         }
     }
 

--- a/NetBird/Source/App/Views/iOS/iOSConnectionView.swift
+++ b/NetBird/Source/App/Views/iOS/iOSConnectionView.swift
@@ -191,12 +191,10 @@ struct iOSConnectionView: View {
         }
         .onAppear {
             // Returning to this tab doesn't go through applyExtensionStatus, so refresh the
-            // network map here to keep the exit node selector current. Only while connected:
-            // GetRoutes answers with an empty list when there is no tunnel session and would
-            // wipe a list that is still valid.
-            if viewModel.vpnDisplayState == .connected {
-                viewModel.routeViewModel.getRoutes()
-            }
+            // network map here to keep the exit node selector current. Unconditional: a read
+            // with no tunnel session fails instead of answering "zero routes", and a failed
+            // read leaves the cached list alone (see RoutesViewModel.getRoutes).
+            viewModel.routeViewModel.getRoutes()
         }
     }
 

--- a/NetbirdKit/NetworkExtensionAdapter.swift
+++ b/NetbirdKit/NetworkExtensionAdapter.swift
@@ -319,7 +319,7 @@ public class NetworkExtensionAdapter: ObservableObject {
             #if os(tvOS)
             // Stop the system from retry-looping the tunnel while the user works through the
             // device code flow — every unattended start would fail on "login required".
-            // applyExtensionStatus re-arms On Demand once the tunnel is up again.
+            // applyStatusSideEffects re-arms On Demand once the tunnel is up again.
             // Await the save: the login starts a tunnel of its own, and a rule that is still
             // in force would race it with an unauthenticated start.
             if isOnDemandEnabled {
@@ -984,7 +984,7 @@ public class NetworkExtensionAdapter: ObservableObject {
         /// The rules were written to the tunnel manager.
         case applied
         /// There was nothing to arm — no manager exists yet, or no configuration to connect
-        /// with. The stored preference stands and `applyExtensionStatus` arms it after the
+        /// with. The stored preference stands and `applyStatusSideEffects` arms it after the
         /// next successful connection.
         case deferred
         /// The tunnel manager rejected the change; what is in force is still the old state.
@@ -1071,7 +1071,7 @@ public class NetworkExtensionAdapter: ObservableObject {
     /// A request that matches what the manager already holds is answered without a write:
     /// saveToPreferences on a configured manager makes NE emit NEVPNStatusDidChange — a
     /// transient .disconnecting among them — and rewriting the rules of a live tunnel can
-    /// have the system reassert it. applyExtensionStatus arms On Demand on every transition
+    /// have the system reassert it. applyStatusSideEffects arms On Demand on every transition
     /// to .connected, so an unconditional write added a spurious disconnect to every connect.
     ///
     /// The skip trusts the manager to reflect what the system holds, which is only true while
@@ -1396,83 +1396,108 @@ public class NetworkExtensionAdapter: ObservableObject {
         #endif
     }
 
-    func getRoutes(completion: @escaping (RoutesSelectionDetails) -> Void) {
-        guard let session = self.session else {
-            let defaultStatus = RoutesSelectionDetails(all: false, append: false, routeSelectionInfo: [])
-            completion(defaultStatus)
-            return
-        }
-        
-        let messageString = "GetRoutes"
-        if let messageData = messageString.data(using: .utf8) {
-            do {
-                try session.sendProviderMessage(messageData) { response in
-                    if let response = response {
-                        do {
-                            let decodedStatus = try self.decoder.decode(RoutesSelectionDetails.self, from: response)
-                            completion(decodedStatus)
-                            return
-                        } catch {
-                            print("Failed to decode route selection details.")
-                        }
-                    } else {
-                        let defaultStatus = RoutesSelectionDetails(all: false, append: false, routeSelectionInfo: [])
-                        completion(defaultStatus)
-                        return
-                    }
-                }
-            } catch {
-                print("Failed to send Provider message")
+    /// Why a route request never reached the core, or never came back from it.
+    ///
+    /// Every one of these means "the answer is unknown", which is categorically different
+    /// from the core answering with an empty network map. Callers must not fold the two
+    /// together: an unknown answer leaves the cached routes standing, an empty answer
+    /// replaces them.
+    enum RouteRequestError: LocalizedError {
+        /// No tunnel session to talk to — the extension is not running.
+        case noSession
+        /// The message could not be encoded, so nothing was sent.
+        case encodingFailed
+        /// `sendProviderMessage` threw; the request never left the app.
+        case sendFailed(Error)
+        /// The extension answered with no payload.
+        case emptyResponse
+        /// The extension answered with something that is not a route selection.
+        case decodingFailed(Error)
+
+        var errorDescription: String? {
+            switch self {
+            case .noSession: return "No tunnel session"
+            case .encodingFailed: return "Failed to encode the request"
+            case .sendFailed(let error): return "Failed to send the request: \(error.localizedDescription)"
+            case .emptyResponse: return "No response from the extension"
+            case .decodingFailed(let error): return "Failed to decode the response: \(error.localizedDescription)"
             }
-        } else {
-            print("Error converting message to Data")
         }
     }
 
-    func selectRoutes(id: String, completion: @escaping (RoutesSelectionDetails) -> Void) {
-        guard let session = self.session else {
-            return
-        }
-
-        let messageString = "Select-\(id)"
-        if let messageData = messageString.data(using: .utf8) {
-            do {
-                try session.sendProviderMessage(messageData) { response in
-                    let routes = RoutesSelectionDetails(all: false, append: false, routeSelectionInfo: [])
-                    completion(routes)
-                }
-            } catch {
-                print("Failed to send Provider message")
-            }
-        } else {
-            print("Error converting message to Data")
-        }
+    /// Reads the current network map from the extension.
+    ///
+    /// The completion fires on every path, success or failure, because callers both
+    /// reconcile optimistic UI against it and balance a `DispatchGroup` around it. A
+    /// failure carries no route list on purpose — see `RouteRequestError`.
+    func getRoutes(completion: @escaping (Result<RoutesSelectionDetails, RouteRequestError>) -> Void) {
+        sendRouteMessage("GetRoutes", decodeResponse: true, completion: completion)
     }
 
-    func deselectRoutes(id: String, completion: @escaping (RoutesSelectionDetails) -> Void) {
-        // Callers (e.g. RoutesViewModel.selectRoute) balance a DispatchGroup enter/leave
-        // around this call, so completion must fire on every exit path or the group hangs
-        // and the pending select is never sent.
-        let routes = RoutesSelectionDetails(all: false, append: false, routeSelectionInfo: [])
+    /// Asks the core to select `id` — a route name, or "All".
+    ///
+    /// The extension answers select/deselect with a bare acknowledgement rather than a
+    /// route list, so success carries an empty `RoutesSelectionDetails` and callers
+    /// re-read the truth with `getRoutes`. What matters here is success vs. failure:
+    /// a failure is the signal to revert an optimistic selection.
+    func selectRoutes(id: String, completion: @escaping (Result<RoutesSelectionDetails, RouteRequestError>) -> Void) {
+        sendRouteMessage("Select-\(id)", decodeResponse: false, completion: completion)
+    }
+
+    /// Asks the core to deselect `id` — a route name, or "All". Same contract as
+    /// `selectRoutes`.
+    func deselectRoutes(id: String, completion: @escaping (Result<RoutesSelectionDetails, RouteRequestError>) -> Void) {
+        sendRouteMessage("Deselect-\(id)", decodeResponse: false, completion: completion)
+    }
+
+    /// Shared body of the three route IPC calls: one exit path per failure mode, and the
+    /// completion invoked on all of them.
+    ///
+    /// - Parameter decodeResponse: `true` for reads, which need the payload; `false` for
+    ///   select/deselect, whose reply is a bare acknowledgement.
+    private func sendRouteMessage(
+        _ messageString: String,
+        decodeResponse: Bool,
+        completion: @escaping (Result<RoutesSelectionDetails, RouteRequestError>) -> Void
+    ) {
+        let acknowledgement = RoutesSelectionDetails(all: false, append: false, routeSelectionInfo: [])
 
         guard let session = self.session else {
-            completion(routes)
+            // Routine, not exceptional: views refresh the network map on appear whether or
+            // not a tunnel is up, and this is the answer that keeps a stale list from being
+            // mistaken for an empty one.
+            logger.debug("\(messageString): no tunnel session")
+            completion(.failure(.noSession))
             return
         }
 
-        let messageString = "Deselect-\(id)"
-        if let messageData = messageString.data(using: .utf8) {
-            do {
-                try session.sendProviderMessage(messageData) { response in
-                    completion(routes)
+        guard let messageData = messageString.data(using: .utf8) else {
+            logger.error("\(messageString): failed to encode the message")
+            completion(.failure(.encodingFailed))
+            return
+        }
+
+        do {
+            try session.sendProviderMessage(messageData) { response in
+                guard decodeResponse else {
+                    completion(.success(acknowledgement))
+                    return
                 }
-            } catch {
-                print("Failed to send Provider message")
-                completion(routes)
+                guard let response else {
+                    self.logger.error("\(messageString): no response from the extension")
+                    completion(.failure(.emptyResponse))
+                    return
+                }
+                do {
+                    completion(.success(try self.decoder.decode(RoutesSelectionDetails.self, from: response)))
+                } catch {
+                    self.logger.error("\(messageString): failed to decode the response: \(error.localizedDescription)")
+                    completion(.failure(.decodingFailed(error)))
+                }
             }
-        } else {
-            print("Error converting message to Data")
-            completion(routes)
+        } catch {
+            logger.error("\(messageString): failed to send the provider message: \(error.localizedDescription)")
+            completion(.failure(.sendFailed(error)))
         }
     }
     


### PR DESCRIPTION
## Summary

Follow-up to #198 and #200. Covers the rest of the exit node / route state issues found while reviewing the community PR: route state sync on server change, On Demand re-arm, tvOS activation state, and route IPC failure handling. Fixes apply to both iOS and tvOS.

## Changes

### 1. iOS: server change clears the previous account's exit nodes
`handleServerChanged()` sets `extensionState = .disconnected` directly and stops polling. After that, nothing could clear the route cache: `applyExtensionStatus` returns early when the status hasn't changed. The exit node selector stayed enabled with the old account's nodes, and a tap on one was silently dropped. It now calls `applyStatusSideEffects(for: .disconnected)`, the same way #200 handled `startActivation`.

### 2. On Demand is re-armed when activation sets `.connected` directly
The On Demand re-arm only ran inside `applyExtensionStatus`, so `startActivation` skipped it. After a login-required cycle (rules disarmed on the manager, preference kept `true`), a tunnel that connected while the app was in the background or killed never got its rules back. The toggle said "on" but no rule was active, and on tvOS `close()` showed a disconnect prompt for a rule that wasn't in force.
- `applyRouteSideEffects` is renamed to `applyStatusSideEffects` and now also re-arms On Demand. Anything that sets `extensionState` directly goes through this one function.
- New `rearmOnDemandIfNeeded()` handles failure: if the manager returns `.failed`, the saved preference is set back to `false` so the UI, storage and manager agree. This follows the #198 `setConnectOnDemand` contract. `.deferred` leaves the preference as is. No extra saves happen: `applyOnDemandState` already skips the save when nothing changed.

### 3. tvOS: activation guards read the live scene phase
`isAppActive` read `scenePhase`, an `@Environment` value on the App struct. The activation task captures a copy of the struct, so checks after `await loadCurrentConnectionState()` saw the phase from when the task started. A `ScenePhaseMirror` reference type, kept in sync from `onAppear` and `onChange(of: scenePhase)`, now supplies the live value. iOS still reads `UIApplication.shared.applicationState`.

### 4. tvOS: `resetForServerChange` clears routes right away
The tvOS path relied on polling (3 s interval) to deliver `.disconnected` before routes were cleared, so old exit nodes stayed visible until the next poll. It now calls `applyStatusSideEffects(for: .disconnected)` right after `performClose()`, the same call the iOS path uses.

### 5 + 6. Route IPC reports every failure; failed reads keep the cache
`getRoutes` and `selectRoutes` either returned an empty route list on failure (which wiped the cache) or never called their completion (so the optimistic selection was never reconciled). An empty network map looked the same as a failed request.

**Adapter**
- New `RouteRequestError` cases: `noSession`, `encodingFailed`, `sendFailed`, `emptyResponse`, `decodingFailed`.
- `getRoutes`, `selectRoutes` and `deselectRoutes` now return `Result<RoutesSelectionDetails, RouteRequestError>` and share one `sendRouteMessage` helper. The completion is called on every path.

**RoutesViewModel**
- `getRoutes()`: a successful reply replaces the list, even an empty one. A failure keeps the cached list. `clearRoutes()` is still the only thing that empties the list on a real disconnect.
- Optimistic select and deselect (`selectRoute`, `deselectRoute`, `setExitNode(nil)`) save a revert point first and restore it on failure. Revert points carry a generation number, so a late failure can't undo a newer selection.

**Views**
- Removed the `vpnDisplayState == .connected` guards in `iOSConnectionView` and `TVMainView`. A failed read can no longer clear the cache, so all `getRoutes()` call sites now behave the same without guards.

## Testing

Builds: iOS app, tvOS app and tvOS extension build. Unit tests pass on the iPhone 15 Pro simulator. There are no automated tests for route state yet, so the steps below are manual.

**iOS: server change (1)**
- [ ] Connect to a server with exit nodes → Settings → Change server → confirm → go back to the connection screen without connecting → the selector is disabled and empty
- [ ] Connect to the new server → the new account's exit nodes appear

**On Demand re-arm (2)**
- [ ] Turn On Demand on and connect, trigger login-required, log in again while the app is in the background or killed, open the app → On Demand is enabled in system VPN settings
- [ ] Manual disconnect with On Demand active still shows the confirmation prompt (iOS and tvOS)

**tvOS: activation (3)**
- [ ] Cold start with the tunnel up → routes load and polling starts
- [ ] Press Home during startup, then come back → no duplicate polling, no stuck "Connecting…", state is up to date
- [ ] Switch quickly between Home and the app several times → state stays correct

**tvOS: server change (4)**
- [ ] Connected with exit nodes → change or reset the server → return to the main screen within 3 s → the selector is already disabled and empty

**Route IPC failures (5, 6)**
- [ ] Account with no routes → the list is empty ("No routes")
- [ ] Connected with routes, then extension killed or session lost, then refresh on Networks → the list stays
- [ ] Tap an exit node with no session → the selection reverts; same for "None" and for turning off a resource
- [ ] Quickly switch exit nodes A → B → C with a live tunnel → the UI and the core both end on C
- [ ] Going Main → Resources → Main while connecting or disconnecting doesn't clear the main screen's exit node state
- [ ] #200 regression: the exit node card updates immediately and turns disabled on disconnect

## Notes

- **Behavior change:** if the tunnel manager rejects the On Demand re-arm, the saved On Demand preference is set to `false`, so the toggle stops showing "on" for a rule that isn't active.
- `RouteRequestError` is logged. Nothing is shown to the user yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved cached routes when route information cannot be retrieved.
  - Reverted route and exit-node selections when network operations fail.
  - Ensured route lists refresh consistently on iOS and tvOS.
  - Correctly cleared stale routes after server changes or configuration resets.
  - Improved VPN activation handling, including route synchronization and On Demand restoration.
  - Improved tvOS foreground-state detection during asynchronous activation tasks.
  - Added clearer handling for failed or timed-out route operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->